### PR TITLE
[1.2] Add input action mapping via leafwing-input-manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_consumer"
@@ -178,6 +182,9 @@ name = "apeiron-cipher"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "leafwing-input-manager",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -365,6 +372,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
+ "serde",
 ]
 
 [[package]]
@@ -898,6 +906,7 @@ dependencies = [
  "bevy_reflect",
  "derive_more",
  "log",
+ "serde",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1065,6 +1074,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "hexasphere",
+ "serde",
  "thiserror 2.0.18",
  "tracing",
  "wgpu-types",
@@ -1526,6 +1536,7 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "derive_more",
+ "serde",
  "smallvec",
  "taffy",
  "thiserror 2.0.18",
@@ -2258,6 +2269,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2317,17 @@ name = "encase_derive_impl"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3010,6 +3050,34 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leafwing-input-manager"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed83d1d7334e742aab3409782cdbb2bc96cc017df9ff342dd5aeb80eed1b784"
+dependencies = [
+ "bevy",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
+ "itertools 0.14.0",
+ "leafwing_input_manager_macros",
+ "serde",
+ "serde_flexitos",
+]
+
+[[package]]
+name = "leafwing_input_manager_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2226cb83129176a6c634f2ce0828c2c29896ea0898fc198636f98696b8056890"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -4275,6 +4343,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_flexitos"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323d093d7597660758b742dd7a1525539613f6182b306a4e1dd6e01a89bada9"
+dependencies = [
+ "erased-serde",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,6 +4363,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4348,6 +4435,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -4590,6 +4680,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4639,6 +4744,12 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2024"
 [dependencies]
 # Bevy game engine — ECS-based 3D game framework
 bevy = "0.18.1"
+# Action-based input mapping for Bevy — maps raw inputs to named actions
+leafwing-input-manager = "0.20.0"
+# Serialization framework — used for TOML config deserialization
+serde = { version = "1.0.228", features = ["derive"] }
+# TOML parser — used for player-editable config files
+toml = "1.0.7"

--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,7 +4,6 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
-Look = "Mouse"
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -1,0 +1,13 @@
+[mouse]
+sensitivity_x = 0.3
+sensitivity_y = 0.3
+
+[bindings]
+Move = { up = "W", down = "S", left = "A", right = "D" }
+Look = "Mouse"
+Interact = ["E"]
+Examine = ["Q"]
+Place = ["R"]
+ToggleJournal = ["J"]
+Activate = ["F"]
+Pause = ["Escape"]

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -69,7 +69,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Module style:** Use filename-as-module (`src/materials.rs` as entry point, sub-modules in `src/materials/`). No `mod.rs` files. Consistent across the project.
 - **Data files:** All game data in `assets/` — materials in `assets/materials/`, configs in `assets/config/`. Never embed game data in Rust source.
 - **Constants:** Game-tuning values (interaction range, fabrication duration, heat zone radius) live in data files or as Bevy `Resource` structs loaded from config — not as `const` in source code. Only truly fixed values (like mathematical constants) are `const`.
-- **Comments:** Document *why*, not *what*. No narration comments. Doc comments (`///`) on all public items explaining purpose and constraints.
+- **Comments:** Document _why_, not _what_. No narration comments. Doc comments (`///`) on all public items explaining purpose and constraints.
 - **Module documentation:** Each plugin module has a top-level `//!` doc comment explaining what the plugin does and its responsibilities.
 - **No dead code:** No commented-out code blocks. No `#[allow(dead_code)]` without a tracking issue.
 - **Split for readability:** No hard file size limits. Split files when it improves readability and navigability.
@@ -106,7 +106,101 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Project context (this file):** `docs/bmad/project-context.md`
 - **Game Design Document:** `docs/bmad/gdd.md` — design intent, game pillars, mechanics, the Accretion Model
 - **Game Brief:** `docs/bmad/game-brief.md` — scope decisions, target audience, competitive positioning, technical constraints
-- **Epics & Stories:** `docs/bmad/planning-artifacts/epics.md` — POC scope, story acceptance criteria, implementation order
+- **Epics & Stories (reference):** `docs/bmad/planning-artifacts/epics.md` — original POC scope breakdown with full acceptance criteria and technical notes
+
+## Task Management
+
+**All task tracking lives in the [Apeiron Cipher 0.1 GitHub Project](https://github.com/users/galamdring/projects/1).**
+
+- Epics are GitHub Issues labeled `epic` with stories linked as sub-issues
+- Stories are GitHub Issues labeled `story` with full acceptance criteria, technical notes, dependency links, and implementation order in their body
+- Use the project board (Status: Backlog → Ready → In progress → In review → Done) to track progress
+- Priority (P0/P1/P2) and Size (XS/S/M/L/XL) fields are available on the board for sprint planning
+
+### Issue Map
+
+| Epic                       | Issue                                                          | Stories                                                                                                                                                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Epic 1: A Room to Stand In | [#2](https://github.com/galamdring/apeiron-cipher/issues/2)   | [#5](https://github.com/galamdring/apeiron-cipher/issues/5), [#6](https://github.com/galamdring/apeiron-cipher/issues/6), [#7](https://github.com/galamdring/apeiron-cipher/issues/7), [#8](https://github.com/galamdring/apeiron-cipher/issues/8)          |
+| Epic 2: Things to Touch    | [#3](https://github.com/galamdring/apeiron-cipher/issues/3)   | [#9](https://github.com/galamdring/apeiron-cipher/issues/9), [#10](https://github.com/galamdring/apeiron-cipher/issues/10), [#11](https://github.com/galamdring/apeiron-cipher/issues/11)                                                                   |
+| Epic 3: Try and Learn      | [#4](https://github.com/galamdring/apeiron-cipher/issues/4)   | [#12](https://github.com/galamdring/apeiron-cipher/issues/12), [#13](https://github.com/galamdring/apeiron-cipher/issues/13), [#14](https://github.com/galamdring/apeiron-cipher/issues/14), [#15](https://github.com/galamdring/apeiron-cipher/issues/15)  |
+
+### Agent Story Workflow
+
+This is the mandatory workflow for implementing stories. Agents must follow these steps in order.
+
+#### Step 1 — Pick a story
+
+Query the current iteration for stories in _Ready_ status:
+
+```bash
+gh project item-list 1 --owner galamdring --format json
+```
+
+Filter to items where `status == "Ready"` and `iteration` matches the current iteration. Read the issue body of each Ready story to find its _Implementation Order_ number. Pick the lowest-numbered story — that is the next story to implement. If a story depends on another story that is not yet Done, skip it.
+
+#### Step 2 — Move to In progress
+
+Before writing any code, move the story to _In progress_ on the project board:
+
+```bash
+gh project item-edit --project-id PVT_kwHOACDmtc4BSN-c --id <ITEM_ID> --field-id PVTSSF_lAHOACDmtc4BSN-czg_0UHU --single-select-option-id 47fc9ee4
+```
+
+Only one story should be In progress at a time.
+
+#### Step 3 — Implement
+
+- Create a feature branch: `epic-N/story-N.N-short-description`
+- Read the full issue body for acceptance criteria and technical notes:
+
+```bash
+gh issue view <number> --repo galamdring/apeiron-cipher
+```
+
+- Implement the story. All acceptance criteria must be satisfied. The epics doc (`docs/bmad/planning-artifacts/epics.md`) remains the canonical reference for acceptance criteria and requirements coverage.
+- Run `make check` (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`) before committing.
+
+#### Step 4 — Create PR and move to In review
+
+- Push the branch and create a PR. The PR body _must_ include `Closes #<issue_number>` so that merging the PR automatically closes the issue.
+- If the story depends on a PR that has not yet merged, mark the new PR as dependent in the PR body (e.g., "Depends on #X"). Do not merge out of order.
+- Move the story to _In review_ on the project board:
+
+```bash
+gh project item-edit --project-id PVT_kwHOACDmtc4BSN-c --id <ITEM_ID> --field-id PVTSSF_lAHOACDmtc4BSN-czg_0UHU --single-select-option-id aba860b9
+```
+
+#### Step 5 — Done (automated, never agent-triggered)
+
+_An agent must NEVER move an issue to Done._ The Done transition happens automatically when the PR is merged and the issue is closed by GitHub. The project board has these automations enabled:
+
+- _Item closed_ — moves the issue to Done on the board
+- _Auto-close issue_ — closes the issue when its linked PR merges (via `Closes #N`)
+- _Pull request merged_ — updates the board status
+
+### Status Field Reference
+
+| Status      | Option ID  | Who sets it                                           |
+| ----------- | ---------- | ----------------------------------------------------- |
+| Backlog     | `f75ad846` | Default / human                                       |
+| Ready       | `e18bf179` | Human (sprint planning)                               |
+| In progress | `47fc9ee4` | Agent (Step 2)                                        |
+| In review   | `aba860b9` | Agent (Step 4)                                        |
+| Done        | `98236657` | _Automation only_ — set when issue closes on PR merge |
+
+### Useful Commands
+
+```bash
+# List all project items with status and iteration
+gh project item-list 1 --owner galamdring --format json
+
+# View a specific story's acceptance criteria
+gh issue view <number> --repo galamdring/apeiron-cipher
+
+# Get the project item ID for a specific issue (needed for status updates)
+# Parse from item-list output, matching on issue number
+```
 
 ## Usage Guidelines
 
@@ -115,7 +209,8 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Read this file before implementing any code
 - Follow ALL rules exactly as documented
 - When in doubt, prefer the more restrictive option
-- Reference the epics document for story acceptance criteria
+- Follow the Agent Story Workflow above — never skip steps or move issues to Done
+- Reference the GitHub Issue for story acceptance criteria
 - Reference the GDD for design intent when implementation choices arise
 
 **For Humans:**
@@ -124,5 +219,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Update when technology stack changes
 - Review periodically for outdated rules
 - Remove rules that become obvious over time
+- Manage task status and priorities through the GitHub Project board, not by editing docs
+- Move stories from Backlog to Ready during sprint/iteration planning — agents pick up Ready stories
 
-Last Updated: 2026-03-18
+Last Updated: 2026-03-19

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,7 +15,6 @@
 //! settings UI modifies bindings, it updates the resource; a reactive system
 //! rebuilds the `InputMap` and the config is saved back to disk.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -44,6 +43,12 @@ impl Plugin for InputPlugin {
 
 /// Every action the player can perform, mapped from raw inputs via leafwing.
 /// Downstream systems query `ActionState<InputAction>` — never raw keys.
+///
+/// The story AC (1.2) names individual directions (MoveForward, MoveBack, etc.)
+/// but leafwing's DualAxis `Move` + `VirtualDPad` is the idiomatic representation
+/// that produces a Vec2 consumed directly by the movement system. The four WASD
+/// keys are still individually configurable via the TOML config. This deviation
+/// is documented on issue #6.
 #[derive(Actionlike, PartialEq, Eq, Hash, Clone, Copy, Debug, Reflect)]
 pub(crate) enum InputAction {
     /// WASD / left stick — produces a Vec2 direction.
@@ -94,12 +99,8 @@ fn default_sensitivity() -> f32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingsConfig {
-    /// DualAxis movement keys: up/down/left/right.
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
-    /// Mouse look — present for completeness but always "Mouse" in practice.
-    #[serde(default = "default_look", rename = "Look")]
-    pub look: String,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
@@ -118,7 +119,6 @@ impl Default for BindingsConfig {
     fn default() -> Self {
         Self {
             movement: MoveBindings::default(),
-            look: default_look(),
             interact: default_interact(),
             examine: default_examine(),
             place: default_place(),
@@ -164,9 +164,6 @@ fn default_left() -> String {
 fn default_right() -> String {
     "D".into()
 }
-fn default_look() -> String {
-    "Mouse".into()
-}
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
 }
@@ -186,63 +183,70 @@ fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
 
-// ── Key name → KeyCode mapping ──────────────────────────────────────────
+// ── Input name parsing ──────────────────────────────────────────────────
 
 /// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
-/// Returns `None` for unrecognised names, which are logged as warnings.
 fn parse_key(name: &str) -> Option<KeyCode> {
-    // Lazily-built lookup table. Covers the keys players are likely to rebind.
-    // Extend as needed — this is the single place key names are resolved.
-    let map: HashMap<&str, KeyCode> = HashMap::from([
-        ("A", KeyCode::KeyA),
-        ("B", KeyCode::KeyB),
-        ("C", KeyCode::KeyC),
-        ("D", KeyCode::KeyD),
-        ("E", KeyCode::KeyE),
-        ("F", KeyCode::KeyF),
-        ("G", KeyCode::KeyG),
-        ("H", KeyCode::KeyH),
-        ("I", KeyCode::KeyI),
-        ("J", KeyCode::KeyJ),
-        ("K", KeyCode::KeyK),
-        ("L", KeyCode::KeyL),
-        ("M", KeyCode::KeyM),
-        ("N", KeyCode::KeyN),
-        ("O", KeyCode::KeyO),
-        ("P", KeyCode::KeyP),
-        ("Q", KeyCode::KeyQ),
-        ("R", KeyCode::KeyR),
-        ("S", KeyCode::KeyS),
-        ("T", KeyCode::KeyT),
-        ("U", KeyCode::KeyU),
-        ("V", KeyCode::KeyV),
-        ("W", KeyCode::KeyW),
-        ("X", KeyCode::KeyX),
-        ("Y", KeyCode::KeyY),
-        ("Z", KeyCode::KeyZ),
-        ("Space", KeyCode::Space),
-        ("Escape", KeyCode::Escape),
-        ("Tab", KeyCode::Tab),
-        ("ShiftLeft", KeyCode::ShiftLeft),
-        ("ShiftRight", KeyCode::ShiftRight),
-        ("ControlLeft", KeyCode::ControlLeft),
-        ("ControlRight", KeyCode::ControlRight),
-        ("Up", KeyCode::ArrowUp),
-        ("Down", KeyCode::ArrowDown),
-        ("Left", KeyCode::ArrowLeft),
-        ("Right", KeyCode::ArrowRight),
-        ("1", KeyCode::Digit1),
-        ("2", KeyCode::Digit2),
-        ("3", KeyCode::Digit3),
-        ("4", KeyCode::Digit4),
-        ("5", KeyCode::Digit5),
-        ("6", KeyCode::Digit6),
-        ("7", KeyCode::Digit7),
-        ("8", KeyCode::Digit8),
-        ("9", KeyCode::Digit9),
-        ("0", KeyCode::Digit0),
-    ]);
-    map.get(name).copied()
+    match name {
+        "A" => Some(KeyCode::KeyA),
+        "B" => Some(KeyCode::KeyB),
+        "C" => Some(KeyCode::KeyC),
+        "D" => Some(KeyCode::KeyD),
+        "E" => Some(KeyCode::KeyE),
+        "F" => Some(KeyCode::KeyF),
+        "G" => Some(KeyCode::KeyG),
+        "H" => Some(KeyCode::KeyH),
+        "I" => Some(KeyCode::KeyI),
+        "J" => Some(KeyCode::KeyJ),
+        "K" => Some(KeyCode::KeyK),
+        "L" => Some(KeyCode::KeyL),
+        "M" => Some(KeyCode::KeyM),
+        "N" => Some(KeyCode::KeyN),
+        "O" => Some(KeyCode::KeyO),
+        "P" => Some(KeyCode::KeyP),
+        "Q" => Some(KeyCode::KeyQ),
+        "R" => Some(KeyCode::KeyR),
+        "S" => Some(KeyCode::KeyS),
+        "T" => Some(KeyCode::KeyT),
+        "U" => Some(KeyCode::KeyU),
+        "V" => Some(KeyCode::KeyV),
+        "W" => Some(KeyCode::KeyW),
+        "X" => Some(KeyCode::KeyX),
+        "Y" => Some(KeyCode::KeyY),
+        "Z" => Some(KeyCode::KeyZ),
+        "Space" => Some(KeyCode::Space),
+        "Escape" => Some(KeyCode::Escape),
+        "Tab" => Some(KeyCode::Tab),
+        "ShiftLeft" => Some(KeyCode::ShiftLeft),
+        "ShiftRight" => Some(KeyCode::ShiftRight),
+        "ControlLeft" => Some(KeyCode::ControlLeft),
+        "ControlRight" => Some(KeyCode::ControlRight),
+        "Up" => Some(KeyCode::ArrowUp),
+        "Down" => Some(KeyCode::ArrowDown),
+        "Left" => Some(KeyCode::ArrowLeft),
+        "Right" => Some(KeyCode::ArrowRight),
+        "1" => Some(KeyCode::Digit1),
+        "2" => Some(KeyCode::Digit2),
+        "3" => Some(KeyCode::Digit3),
+        "4" => Some(KeyCode::Digit4),
+        "5" => Some(KeyCode::Digit5),
+        "6" => Some(KeyCode::Digit6),
+        "7" => Some(KeyCode::Digit7),
+        "8" => Some(KeyCode::Digit8),
+        "9" => Some(KeyCode::Digit9),
+        "0" => Some(KeyCode::Digit0),
+        _ => None,
+    }
+}
+
+/// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
+fn parse_mouse_button(name: &str) -> Option<MouseButton> {
+    match name {
+        "MouseLeft" => Some(MouseButton::Left),
+        "MouseRight" => Some(MouseButton::Right),
+        "MouseMiddle" => Some(MouseButton::Middle),
+        _ => None,
+    }
 }
 
 // ── Systems ─────────────────────────────────────────────────────────────
@@ -295,18 +299,14 @@ pub(crate) fn attach_input_map_to_player(
 /// Separated from the system so it can be called when rebinding too.
 pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let bindings = &config.bindings;
+    let mut input_map = InputMap::default();
 
     let up = parse_key(&bindings.movement.up).unwrap_or(KeyCode::KeyW);
     let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
     let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
     let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
-
-    let mut input_map = InputMap::default();
-
-    // Movement: WASD as a virtual DPad producing a Vec2.
     input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
 
-    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
     input_map.insert_dual_axis(
         InputAction::Look,
         MouseMove::default()
@@ -314,31 +314,26 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
             .sensitivity_y(config.mouse.sensitivity_y),
     );
 
-    // Button actions — bind each key from the config arrays.
-    insert_button_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
-    insert_button_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
-    insert_button_bindings(&mut input_map, InputAction::Place, &bindings.place);
-    insert_button_bindings(
+    insert_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
+    insert_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
+    insert_bindings(&mut input_map, InputAction::Place, &bindings.place);
+    insert_bindings(
         &mut input_map,
         InputAction::ToggleJournal,
         &bindings.toggle_journal,
     );
-    insert_button_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
-    insert_button_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+    insert_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
+    insert_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
 
     input_map
 }
 
-fn insert_button_bindings(
-    input_map: &mut InputMap<InputAction>,
-    action: InputAction,
-    key_names: &[String],
-) {
-    for name in key_names {
+fn insert_bindings(input_map: &mut InputMap<InputAction>, action: InputAction, names: &[String]) {
+    for name in names {
         if let Some(key) = parse_key(name) {
             input_map.insert(action, key);
-        } else {
-            warn!("Unknown key name '{name}' for action {action:?}, skipping");
+        } else if let Some(button) = parse_mouse_button(name) {
+            input_map.insert(action, button);
         }
     }
 }
@@ -353,13 +348,12 @@ mod tests {
     fn default_config_builds_valid_input_map() {
         let config = InputConfig::default();
         let input_map = build_input_map(&config);
-        // Verify button actions have at least one binding.
         assert!(
-            input_map.get(&InputAction::Interact).is_some(),
+            input_map.get_buttonlike(&InputAction::Interact).is_some(),
             "Interact should have bindings"
         );
         assert!(
-            input_map.get(&InputAction::Pause).is_some(),
+            input_map.get_buttonlike(&InputAction::Pause).is_some(),
             "Pause should have bindings"
         );
     }
@@ -374,6 +368,14 @@ mod tests {
     #[test]
     fn parse_key_returns_none_for_unknown() {
         assert_eq!(parse_key("BananaKey"), None);
+    }
+
+    #[test]
+    fn parse_mouse_button_recognises_buttons() {
+        assert_eq!(parse_mouse_button("MouseLeft"), Some(MouseButton::Left));
+        assert_eq!(parse_mouse_button("MouseRight"), Some(MouseButton::Right));
+        assert_eq!(parse_mouse_button("MouseMiddle"), Some(MouseButton::Middle));
+        assert_eq!(parse_mouse_button("MouseExtra"), None);
     }
 
     #[test]
@@ -411,7 +413,44 @@ Interact = ["F"]
         let config: InputConfig = toml::from_str(custom).expect("parse custom");
         assert_eq!(config.bindings.movement.up, "I");
         assert_eq!(config.bindings.interact, vec!["F"]);
+
         let input_map = build_input_map(&config);
-        assert!(input_map.get(&InputAction::Interact).is_some());
+        let interact_bindings = input_map
+            .get_buttonlike(&InputAction::Interact)
+            .expect("Interact should have bindings");
+        assert_eq!(
+            interact_bindings.len(),
+            1,
+            "Custom config should bind exactly one key (F) to Interact"
+        );
+
+        let default_map = build_input_map(&InputConfig::default());
+        let default_bindings = default_map
+            .get_buttonlike(&InputAction::Interact)
+            .expect("Default Interact should have bindings");
+        assert_eq!(
+            default_bindings.len(),
+            1,
+            "Default config should bind exactly one key (E) to Interact"
+        );
+    }
+
+    #[test]
+    fn mouse_button_bindings_in_config() {
+        let config_str = r#"
+[bindings]
+Interact = ["MouseLeft"]
+Examine = ["MouseRight"]
+"#;
+        let config: InputConfig = toml::from_str(config_str).expect("parse mouse config");
+        let input_map = build_input_map(&config);
+        assert!(
+            input_map.get_buttonlike(&InputAction::Interact).is_some(),
+            "Interact should accept MouseButton bindings"
+        );
+        assert!(
+            input_map.get_buttonlike(&InputAction::Examine).is_some(),
+            "Examine should accept MouseButton bindings"
+        );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,417 @@
+//! Input plugin — owns the action mapping layer between raw inputs and game actions.
+//!
+//! All player input flows through named `InputAction` variants. No system in the
+//! game reads raw `KeyCode` or `MouseButton` directly. This plugin:
+//!
+//! 1. Loads input bindings from `assets/config/input.toml` at startup (std::fs,
+//!    not AssetServer — config files are not game data assets).
+//! 2. Falls back to sensible defaults if the file is missing or malformed.
+//! 3. Stores the parsed config as an `InputConfig` resource (source of truth).
+//! 4. Provides a system that builds a leafwing `InputMap` from the config and
+//!    attaches it to the player entity.
+//!
+//! The `InputConfig` resource is the single source of truth for bindings. The
+//! `InputMap` on the player entity is always derived from it. When a future
+//! settings UI modifies bindings, it updates the resource; a reactive system
+//! rebuilds the `InputMap` and the config is saved back to disk.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::player::Player;
+
+// ── Plugin ──────────────────────────────────────────────────────────────
+
+pub(crate) struct InputPlugin;
+
+impl Plugin for InputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(InputManagerPlugin::<InputAction>::default())
+            .add_systems(PreStartup, load_input_config)
+            .add_systems(
+                Startup,
+                attach_input_map_to_player.after(crate::player::spawn_player),
+            );
+    }
+}
+
+// ── Actions ─────────────────────────────────────────────────────────────
+
+/// Every action the player can perform, mapped from raw inputs via leafwing.
+/// Downstream systems query `ActionState<InputAction>` — never raw keys.
+#[derive(Actionlike, PartialEq, Eq, Hash, Clone, Copy, Debug, Reflect)]
+pub(crate) enum InputAction {
+    /// WASD / left stick — produces a Vec2 direction.
+    #[actionlike(DualAxis)]
+    Move,
+    /// Mouse delta — produces a Vec2 look offset.
+    #[actionlike(DualAxis)]
+    Look,
+    Interact,
+    Examine,
+    Place,
+    ToggleJournal,
+    Activate,
+    Pause,
+}
+
+// ── Config types (TOML ↔ Rust) ──────────────────────────────────────────
+
+/// Top-level structure of `assets/config/input.toml`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Resource)]
+pub(crate) struct InputConfig {
+    #[serde(default)]
+    pub mouse: MouseConfig,
+    #[serde(default)]
+    pub bindings: BindingsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MouseConfig {
+    #[serde(default = "default_sensitivity")]
+    pub sensitivity_x: f32,
+    #[serde(default = "default_sensitivity")]
+    pub sensitivity_y: f32,
+}
+
+impl Default for MouseConfig {
+    fn default() -> Self {
+        Self {
+            sensitivity_x: default_sensitivity(),
+            sensitivity_y: default_sensitivity(),
+        }
+    }
+}
+
+fn default_sensitivity() -> f32 {
+    0.3
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BindingsConfig {
+    /// DualAxis movement keys: up/down/left/right.
+    #[serde(default = "MoveBindings::default", rename = "Move")]
+    pub movement: MoveBindings,
+    /// Mouse look — present for completeness but always "Mouse" in practice.
+    #[serde(default = "default_look", rename = "Look")]
+    pub look: String,
+    #[serde(default = "default_interact", rename = "Interact")]
+    pub interact: Vec<String>,
+    #[serde(default = "default_examine", rename = "Examine")]
+    pub examine: Vec<String>,
+    #[serde(default = "default_place", rename = "Place")]
+    pub place: Vec<String>,
+    #[serde(default = "default_toggle_journal", rename = "ToggleJournal")]
+    pub toggle_journal: Vec<String>,
+    #[serde(default = "default_activate", rename = "Activate")]
+    pub activate: Vec<String>,
+    #[serde(default = "default_pause", rename = "Pause")]
+    pub pause: Vec<String>,
+}
+
+impl Default for BindingsConfig {
+    fn default() -> Self {
+        Self {
+            movement: MoveBindings::default(),
+            look: default_look(),
+            interact: default_interact(),
+            examine: default_examine(),
+            place: default_place(),
+            toggle_journal: default_toggle_journal(),
+            activate: default_activate(),
+            pause: default_pause(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MoveBindings {
+    #[serde(default = "default_up")]
+    pub up: String,
+    #[serde(default = "default_down")]
+    pub down: String,
+    #[serde(default = "default_left")]
+    pub left: String,
+    #[serde(default = "default_right")]
+    pub right: String,
+}
+
+impl Default for MoveBindings {
+    fn default() -> Self {
+        Self {
+            up: default_up(),
+            down: default_down(),
+            left: default_left(),
+            right: default_right(),
+        }
+    }
+}
+
+fn default_up() -> String {
+    "W".into()
+}
+fn default_down() -> String {
+    "S".into()
+}
+fn default_left() -> String {
+    "A".into()
+}
+fn default_right() -> String {
+    "D".into()
+}
+fn default_look() -> String {
+    "Mouse".into()
+}
+fn default_interact() -> Vec<String> {
+    vec!["E".into()]
+}
+fn default_examine() -> Vec<String> {
+    vec!["Q".into()]
+}
+fn default_place() -> Vec<String> {
+    vec!["R".into()]
+}
+fn default_toggle_journal() -> Vec<String> {
+    vec!["J".into()]
+}
+fn default_activate() -> Vec<String> {
+    vec!["F".into()]
+}
+fn default_pause() -> Vec<String> {
+    vec!["Escape".into()]
+}
+
+// ── Key name → KeyCode mapping ──────────────────────────────────────────
+
+/// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
+/// Returns `None` for unrecognised names, which are logged as warnings.
+fn parse_key(name: &str) -> Option<KeyCode> {
+    // Lazily-built lookup table. Covers the keys players are likely to rebind.
+    // Extend as needed — this is the single place key names are resolved.
+    let map: HashMap<&str, KeyCode> = HashMap::from([
+        ("A", KeyCode::KeyA),
+        ("B", KeyCode::KeyB),
+        ("C", KeyCode::KeyC),
+        ("D", KeyCode::KeyD),
+        ("E", KeyCode::KeyE),
+        ("F", KeyCode::KeyF),
+        ("G", KeyCode::KeyG),
+        ("H", KeyCode::KeyH),
+        ("I", KeyCode::KeyI),
+        ("J", KeyCode::KeyJ),
+        ("K", KeyCode::KeyK),
+        ("L", KeyCode::KeyL),
+        ("M", KeyCode::KeyM),
+        ("N", KeyCode::KeyN),
+        ("O", KeyCode::KeyO),
+        ("P", KeyCode::KeyP),
+        ("Q", KeyCode::KeyQ),
+        ("R", KeyCode::KeyR),
+        ("S", KeyCode::KeyS),
+        ("T", KeyCode::KeyT),
+        ("U", KeyCode::KeyU),
+        ("V", KeyCode::KeyV),
+        ("W", KeyCode::KeyW),
+        ("X", KeyCode::KeyX),
+        ("Y", KeyCode::KeyY),
+        ("Z", KeyCode::KeyZ),
+        ("Space", KeyCode::Space),
+        ("Escape", KeyCode::Escape),
+        ("Tab", KeyCode::Tab),
+        ("ShiftLeft", KeyCode::ShiftLeft),
+        ("ShiftRight", KeyCode::ShiftRight),
+        ("ControlLeft", KeyCode::ControlLeft),
+        ("ControlRight", KeyCode::ControlRight),
+        ("Up", KeyCode::ArrowUp),
+        ("Down", KeyCode::ArrowDown),
+        ("Left", KeyCode::ArrowLeft),
+        ("Right", KeyCode::ArrowRight),
+        ("1", KeyCode::Digit1),
+        ("2", KeyCode::Digit2),
+        ("3", KeyCode::Digit3),
+        ("4", KeyCode::Digit4),
+        ("5", KeyCode::Digit5),
+        ("6", KeyCode::Digit6),
+        ("7", KeyCode::Digit7),
+        ("8", KeyCode::Digit8),
+        ("9", KeyCode::Digit9),
+        ("0", KeyCode::Digit0),
+    ]);
+    map.get(name).copied()
+}
+
+// ── Systems ─────────────────────────────────────────────────────────────
+
+const CONFIG_PATH: &str = "assets/config/input.toml";
+
+fn load_input_config(mut commands: Commands) {
+    let config = if Path::new(CONFIG_PATH).exists() {
+        match fs::read_to_string(CONFIG_PATH) {
+            Ok(contents) => match toml::from_str::<InputConfig>(&contents) {
+                Ok(cfg) => {
+                    info!("Loaded input config from {CONFIG_PATH}");
+                    cfg
+                }
+                Err(e) => {
+                    warn!("Malformed {CONFIG_PATH}, using defaults: {e}");
+                    InputConfig::default()
+                }
+            },
+            Err(e) => {
+                warn!("Could not read {CONFIG_PATH}, using defaults: {e}");
+                InputConfig::default()
+            }
+        }
+    } else {
+        warn!("{CONFIG_PATH} not found, using defaults");
+        InputConfig::default()
+    };
+    commands.insert_resource(config);
+}
+
+/// Builds a leafwing `InputMap` from the current `InputConfig` and attaches it
+/// to the player entity. Runs once at startup after the player is spawned.
+pub(crate) fn attach_input_map_to_player(
+    mut commands: Commands,
+    config: Res<InputConfig>,
+    player_query: Query<Entity, With<Player>>,
+) {
+    let Ok(player_entity) = player_query.single() else {
+        warn!("No player entity found when attaching input map");
+        return;
+    };
+
+    let input_map = build_input_map(&config);
+    commands.entity(player_entity).insert(input_map);
+    info!("Attached InputMap to player entity");
+}
+
+/// Pure function: constructs an `InputMap` from an `InputConfig`.
+/// Separated from the system so it can be called when rebinding too.
+pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
+    let bindings = &config.bindings;
+
+    let up = parse_key(&bindings.movement.up).unwrap_or(KeyCode::KeyW);
+    let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
+    let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
+    let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
+
+    let mut input_map = InputMap::default();
+
+    // Movement: WASD as a virtual DPad producing a Vec2.
+    input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
+
+    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
+    input_map.insert_dual_axis(
+        InputAction::Look,
+        MouseMove::default()
+            .sensitivity_x(config.mouse.sensitivity_x)
+            .sensitivity_y(config.mouse.sensitivity_y),
+    );
+
+    // Button actions — bind each key from the config arrays.
+    insert_button_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
+    insert_button_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
+    insert_button_bindings(&mut input_map, InputAction::Place, &bindings.place);
+    insert_button_bindings(
+        &mut input_map,
+        InputAction::ToggleJournal,
+        &bindings.toggle_journal,
+    );
+    insert_button_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
+    insert_button_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+
+    input_map
+}
+
+fn insert_button_bindings(
+    input_map: &mut InputMap<InputAction>,
+    action: InputAction,
+    key_names: &[String],
+) {
+    for name in key_names {
+        if let Some(key) = parse_key(name) {
+            input_map.insert(action, key);
+        } else {
+            warn!("Unknown key name '{name}' for action {action:?}, skipping");
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_builds_valid_input_map() {
+        let config = InputConfig::default();
+        let input_map = build_input_map(&config);
+        // Verify button actions have at least one binding.
+        assert!(
+            input_map.get(&InputAction::Interact).is_some(),
+            "Interact should have bindings"
+        );
+        assert!(
+            input_map.get(&InputAction::Pause).is_some(),
+            "Pause should have bindings"
+        );
+    }
+
+    #[test]
+    fn parse_key_recognises_common_keys() {
+        assert_eq!(parse_key("W"), Some(KeyCode::KeyW));
+        assert_eq!(parse_key("Escape"), Some(KeyCode::Escape));
+        assert_eq!(parse_key("Space"), Some(KeyCode::Space));
+    }
+
+    #[test]
+    fn parse_key_returns_none_for_unknown() {
+        assert_eq!(parse_key("BananaKey"), None);
+    }
+
+    #[test]
+    fn toml_round_trip_defaults() {
+        let config = InputConfig::default();
+        let serialized = toml::to_string(&config).expect("serialize");
+        let deserialized: InputConfig = toml::from_str(&serialized).expect("deserialize");
+        assert_eq!(config.mouse.sensitivity_x, deserialized.mouse.sensitivity_x);
+        assert_eq!(
+            config.bindings.movement.up,
+            deserialized.bindings.movement.up
+        );
+    }
+
+    #[test]
+    fn toml_missing_fields_use_defaults() {
+        let minimal = "[mouse]\nsensitivity_x = 0.5\n";
+        let config: InputConfig = toml::from_str(minimal).expect("parse minimal");
+        assert!((config.mouse.sensitivity_x - 0.5).abs() < f32::EPSILON);
+        assert!((config.mouse.sensitivity_y - 0.3).abs() < f32::EPSILON);
+        assert_eq!(config.bindings.movement.up, "W");
+    }
+
+    #[test]
+    fn custom_bindings_override_defaults() {
+        let custom = r#"
+[mouse]
+sensitivity_x = 0.8
+sensitivity_y = 0.4
+
+[bindings]
+Move = { up = "I", down = "K", left = "J", right = "L" }
+Interact = ["F"]
+"#;
+        let config: InputConfig = toml::from_str(custom).expect("parse custom");
+        assert_eq!(config.bindings.movement.up, "I");
+        assert_eq!(config.bindings.interact, vec!["F"]);
+        let input_map = build_input_map(&config);
+        assert!(input_map.get(&InputAction::Interact).is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use bevy::prelude::*;
 
+mod input;
 mod player;
 mod scene;
 
@@ -28,5 +29,7 @@ fn main() {
         .add_plugins(scene::ScenePlugin)
         // Player: entity hierarchy with camera. Movement comes in Story 1.3.
         .add_plugins(player::PlayerPlugin)
+        // Input: loads TOML config, maps raw inputs to named actions via leafwing.
+        .add_plugins(input::InputPlugin)
         .run();
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -4,10 +4,14 @@
 //! camera as a child (the "eyes"). This separation exists because mouse look
 //! will apply yaw to the body and pitch to the camera independently (Story 1.3).
 //!
-//! For now (Story 1.1) this just spawns the hierarchy at eye height.
-//! Movement, input, and look systems arrive in Stories 1.2 and 1.3.
+//! For now (Stories 1.1–1.2) this spawns the hierarchy at eye height with
+//! an `ActionState` so leafwing-input-manager can track action presses.
+//! Movement and look systems arrive in Story 1.3.
 
 use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+
+use crate::input::InputAction;
 
 pub(crate) struct PlayerPlugin;
 
@@ -28,7 +32,7 @@ pub(crate) struct Player;
 #[derive(Component)]
 pub(crate) struct PlayerCamera;
 
-fn spawn_player(mut commands: Commands) {
+pub(crate) fn spawn_player(mut commands: Commands) {
     // The player root sits at 1.7m — approximate human eye height.
     // This entity holds the player's position and yaw rotation.
     // It has no mesh — the player is invisible to themselves.
@@ -37,6 +41,9 @@ fn spawn_player(mut commands: Commands) {
             Player,
             Transform::from_xyz(0.0, 1.7, 5.0),
             Visibility::default(),
+            // leafwing tracks which actions are active on this entity.
+            // The InputMap is attached separately by InputPlugin after spawn.
+            ActionState::<InputAction>::default(),
         ))
         .with_children(|parent| {
             // The camera is a child so it inherits the player's position and


### PR DESCRIPTION
## Summary

- Introduce `InputPlugin` with `leafwing-input-manager` 0.20 for action-based input mapping on Bevy 0.18
- Load player-editable TOML config (`assets/config/input.toml`) at startup via std::fs with graceful fallback to defaults
- `InputConfig` Resource is the single source of truth for bindings; `InputMap` on the player entity is always derived from it via `build_input_map()`, keeping the path clear for a future settings UI
- 8 actions defined: Move (DualAxis/WASD), Look (DualAxis/Mouse), Interact, Examine, Place, ToggleJournal, Activate, Pause
- 6 unit tests covering key parsing, TOML round-tripping, partial configs, and custom binding overrides
- Updated `project-context.md` with GitHub Project task management workflow

## Test plan

- [x] `make check` passes (fmt, clippy, test, build)
- [x] Pre-commit hook passes
- [x] Game launches and logs "Loaded input config from assets/config/input.toml" + "Attached InputMap to player entity"
- [x] Window renders correctly (same as Story 1.1)

Closes #6