### PR TITLE
feat: heat source with thermal exposure, reaction visuals, and property revelation

### DIFF
--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -52,3 +52,15 @@ x = 0.6
 z = -3.15
 y = 0.92
 
+[heat_source]
+# Offset from workbench center — sits on the right side of the bench.
+offset_x = 0.55
+offset_z = 0.0
+radius = 0.1
+# Materials within this distance of the burner are "in the heat zone".
+zone_radius = 1.0
+light_intensity = 40_000.0
+# Seconds of continuous exposure for a material to fully react.
+reaction_seconds = 2.5
+# Seconds of continuous exposure before thermal_resistance is revealed.
+reveal_seconds = 3.5

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -1,0 +1,307 @@
+//! Heat plugin — environmental property revelation through thermal exposure.
+//!
+//! Spawns a heat source (burner) on the workbench and drives the heat-zone
+//! loop: materials placed near the burner accumulate exposure, visually react
+//! based on their `thermal_resistance`, and eventually have that hidden
+//! property revealed for the examine panel.
+//!
+//! No labels, no numbers. The player watches the material change (or not) and
+//! draws their own conclusions.
+//!
+//! Systems:
+//! - `spawn_heat_source`: glowing disc + point light on the workbench
+//! - `track_heat_exposure`: increment/reset exposure timers for materials in the zone
+//! - `apply_thermal_reaction`: visual feedback (emissive glow, color shift, scale)
+//! - `reveal_thermal_property`: flip `thermal_resistance` to `Revealed` after threshold
+
+use bevy::prelude::*;
+
+use crate::interaction::HeldItem;
+use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
+use crate::scene::{SceneConfig, Workbench};
+
+pub(crate) struct HeatPlugin;
+
+impl Plugin for HeatPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_heat_source).add_systems(
+            Update,
+            (
+                track_heat_exposure,
+                apply_thermal_reaction.after(track_heat_exposure),
+                reveal_thermal_property.after(track_heat_exposure),
+            ),
+        );
+    }
+}
+
+// ── Components ──────────────────────────────────────────────────────────
+
+/// Marks the burner entity so systems can locate the heat source position.
+#[derive(Component)]
+struct HeatSource;
+
+/// Tracks cumulative seconds a material has spent inside the heat zone.
+/// Added dynamically when a material first enters the zone, persists when
+/// moved away so past exposure is remembered.
+#[derive(Component)]
+struct HeatExposure {
+    elapsed: f32,
+    in_zone: bool,
+}
+
+impl HeatExposure {
+    fn new() -> Self {
+        Self {
+            elapsed: 0.0,
+            in_zone: false,
+        }
+    }
+}
+
+// ── Spawn ───────────────────────────────────────────────────────────────
+
+fn spawn_heat_source(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    cfg: Res<SceneConfig>,
+    workbench_query: Query<&Transform, With<Workbench>>,
+) {
+    let Ok(wb_tf) = workbench_query.single() else {
+        warn!("No workbench found — heat source will not be spawned");
+        return;
+    };
+
+    let hs = &cfg.heat_source;
+    let fur = &cfg.furniture;
+
+    let pos = Vec3::new(
+        wb_tf.translation.x + hs.offset_x,
+        fur.workbench_height + hs.radius * 0.5,
+        wb_tf.translation.z + hs.offset_z,
+    );
+
+    let burner_mesh = meshes.add(Cylinder::new(hs.radius, hs.radius * 0.3));
+    let burner_mat = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.15, 0.12, 0.12),
+        emissive: LinearRgba::new(80.0, 20.0, 5.0, 1.0),
+        ..default()
+    });
+
+    commands
+        .spawn((
+            HeatSource,
+            Mesh3d(burner_mesh),
+            MeshMaterial3d(burner_mat),
+            Transform::from_translation(pos),
+        ))
+        .with_child((PointLight {
+            color: Color::srgb(1.0, 0.5, 0.15),
+            intensity: hs.light_intensity,
+            range: hs.zone_radius * 2.0,
+            shadows_enabled: false,
+            ..default()
+        },));
+
+    info!("Spawned heat source at ({}, {}, {})", pos.x, pos.y, pos.z);
+}
+
+// ── Exposure tracking ───────────────────────────────────────────────────
+
+// Bevy queries are inherently generic-heavy; a type alias would hide which
+// components/filters the system accesses, making the signature harder to audit.
+#[allow(clippy::type_complexity)]
+fn track_heat_exposure(
+    mut commands: Commands,
+    time: Res<Time>,
+    cfg: Res<SceneConfig>,
+    heat_query: Query<&GlobalTransform, With<HeatSource>>,
+    mut material_query: Query<
+        (Entity, &GlobalTransform, Option<&mut HeatExposure>),
+        (With<MaterialObject>, Without<HeldItem>),
+    >,
+) {
+    let Ok(heat_gtf) = heat_query.single() else {
+        return;
+    };
+    let heat_pos = heat_gtf.translation();
+    let zone_r_sq = cfg.heat_source.zone_radius * cfg.heat_source.zone_radius;
+    let dt = time.delta_secs();
+
+    for (entity, mat_gtf, exposure) in &mut material_query {
+        let dist_sq = mat_gtf.translation().distance_squared(heat_pos);
+        let inside = dist_sq <= zone_r_sq;
+
+        match exposure {
+            Some(mut exp) => {
+                exp.in_zone = inside;
+                if inside {
+                    exp.elapsed += dt;
+                }
+            }
+            None if inside => {
+                commands.entity(entity).insert(HeatExposure::new());
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── Thermal reaction (visual feedback) ──────────────────────────────────
+
+/// Reaction intensity as a function of exposure progress and thermal resistance.
+/// Low resistance → fast, strong reaction. High resistance → slow, weak reaction.
+fn reaction_intensity(exposure_frac: f32, thermal_resistance: f32) -> f32 {
+    let sensitivity = 1.0 - thermal_resistance;
+    (exposure_frac * sensitivity * 1.5).clamp(0.0, 1.0)
+}
+
+/// Returns the emissive glow colour at a given reaction intensity.
+fn reaction_emissive(intensity: f32) -> LinearRgba {
+    LinearRgba::new(intensity * 200.0, intensity * 40.0, intensity * 5.0, 1.0)
+}
+
+/// Scale deformation: low-resistance materials "soften" (Y shrinks, XZ expands).
+fn reaction_scale(intensity: f32, thermal_resistance: f32) -> Vec3 {
+    if thermal_resistance > 0.7 {
+        return Vec3::ONE;
+    }
+    let deform = intensity * (1.0 - thermal_resistance) * 0.15;
+    Vec3::new(1.0 + deform, 1.0 - deform * 0.8, 1.0 + deform)
+}
+
+// Two separate queries needed: one for the material handle (shared access) and one
+// for the mutable transform. Collapsing would require unsafe world access.
+#[allow(clippy::type_complexity)]
+fn apply_thermal_reaction(
+    cfg: Res<SceneConfig>,
+    exposure_query: Query<
+        (
+            &HeatExposure,
+            &GameMaterial,
+            &MeshMaterial3d<StandardMaterial>,
+        ),
+        With<MaterialObject>,
+    >,
+    mut std_materials: ResMut<Assets<StandardMaterial>>,
+    mut transform_query: Query<
+        (&HeatExposure, &GameMaterial, &mut Transform),
+        With<MaterialObject>,
+    >,
+) {
+    let reaction_secs = cfg.heat_source.reaction_seconds;
+
+    for (exp, mat, mat_handle) in &exposure_query {
+        let frac = (exp.elapsed / reaction_secs).clamp(0.0, 1.0);
+        let intensity = reaction_intensity(frac, mat.thermal_resistance.value);
+
+        if let Some(std_mat) = std_materials.get_mut(mat_handle) {
+            std_mat.emissive = reaction_emissive(intensity);
+
+            let warm_shift = intensity * (1.0 - mat.thermal_resistance.value) * 0.3;
+            let [r, g, b] = mat.color;
+            std_mat.base_color = Color::srgb(
+                (r + warm_shift).min(1.0),
+                g,
+                (b - warm_shift * 0.5).max(0.0),
+            );
+        }
+    }
+
+    for (exp, mat, mut tf) in &mut transform_query {
+        let frac = (exp.elapsed / reaction_secs).clamp(0.0, 1.0);
+        let intensity = reaction_intensity(frac, mat.thermal_resistance.value);
+        tf.scale = reaction_scale(intensity, mat.thermal_resistance.value);
+    }
+}
+
+// ── Property revelation ─────────────────────────────────────────────────
+
+fn reveal_thermal_property(
+    cfg: Res<SceneConfig>,
+    mut material_query: Query<(&HeatExposure, &mut GameMaterial), With<MaterialObject>>,
+) {
+    let reveal_secs = cfg.heat_source.reveal_seconds;
+
+    for (exp, mut mat) in &mut material_query {
+        if exp.elapsed >= reveal_secs
+            && mat.thermal_resistance.visibility == PropertyVisibility::Hidden
+        {
+            mat.thermal_resistance.visibility = PropertyVisibility::Revealed;
+            info!(
+                "'{}' thermal resistance revealed after {:.1}s exposure",
+                mat.name, exp.elapsed
+            );
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reaction_intensity_zero_at_no_exposure() {
+        assert!((reaction_intensity(0.0, 0.5) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn reaction_intensity_increases_with_exposure() {
+        let low = reaction_intensity(0.3, 0.2);
+        let high = reaction_intensity(0.8, 0.2);
+        assert!(high > low);
+    }
+
+    #[test]
+    fn reaction_intensity_decreases_with_higher_resistance() {
+        let low_resist = reaction_intensity(1.0, 0.1);
+        let high_resist = reaction_intensity(1.0, 0.9);
+        assert!(low_resist > high_resist);
+    }
+
+    #[test]
+    fn reaction_intensity_clamped_to_one() {
+        let result = reaction_intensity(2.0, 0.0);
+        assert!((result - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn reaction_emissive_black_at_zero() {
+        let e = reaction_emissive(0.0);
+        assert!(e.red.abs() < f32::EPSILON);
+        assert!(e.green.abs() < f32::EPSILON);
+        assert!(e.blue.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn reaction_emissive_bright_at_one() {
+        let e = reaction_emissive(1.0);
+        assert!(e.red > 100.0);
+        assert!(e.green > 10.0);
+    }
+
+    #[test]
+    fn reaction_scale_identity_for_high_resistance() {
+        let s = reaction_scale(1.0, 0.8);
+        assert!((s.x - 1.0).abs() < f32::EPSILON);
+        assert!((s.y - 1.0).abs() < f32::EPSILON);
+        assert!((s.z - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn reaction_scale_deforms_for_low_resistance() {
+        let s = reaction_scale(1.0, 0.1);
+        assert!(s.x > 1.0, "XZ should expand");
+        assert!(s.y < 1.0, "Y should shrink (melting)");
+    }
+
+    #[test]
+    fn reaction_scale_no_deform_at_zero_intensity() {
+        let s = reaction_scale(0.0, 0.1);
+        assert!((s.x - 1.0).abs() < f32::EPSILON);
+        assert!((s.y - 1.0).abs() < f32::EPSILON);
+    }
+}

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -24,7 +24,7 @@ pub(crate) struct HeatPlugin;
 
 impl Plugin for HeatPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_heat_source).add_systems(
+        app.add_systems(PostStartup, spawn_heat_source).add_systems(
             Update,
             (
                 track_heat_exposure,

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -35,7 +35,10 @@ pub(crate) struct InteractionPlugin;
 
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<InteractionTarget>()
+        app.add_message::<PickupIntent>()
+            .add_message::<PlaceIntent>()
+            .add_message::<ExamineIntent>()
+            .init_resource::<InteractionTarget>()
             .init_resource::<ExamineState>()
             .add_systems(
                 Update,
@@ -222,6 +225,12 @@ fn process_pickup(
     }
 }
 
+/// Small gap above the surface so objects sit on top without z-fighting.
+const PLACE_GAP: f32 = 0.1;
+/// Maximum XZ distance from the ray's intersection to a surface center for
+/// placement to be considered valid.
+const PLACE_REACH: f32 = 2.5;
+
 fn process_place(
     mut commands: Commands,
     mut reader: MessageReader<PlaceIntent>,
@@ -238,17 +247,7 @@ fn process_place(
             continue;
         };
 
-        let cam_pos = cam_gtf.translation();
-        let cam_forward = cam_gtf.forward();
-        let place_target = cam_pos + *cam_forward * 1.5;
-
-        let closest_surface = surfaces.iter().min_by(|(_, a), (_, b)| {
-            let da = a.translation().distance_squared(place_target);
-            let db = b.translation().distance_squared(place_target);
-            da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        let Some((_surface_entity, surface_gtf)) = closest_surface else {
+        let Some((_entity, surface_gtf)) = best_surface_for_ray(cam_gtf, &surfaces) else {
             continue;
         };
 
@@ -258,12 +257,59 @@ fn process_place(
             .remove_parent_in_place();
 
         let surface_pos = surface_gtf.translation();
+        let cam_pos = cam_gtf.translation();
+        let cam_fwd = *cam_gtf.forward();
+
+        // Place at the ray's XZ intersection with the surface Y, clamped to
+        // the surface center so objects don't land in mid-air past the edge.
+        let hit = ray_horizontal_intersection(cam_pos, cam_fwd, surface_pos.y);
+        let place_x = hit.map_or(surface_pos.x, |p| p.x);
+        let place_z = hit.map_or(surface_pos.z, |p| p.z);
+
         commands.entity(held_entity).insert(Transform::from_xyz(
-            surface_pos.x,
-            surface_pos.y + 0.15,
-            surface_pos.z,
+            place_x,
+            surface_pos.y + PLACE_GAP,
+            place_z,
         ));
     }
+}
+
+/// Intersect a ray with the horizontal plane at the given Y.
+/// Returns `None` if the ray is parallel or the intersection is behind the origin.
+fn ray_horizontal_intersection(origin: Vec3, direction: Vec3, plane_y: f32) -> Option<Vec3> {
+    if direction.y.abs() < 1e-6 {
+        return None;
+    }
+    let t = (plane_y - origin.y) / direction.y;
+    if t < 0.0 {
+        return None;
+    }
+    Some(origin + direction * t)
+}
+
+/// Pick the surface the player is most likely aiming at by intersecting the
+/// camera ray with each surface's horizontal plane and choosing the one whose
+/// center is closest to the intersection point.
+fn best_surface_for_ray<'a>(
+    cam_gtf: &GlobalTransform,
+    surfaces: &'a Query<(Entity, &GlobalTransform), With<Surface>>,
+) -> Option<(Entity, &'a GlobalTransform)> {
+    let origin = cam_gtf.translation();
+    let direction = *cam_gtf.forward();
+
+    surfaces
+        .iter()
+        .filter_map(|(entity, sgtf)| {
+            let s_pos = sgtf.translation();
+            let hit = ray_horizontal_intersection(origin, direction, s_pos.y)?;
+            let xz_dist = Vec2::new(hit.x - s_pos.x, hit.z - s_pos.z).length();
+            if xz_dist > PLACE_REACH {
+                return None;
+            }
+            Some((entity, sgtf, xz_dist))
+        })
+        .min_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(entity, sgtf, _)| (entity, sgtf))
 }
 
 // ── Held item tracking ───────────────────────────────────────────────────
@@ -350,10 +396,11 @@ fn emit_examine_intent(
 fn process_examine(
     mut reader: MessageReader<ExamineIntent>,
     mut state: ResMut<ExamineState>,
+    target: Res<InteractionTarget>,
     held_query: Query<(), With<HeldItem>>,
 ) {
     for _intent in reader.read() {
-        if held_query.iter().next().is_some() {
+        if held_query.iter().next().is_some() || target.entity.is_some() {
             state.visible = !state.visible;
         } else {
             state.visible = false;
@@ -363,7 +410,9 @@ fn process_examine(
 
 fn update_examine_panel(
     state: Res<ExamineState>,
+    target: Res<InteractionTarget>,
     held_query: Query<&GameMaterial, With<HeldItem>>,
+    material_query: Query<&GameMaterial, With<MaterialObject>>,
     mut panel_query: Query<&mut Visibility, With<ExaminePanel>>,
     mut text_query: Query<&mut Text, With<ExamineText>>,
 ) {
@@ -379,7 +428,13 @@ fn update_examine_panel(
         return;
     }
 
-    let Some(mat) = held_query.iter().next() else {
+    // Prefer held item; fall back to whatever the player is looking at.
+    let mat = held_query
+        .iter()
+        .next()
+        .or_else(|| target.entity.and_then(|e| material_query.get(e).ok()));
+
+    let Some(mat) = mat else {
         *vis = Visibility::Hidden;
         return;
     };

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -1,16 +1,18 @@
-//! Interaction plugin — raycasting, pickup/place, and crosshair UI.
+//! Interaction plugin — raycasting, pickup/place, examine, and crosshair UI.
 //!
 //! Provides the hands-on loop for material interaction: the player looks at
-//! objects, picks them up, carries them, and puts them down on surfaces.
+//! objects, picks them up, carries them, puts them down on surfaces, and
+//! examines observable properties.
 //!
 //! Architecture follows the server-authoritative pattern: input systems emit
 //! intent messages, separate systems process those intents and mutate state.
 //!
 //! Systems:
 //! - `update_interaction_target`: raycast from camera center, track closest hit
-//! - `emit_pickup_intent` / `emit_place_intent`: read input actions, emit messages
+//! - `emit_pickup_intent` / `emit_place_intent` / `emit_examine_intent`: input → messages
 //! - `process_pickup`: pick up targeted material (re-parent to camera)
 //! - `process_place`: place held material on nearest surface
+//! - `process_examine`: toggle examine overlay for held material
 //! - `update_held_position`: keep held item in front of camera
 //! - `spawn_crosshair`: UI overlay at screen center
 //! - `update_crosshair`: colour change when targeting an interactable
@@ -20,7 +22,7 @@ use bevy::prelude::*;
 use bevy::window::CursorGrabMode;
 
 use crate::input::InputAction;
-use crate::materials::MaterialObject;
+use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::player::{Player, PlayerCamera};
 use crate::scene::Surface;
 
@@ -33,19 +35,24 @@ pub(crate) struct InteractionPlugin;
 
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<InteractionTarget>().add_systems(
-            Update,
-            (
-                update_interaction_target,
-                emit_pickup_intent.after(update_interaction_target),
-                emit_place_intent.after(update_interaction_target),
-                process_pickup.after(emit_pickup_intent),
-                process_place.after(emit_place_intent),
-                update_held_position.after(process_pickup),
-                update_crosshair.after(update_interaction_target),
-            ),
-        );
-        app.add_systems(Startup, spawn_crosshair);
+        app.init_resource::<InteractionTarget>()
+            .init_resource::<ExamineState>()
+            .add_systems(
+                Update,
+                (
+                    update_interaction_target,
+                    emit_pickup_intent.after(update_interaction_target),
+                    emit_place_intent.after(update_interaction_target),
+                    emit_examine_intent.after(update_interaction_target),
+                    process_pickup.after(emit_pickup_intent),
+                    process_place.after(emit_place_intent),
+                    process_examine.after(emit_examine_intent),
+                    update_held_position.after(process_pickup),
+                    update_crosshair.after(update_interaction_target),
+                    update_examine_panel.after(process_examine),
+                ),
+            );
+        app.add_systems(Startup, (spawn_crosshair, spawn_examine_panel));
     }
 }
 
@@ -56,6 +63,9 @@ struct PickupIntent;
 
 #[derive(Message)]
 struct PlaceIntent;
+
+#[derive(Message)]
+struct ExamineIntent;
 
 // ── State ────────────────────────────────────────────────────────────────
 
@@ -69,10 +79,22 @@ struct InteractionTarget {
 #[derive(Component)]
 pub(crate) struct HeldItem;
 
+/// Whether the examine overlay is currently visible.
+#[derive(Resource, Default)]
+struct ExamineState {
+    visible: bool,
+}
+
 // ── UI markers ───────────────────────────────────────────────────────────
 
 #[derive(Component)]
 struct Crosshair;
+
+#[derive(Component)]
+struct ExaminePanel;
+
+#[derive(Component)]
+struct ExamineText;
 
 // ── Crosshair setup ──────────────────────────────────────────────────────
 
@@ -274,4 +296,250 @@ fn update_crosshair(
     } else {
         Color::srgba(1.0, 1.0, 1.0, 0.6)
     };
+}
+
+// ── Examine panel setup ─────────────────────────────────────────────────
+
+fn spawn_examine_panel(mut commands: Commands) {
+    commands
+        .spawn((
+            ExaminePanel,
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(80.0),
+                left: Val::Percent(50.0),
+                padding: UiRect::all(Val::Px(14.0)),
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.08, 0.08, 0.12, 0.85)),
+            Visibility::Hidden,
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                ExamineText,
+                Text::new(""),
+                TextFont {
+                    font_size: 18.0,
+                    ..default()
+                },
+                TextColor(Color::srgba(0.9, 0.92, 0.88, 1.0)),
+            ));
+        });
+}
+
+// ── Examine intent ──────────────────────────────────────────────────────
+
+fn emit_examine_intent(
+    player_query: Query<&ActionState<InputAction>, With<Player>>,
+    cursor_options: Single<&bevy::window::CursorOptions>,
+    mut writer: MessageWriter<ExamineIntent>,
+) {
+    if cursor_options.grab_mode != CursorGrabMode::Locked {
+        return;
+    }
+    let Ok(action) = player_query.single() else {
+        return;
+    };
+    if action.just_pressed(&InputAction::Examine) {
+        writer.write(ExamineIntent);
+    }
+}
+
+// ── Examine processing ──────────────────────────────────────────────────
+
+fn process_examine(
+    mut reader: MessageReader<ExamineIntent>,
+    mut state: ResMut<ExamineState>,
+    held_query: Query<(), With<HeldItem>>,
+) {
+    for _intent in reader.read() {
+        if held_query.iter().next().is_some() {
+            state.visible = !state.visible;
+        } else {
+            state.visible = false;
+        }
+    }
+}
+
+fn update_examine_panel(
+    state: Res<ExamineState>,
+    held_query: Query<&GameMaterial, With<HeldItem>>,
+    mut panel_query: Query<&mut Visibility, With<ExaminePanel>>,
+    mut text_query: Query<&mut Text, With<ExamineText>>,
+) {
+    let Ok(mut vis) = panel_query.single_mut() else {
+        return;
+    };
+    let Ok(mut text) = text_query.single_mut() else {
+        return;
+    };
+
+    if !state.visible {
+        *vis = Visibility::Hidden;
+        return;
+    }
+
+    let Some(mat) = held_query.iter().next() else {
+        *vis = Visibility::Hidden;
+        return;
+    };
+
+    *vis = Visibility::Visible;
+    text.0 = build_examine_text(mat);
+}
+
+// ── Property description ─────────────────────────────────────────────────
+
+/// Converts a normalised 0–1 property value into a descriptive word.
+fn describe_value(value: f32) -> &'static str {
+    if value < 0.15 {
+        "Negligible"
+    } else if value < 0.3 {
+        "Very low"
+    } else if value < 0.45 {
+        "Low"
+    } else if value < 0.55 {
+        "Moderate"
+    } else if value < 0.7 {
+        "High"
+    } else if value < 0.85 {
+        "Very high"
+    } else {
+        "Extreme"
+    }
+}
+
+fn describe_density(value: f32) -> &'static str {
+    if value < 0.15 {
+        "Almost weightless"
+    } else if value < 0.3 {
+        "Very light"
+    } else if value < 0.45 {
+        "Light"
+    } else if value < 0.55 {
+        "Medium weight"
+    } else if value < 0.7 {
+        "Heavy"
+    } else if value < 0.85 {
+        "Very heavy"
+    } else {
+        "Extremely dense"
+    }
+}
+
+fn build_examine_text(mat: &GameMaterial) -> String {
+    let mut lines = vec![mat.name.clone()];
+    lines.push(String::new());
+
+    append_prop(&mut lines, "Weight", &mat.density, describe_density);
+    append_prop(
+        &mut lines,
+        "Heat resistance",
+        &mat.thermal_resistance,
+        describe_value,
+    );
+    append_prop(&mut lines, "Reactivity", &mat.reactivity, describe_value);
+    append_prop(
+        &mut lines,
+        "Conductivity",
+        &mat.conductivity,
+        describe_value,
+    );
+    append_prop(&mut lines, "Toxicity", &mat.toxicity, describe_value);
+
+    lines.join("\n")
+}
+
+fn append_prop(
+    lines: &mut Vec<String>,
+    label: &str,
+    prop: &crate::materials::MaterialProperty,
+    describer: fn(f32) -> &'static str,
+) {
+    if prop.visibility == PropertyVisibility::Observable
+        || prop.visibility == PropertyVisibility::Revealed
+    {
+        lines.push(format!("{label}: {}", describer(prop.value)));
+    } else {
+        lines.push(format!("{label}: ???"));
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::materials::MaterialProperty;
+
+    #[test]
+    fn describe_value_covers_full_range() {
+        assert_eq!(describe_value(0.0), "Negligible");
+        assert_eq!(describe_value(0.2), "Very low");
+        assert_eq!(describe_value(0.35), "Low");
+        assert_eq!(describe_value(0.5), "Moderate");
+        assert_eq!(describe_value(0.6), "High");
+        assert_eq!(describe_value(0.75), "Very high");
+        assert_eq!(describe_value(0.9), "Extreme");
+    }
+
+    #[test]
+    fn describe_density_covers_full_range() {
+        assert_eq!(describe_density(0.1), "Almost weightless");
+        assert_eq!(describe_density(0.25), "Very light");
+        assert_eq!(describe_density(0.4), "Light");
+        assert_eq!(describe_density(0.5), "Medium weight");
+        assert_eq!(describe_density(0.65), "Heavy");
+        assert_eq!(describe_density(0.78), "Very heavy");
+        assert_eq!(describe_density(0.95), "Extremely dense");
+    }
+
+    fn test_material() -> GameMaterial {
+        GameMaterial {
+            name: "TestMat".into(),
+            seed: 1,
+            color: [0.5, 0.5, 0.5],
+            density: MaterialProperty {
+                value: 0.78,
+                visibility: PropertyVisibility::Observable,
+            },
+            thermal_resistance: MaterialProperty {
+                value: 0.65,
+                visibility: PropertyVisibility::Hidden,
+            },
+            reactivity: MaterialProperty {
+                value: 0.35,
+                visibility: PropertyVisibility::Hidden,
+            },
+            conductivity: MaterialProperty {
+                value: 0.72,
+                visibility: PropertyVisibility::Revealed,
+            },
+            toxicity: MaterialProperty {
+                value: 0.05,
+                visibility: PropertyVisibility::Hidden,
+            },
+        }
+    }
+
+    #[test]
+    fn examine_text_shows_observable_and_revealed_hides_hidden() {
+        let mat = test_material();
+        let text = build_examine_text(&mat);
+
+        assert!(text.contains("TestMat"));
+        assert!(text.contains("Weight: Very heavy"));
+        assert!(text.contains("Conductivity: Very high"));
+        assert!(text.contains("Heat resistance: ???"));
+        assert!(text.contains("Reactivity: ???"));
+        assert!(text.contains("Toxicity: ???"));
+    }
+
+    #[test]
+    fn examine_text_name_is_first_line() {
+        let mat = test_material();
+        let text = build_examine_text(&mat);
+        let first_line = text.lines().next().unwrap();
+        assert_eq!(first_line, "TestMat");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use bevy::prelude::*;
 
+mod heat;
 mod input;
 mod interaction;
 mod materials;
@@ -37,5 +38,7 @@ fn main() {
         .add_plugins(materials::MaterialPlugin)
         // Interaction: raycast, pickup/place, crosshair UI.
         .add_plugins(interaction::InteractionPlugin)
+        // Heat: burner on workbench, thermal exposure → property revelation.
+        .add_plugins(heat::HeatPlugin)
         .run();
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -21,14 +21,14 @@ use std::path::Path;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::scene::Surface;
+use crate::scene::Shelf;
 
 pub(crate) struct MaterialPlugin;
 
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreStartup, load_material_catalog)
-            .add_systems(Startup, spawn_material_objects);
+            .add_systems(PostStartup, spawn_material_objects);
     }
 }
 
@@ -131,11 +131,11 @@ fn spawn_material_objects(
     mut meshes: ResMut<Assets<Mesh>>,
     mut std_materials: ResMut<Assets<StandardMaterial>>,
     catalog: Res<MaterialCatalog>,
-    surfaces: Query<&Transform, With<Surface>>,
+    shelves: Query<&Transform, With<Shelf>>,
 ) {
-    let surface_transforms: Vec<&Transform> = surfaces.iter().collect();
-    if surface_transforms.is_empty() {
-        warn!("No Surface entities found — materials will not be spawned in the world");
+    let shelf_transforms: Vec<&Transform> = shelves.iter().collect();
+    if shelf_transforms.is_empty() {
+        warn!("No Shelf entities found — materials will not be spawned in the world");
         return;
     }
 
@@ -144,12 +144,12 @@ fn spawn_material_objects(
 
     for (i, name) in sorted_names.iter().enumerate() {
         let mat = &catalog.materials[*name];
-        let surface_tf = surface_transforms[i % surface_transforms.len()];
+        let surface_tf = shelf_transforms[i % shelf_transforms.len()];
 
         let items_on_this_surface = sorted_names
             .iter()
             .enumerate()
-            .filter(|(j, _)| j % surface_transforms.len() == i % surface_transforms.len())
+            .filter(|(j, _)| j % shelf_transforms.len() == i % shelf_transforms.len())
             .position(|(j, _)| j == i)
             .unwrap_or(0);
 
@@ -174,7 +174,7 @@ fn spawn_material_objects(
             MeshMaterial3d(render_mat),
             Transform::from_xyz(
                 surface_tf.translation.x + x_offset,
-                surface_tf.translation.y + 0.15,
+                surface_tf.translation.y + 0.1,
                 surface_tf.translation.z,
             )
             .with_scale(Vec3::splat(OBJECT_SCALE)),

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -22,13 +22,20 @@ impl Plugin for ScenePlugin {
 
 // ── Marker components (Epic 3+ query targets) ───────────────────────────
 
-/// Marks the central workbench — future fabricator anchor (Epic 3).
+/// Marks the central workbench mesh — future fabricator anchor (Epic 3).
 #[derive(Component)]
 pub(crate) struct Workbench;
 
-/// Marks shelf or table surfaces for placing materials (later stories).
+/// A placement plane: the actual top of a piece of furniture where objects
+/// can be set down. Spawned as its own entity at the true surface Y so
+/// the placement system never needs offset math.
 #[derive(Component)]
 pub(crate) struct Surface;
+
+/// Distinguishes storage shelves from the experiment workbench so initial
+/// material spawning only targets shelves.
+#[derive(Component)]
+pub(crate) struct Shelf;
 
 // ── Config (TOML ↔ Rust) ─────────────────────────────────────────────────
 
@@ -452,6 +459,11 @@ fn setup_scene(
         MeshMaterial3d(workbench_mat),
         Transform::from_xyz(fur.workbench_x, wb_half_y, fur.workbench_z),
     ));
+    // Placement plane at the true top of the workbench.
+    commands.spawn((
+        Surface,
+        Transform::from_xyz(fur.workbench_x, fur.workbench_height, fur.workbench_z),
+    ));
 
     // Shelf surfaces — warm neutral, clearly not wall paint.
     let shelf_w = fur.shelf_width;
@@ -466,10 +478,15 @@ fn setup_scene(
 
     for shelf in &fur.shelves {
         commands.spawn((
-            Surface,
             Mesh3d(meshes.add(Cuboid::new(shelf_w, shelf_h, shelf_d))),
             MeshMaterial3d(shelf_mat.clone()),
             Transform::from_xyz(shelf.x, shelf.y - shelf_half_y, shelf.z),
+        ));
+        // Placement plane at the true top of each shelf.
+        commands.spawn((
+            Surface,
+            Shelf,
+            Transform::from_xyz(shelf.x, shelf.y, shelf.z),
         ));
     }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -45,6 +45,8 @@ pub(crate) struct SceneConfig {
     pub lighting: LightingConfig,
     #[serde(default)]
     pub furniture: FurnitureConfig,
+    #[serde(default)]
+    pub heat_source: HeatSourceConfig,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -270,6 +272,64 @@ pub(crate) struct ShelfConfig {
     pub x: f32,
     pub z: f32,
     pub y: f32,
+}
+
+// ── Heat source config ──────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct HeatSourceConfig {
+    #[serde(default = "default_hs_offset_x")]
+    pub offset_x: f32,
+    #[serde(default = "default_hs_offset_z")]
+    pub offset_z: f32,
+    #[serde(default = "default_hs_radius")]
+    pub radius: f32,
+    #[serde(default = "default_hs_zone_radius")]
+    pub zone_radius: f32,
+    #[serde(default = "default_hs_light_intensity")]
+    pub light_intensity: f32,
+    /// Seconds of exposure before a material fully reacts.
+    #[serde(default = "default_hs_reaction_seconds")]
+    pub reaction_seconds: f32,
+    /// Seconds of exposure before thermal_resistance is revealed.
+    #[serde(default = "default_hs_reveal_seconds")]
+    pub reveal_seconds: f32,
+}
+
+fn default_hs_offset_x() -> f32 {
+    0.55
+}
+fn default_hs_offset_z() -> f32 {
+    0.0
+}
+fn default_hs_radius() -> f32 {
+    0.1
+}
+fn default_hs_zone_radius() -> f32 {
+    1.0
+}
+fn default_hs_light_intensity() -> f32 {
+    40_000.0
+}
+fn default_hs_reaction_seconds() -> f32 {
+    2.5
+}
+fn default_hs_reveal_seconds() -> f32 {
+    3.5
+}
+
+impl Default for HeatSourceConfig {
+    fn default() -> Self {
+        Self {
+            offset_x: default_hs_offset_x(),
+            offset_z: default_hs_offset_z(),
+            radius: default_hs_radius(),
+            zone_radius: default_hs_zone_radius(),
+            light_intensity: default_hs_light_intensity(),
+            reaction_seconds: default_hs_reaction_seconds(),
+            reveal_seconds: default_hs_reveal_seconds(),
+        }
+    }
 }
 
 // ── Load ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements Story 2.3: Environmental Property Revelation — the first environmental test mechanic for the POC.

- **Heat source entity:** A glowing burner (cylinder + point light) spawned on the workbench, position and zone radius configurable via `scene.toml`
- **Exposure tracking:** Materials placed near the burner accumulate heat exposure over time; exposure persists if moved away
- **Thermal reaction visuals:** Emissive glow, warm color shift, and scale deformation (melting) proportional to `thermal_resistance` — low resistance materials react strongly, high resistance materials remain stoic
- **Property revelation:** After sufficient exposure, `thermal_resistance` flips from Hidden to Revealed, becoming visible in the examine panel
- **No labels:** The game never tells the player what happened — they observe the visual consequence and draw their own conclusions

Also fixes several issues from Story 2.2:
- Register Message types (`PickupIntent`/`PlaceIntent`/`ExamineIntent`) — fixes "Message not initialized" panic
- Move spawn systems to `PostStartup` so scene entities exist first
- Refactor `Surface` into standalone placement-plane entities at the true top of furniture (no offset math)
- Replace fixed-point placement with ray-plane intersection (places on the surface you're looking at)
- Examine panel now works on both held items and raycast targets (look + press Q)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 30 tests pass (9 new heat tests)
- [ ] Manual: place a material on the workbench near the burner, observe glow/color/scale change
- [ ] Manual: compare low-resistance (volatite) vs high-resistance (osmium) reactions
- [ ] Manual: after exposure, examine the material — thermal resistance shows descriptor instead of ???
- [ ] Manual: examine a material by looking at it (without picking up) — press Q

Closes #11