### PR TITLE
feat: Story 3.1a — Fabricator slot entities on workbench

### DIFF
--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -52,6 +52,20 @@ x = 0.6
 z = -3.15
 y = 0.92
 
+[fabricator]
+# Input slots: left side of bench, spaced apart on the Z axis.
+slot_offset_x = -0.45
+slot_spacing_z = 0.3
+slot_radius = 0.07
+slot_height = 0.02
+# Output slot: center of bench, slightly forward.
+output_offset_x = 0.0
+output_offset_z = -0.25
+output_radius = 0.09
+output_height = 0.02
+# How long the fabrication process takes (seconds).
+process_seconds = 2.5
+
 [heat_source]
 # Offset from workbench center — sits on the right side of the bench.
 offset_x = 0.55

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -1,0 +1,119 @@
+//! Fabricator plugin — the workbench combination device.
+//!
+//! The fabricator has two input slots and one output slot, all positioned on
+//! the workbench surface. Players place materials into input slots, activate
+//! the fabricator, and receive a combined output material.
+//!
+//! This module owns the slot entities, fabrication state machine, and output
+//! spawning. Slot targeting and material placement routing live in the
+//! interaction plugin.
+
+use bevy::prelude::*;
+
+use crate::scene::{SceneConfig, Workbench};
+
+pub(crate) struct FabricatorPlugin;
+
+impl Plugin for FabricatorPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PostStartup, spawn_fabricator_slots);
+    }
+}
+
+// ── Components ──────────────────────────────────────────────────────────
+
+/// Marks a fabricator input receptacle. `index` distinguishes slot 0 from slot 1.
+/// `material` holds the entity of the material currently seated in this slot.
+// Fields read by interaction routing (PR b) and activation state machine (PR c).
+#[allow(dead_code)]
+#[derive(Component, Debug)]
+pub(crate) struct InputSlot {
+    pub index: usize,
+    pub material: Option<Entity>,
+}
+
+/// Marks the fabricator output receptacle where the combined material appears.
+// Field read by activation state machine (PR c).
+#[allow(dead_code)]
+#[derive(Component, Debug)]
+pub(crate) struct OutputSlot {
+    pub material: Option<Entity>,
+}
+
+// ── Slot spawning ───────────────────────────────────────────────────────
+
+fn spawn_fabricator_slots(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    cfg: Res<SceneConfig>,
+    workbench_query: Query<&Transform, With<Workbench>>,
+) {
+    let Ok(wb_tf) = workbench_query.single() else {
+        warn!("No workbench found — fabricator slots will not be spawned");
+        return;
+    };
+
+    let fab = &cfg.fabricator;
+    let fur = &cfg.furniture;
+    let wb_top_y = fur.workbench_height;
+    let wb_center = wb_tf.translation;
+
+    let slot_mat = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.25, 0.28, 0.35),
+        perceptual_roughness: 0.3,
+        metallic: 0.7,
+        ..default()
+    });
+
+    let output_mat = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.35, 0.32, 0.25),
+        perceptual_roughness: 0.3,
+        metallic: 0.7,
+        ..default()
+    });
+
+    // Two input slots, symmetric about the workbench center on Z.
+    for i in 0..2 {
+        let z_sign = if i == 0 { 1.0 } else { -1.0 };
+        let pos = Vec3::new(
+            wb_center.x + fab.slot_offset_x,
+            wb_top_y + fab.slot_height * 0.5,
+            wb_center.z + fab.slot_spacing_z * z_sign,
+        );
+
+        commands.spawn((
+            InputSlot {
+                index: i,
+                material: None,
+            },
+            Mesh3d(meshes.add(Cylinder::new(fab.slot_radius, fab.slot_height))),
+            MeshMaterial3d(slot_mat.clone()),
+            Transform::from_translation(pos),
+        ));
+
+        info!(
+            "Spawned input slot {i} at ({}, {}, {})",
+            pos.x, pos.y, pos.z
+        );
+    }
+
+    // Output slot.
+    let output_pos = Vec3::new(
+        wb_center.x + fab.output_offset_x,
+        wb_top_y + fab.output_height * 0.5,
+        wb_center.z + fab.output_offset_z,
+    );
+
+    commands.spawn((
+        OutputSlot { material: None },
+        Mesh3d(meshes.add(Cylinder::new(fab.output_radius, fab.output_height))),
+        MeshMaterial3d(output_mat),
+        Transform::from_translation(output_pos),
+    ));
+
+    info!(
+        "Spawned output slot at ({}, {}, {})",
+        output_pos.x, output_pos.y, output_pos.z
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use bevy::prelude::*;
 
+mod fabricator;
 mod heat;
 mod input;
 mod interaction;
@@ -40,5 +41,7 @@ fn main() {
         .add_plugins(interaction::InteractionPlugin)
         // Heat: burner on workbench, thermal exposure → property revelation.
         .add_plugins(heat::HeatPlugin)
+        // Fabricator: input/output slots on the workbench for material combination.
+        .add_plugins(fabricator::FabricatorPlugin)
         .run();
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -53,6 +53,8 @@ pub(crate) struct SceneConfig {
     #[serde(default)]
     pub furniture: FurnitureConfig,
     #[serde(default)]
+    pub fabricator: FabricatorSceneConfig,
+    #[serde(default)]
     pub heat_source: HeatSourceConfig,
 }
 
@@ -279,6 +281,74 @@ pub(crate) struct ShelfConfig {
     pub x: f32,
     pub z: f32,
     pub y: f32,
+}
+
+// ── Fabricator config ────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct FabricatorSceneConfig {
+    #[serde(default = "default_fab_slot_offset_x")]
+    pub slot_offset_x: f32,
+    #[serde(default = "default_fab_slot_spacing_z")]
+    pub slot_spacing_z: f32,
+    #[serde(default = "default_fab_slot_radius")]
+    pub slot_radius: f32,
+    #[serde(default = "default_fab_slot_height")]
+    pub slot_height: f32,
+    #[serde(default = "default_fab_output_offset_x")]
+    pub output_offset_x: f32,
+    #[serde(default = "default_fab_output_offset_z")]
+    pub output_offset_z: f32,
+    #[serde(default = "default_fab_output_radius")]
+    pub output_radius: f32,
+    #[serde(default = "default_fab_output_height")]
+    pub output_height: f32,
+    #[serde(default = "default_fab_process_seconds")]
+    pub process_seconds: f32,
+}
+
+fn default_fab_slot_offset_x() -> f32 {
+    -0.45
+}
+fn default_fab_slot_spacing_z() -> f32 {
+    0.3
+}
+fn default_fab_slot_radius() -> f32 {
+    0.07
+}
+fn default_fab_slot_height() -> f32 {
+    0.02
+}
+fn default_fab_output_offset_x() -> f32 {
+    0.0
+}
+fn default_fab_output_offset_z() -> f32 {
+    -0.25
+}
+fn default_fab_output_radius() -> f32 {
+    0.09
+}
+fn default_fab_output_height() -> f32 {
+    0.02
+}
+fn default_fab_process_seconds() -> f32 {
+    2.5
+}
+
+impl Default for FabricatorSceneConfig {
+    fn default() -> Self {
+        Self {
+            slot_offset_x: default_fab_slot_offset_x(),
+            slot_spacing_z: default_fab_slot_spacing_z(),
+            slot_radius: default_fab_slot_radius(),
+            slot_height: default_fab_slot_height(),
+            output_offset_x: default_fab_output_offset_x(),
+            output_offset_z: default_fab_output_offset_z(),
+            output_radius: default_fab_output_radius(),
+            output_height: default_fab_output_height(),
+            process_seconds: default_fab_process_seconds(),
+        }
+    }
 }
 
 // ── Heat source config ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `[fabricator]` config section to `scene.toml` with slot positions, radii, and processing time
- Add `FabricatorSceneConfig` to `scene.rs` with defaults and serde support
- Create `fabricator.rs` with `FabricatorPlugin` that spawns two `InputSlot` cylinders (left side of bench) and one `OutputSlot` cylinder (center-front)
- Register plugin in `main.rs`

Part 1 of 3 for Story 3.1 (Fabricator Interaction).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 30 tests pass
- [ ] Manual: run the game and verify three small cylinders are visible on the workbench surface