### PR TITLE
feat: 3.2a - combination rules data model and TOML config

### DIFF
--- a/assets/config/combinations.toml
+++ b/assets/config/combinations.toml
@@ -1,0 +1,65 @@
+# Combination rules — maps material pairs to per-property rule sets.
+#
+# Each [[rules]] entry names two materials (order doesn't matter) and
+# specifies a rule for each property. Missing properties use the default
+# rule (Blend with equal weights).
+#
+# Rule types:
+#   Blend { weight_a, weight_b }  — weighted average (predictable)
+#   Max                           — takes the higher value (predictable)
+#   Min                           — takes the lower value (predictable)
+#   Catalyze { multiplier }       — max of inputs × multiplier (emergent)
+#   Inert                         — produces waste: all properties → 0.1
+
+# Default rule applied when a pair has no entry here:
+[default_rule]
+type = "Blend"
+weight_a = 0.5
+weight_b = 0.5
+
+# ── Specific pair rules ──────────────────────────────────────────────────
+
+[[rules]]
+material_a = "Ferrite"
+material_b = "Phosphite"
+density = { type = "Max" }
+thermal_resistance = { type = "Catalyze", multiplier = 1.4 }
+reactivity = { type = "Blend", weight_a = 0.7, weight_b = 0.3 }
+conductivity = { type = "Min" }
+toxicity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
+
+[[rules]]
+material_a = "Volatite"
+material_b = "Calcium"
+density = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
+thermal_resistance = { type = "Min" }
+reactivity = { type = "Catalyze", multiplier = 1.6 }
+conductivity = { type = "Blend", weight_a = 0.4, weight_b = 0.6 }
+toxicity = { type = "Max" }
+
+[[rules]]
+material_a = "Sulfurite"
+material_b = "Osmium"
+density = { type = "Inert" }
+thermal_resistance = { type = "Inert" }
+reactivity = { type = "Inert" }
+conductivity = { type = "Inert" }
+toxicity = { type = "Inert" }
+
+[[rules]]
+material_a = "Cobaltine"
+material_b = "Verdant"
+density = { type = "Blend", weight_a = 0.3, weight_b = 0.7 }
+thermal_resistance = { type = "Max" }
+reactivity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
+conductivity = { type = "Catalyze", multiplier = 1.3 }
+toxicity = { type = "Min" }
+
+[[rules]]
+material_a = "Silite"
+material_b = "Prismate"
+density = { type = "Min" }
+thermal_resistance = { type = "Blend", weight_a = 0.6, weight_b = 0.4 }
+reactivity = { type = "Max" }
+conductivity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
+toxicity = { type = "Catalyze", multiplier = 1.5 }

--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -132,3 +132,16 @@ y = 0.92
 x = 0.6
 z = -3.15
 y = 0.92
+
+[heat_source]
+# Offset from workbench center — sits on the right side of the bench.
+offset_x = 0.55
+offset_z = 0.0
+radius = 0.1
+# Materials within this distance of the burner are "in the heat zone".
+zone_radius = 1.0
+light_intensity = 40_000.0
+# Seconds of continuous exposure for a material to fully react.
+reaction_seconds = 2.5
+# Seconds of continuous exposure before thermal_resistance is revealed.
+reveal_seconds = 3.5

--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -78,3 +78,57 @@ light_intensity = 40_000.0
 reaction_seconds = 2.5
 # Seconds of continuous exposure before thermal_resistance is revealed.
 reveal_seconds = 3.5
+
+# Scene tuning — room geometry, lighting, and player spawn.
+# Edit these values instead of changing Rust constants.
+
+[room]
+half_extent_x = 4.0
+half_extent_z = 4.0
+wall_height = 3.0
+wall_thickness = 0.2
+# Player AABB clamp: inner half-extent minus this margin (meters).
+boundary_margin = 0.12
+
+[player]
+eye_height = 1.7
+spawn_x = 0.0
+spawn_z = 2.0
+move_speed = 5.0
+
+[lighting]
+ambient_brightness = 14.0
+directional_illuminance = 1100.0
+directional_shadows = true
+# Spot above workbench — lumens (Bevy PBR units).
+spot_intensity = 280_000.0
+spot_range = 12.0
+spot_inner_angle = 0.28
+spot_outer_angle = 0.48
+spot_height = 2.75
+spot_target_y = 0.45
+
+[furniture]
+workbench_width = 2.0
+workbench_height = 0.88
+workbench_depth = 1.0
+workbench_x = 0.0
+workbench_z = 0.0
+shelf_width = 1.35
+shelf_thickness = 0.07
+shelf_depth = 0.55
+
+[[shelves]]
+x = -3.15
+z = 0.7
+y = 0.92
+
+[[shelves]]
+x = 3.15
+z = -0.7
+y = 0.92
+
+[[shelves]]
+x = 0.6
+z = -3.15
+y = 0.92

--- a/src/combination.rs
+++ b/src/combination.rs
@@ -1,0 +1,332 @@
+//! Combination rules — data-driven system for material combination outcomes.
+//!
+//! Rules are loaded from `assets/config/combinations.toml` at startup. Each
+//! rule entry maps a pair of material names to per-property combination rules.
+//! Pairs without an explicit entry use the default rule (equal-weight blend).
+//!
+//! Rule types:
+//! - `Blend { weight_a, weight_b }`: weighted average (predictable)
+//! - `Max`: takes the higher of the two input values (predictable)
+//! - `Min`: takes the lower of the two input values (predictable)
+//! - `Catalyze { multiplier }`: max of inputs × multiplier, clamped to 1.0 (emergent)
+//! - `Inert`: all outputs become 0.1 — a failed experiment (emergent)
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+pub(crate) struct CombinationPlugin;
+
+impl Plugin for CombinationPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PreStartup, load_combination_rules);
+    }
+}
+
+// ── Rule types ──────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub(crate) enum PropertyRule {
+    Blend { weight_a: f32, weight_b: f32 },
+    Max,
+    Min,
+    Catalyze { multiplier: f32 },
+    Inert,
+}
+
+impl PropertyRule {
+    /// Used by the fabricator in the next PR to compute output property values.
+    #[allow(dead_code)]
+    pub(crate) fn apply(&self, a: f32, b: f32) -> f32 {
+        match self {
+            PropertyRule::Blend { weight_a, weight_b } => {
+                let total = weight_a + weight_b;
+                if total < f32::EPSILON {
+                    return (a + b) * 0.5;
+                }
+                ((a * weight_a + b * weight_b) / total).clamp(0.0, 1.0)
+            }
+            PropertyRule::Max => a.max(b),
+            PropertyRule::Min => a.min(b),
+            PropertyRule::Catalyze { multiplier } => (a.max(b) * multiplier).clamp(0.0, 1.0),
+            PropertyRule::Inert => 0.1,
+        }
+    }
+}
+
+impl Default for PropertyRule {
+    fn default() -> Self {
+        PropertyRule::Blend {
+            weight_a: 0.5,
+            weight_b: 0.5,
+        }
+    }
+}
+
+// ── Rule set for a material pair ────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct PairRuleSet {
+    pub density: PropertyRule,
+    pub thermal_resistance: PropertyRule,
+    pub reactivity: PropertyRule,
+    pub conductivity: PropertyRule,
+    pub toxicity: PropertyRule,
+}
+
+impl PairRuleSet {
+    /// Constructor used by tests and future combination logic.
+    #[allow(dead_code)]
+    pub(crate) fn all_inert() -> Self {
+        Self {
+            density: PropertyRule::Inert,
+            thermal_resistance: PropertyRule::Inert,
+            reactivity: PropertyRule::Inert,
+            conductivity: PropertyRule::Inert,
+            toxicity: PropertyRule::Inert,
+        }
+    }
+
+    /// Used by the fabricator to detect waste outputs.
+    #[allow(dead_code)]
+    pub(crate) fn is_inert(&self) -> bool {
+        self.density == PropertyRule::Inert
+            && self.thermal_resistance == PropertyRule::Inert
+            && self.reactivity == PropertyRule::Inert
+            && self.conductivity == PropertyRule::Inert
+            && self.toxicity == PropertyRule::Inert
+    }
+}
+
+// ── TOML file format ────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct CombinationFile {
+    #[serde(default)]
+    default_rule: PropertyRule,
+    #[serde(default)]
+    rules: Vec<PairRuleEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PairRuleEntry {
+    material_a: String,
+    material_b: String,
+    #[serde(default)]
+    density: Option<PropertyRule>,
+    #[serde(default)]
+    thermal_resistance: Option<PropertyRule>,
+    #[serde(default)]
+    reactivity: Option<PropertyRule>,
+    #[serde(default)]
+    conductivity: Option<PropertyRule>,
+    #[serde(default)]
+    toxicity: Option<PropertyRule>,
+}
+
+// ── Resource ────────────────────────────────────────────────────────────
+
+/// Canonical key for a material pair — alphabetically sorted so (A,B) == (B,A).
+fn pair_key(a: &str, b: &str) -> (String, String) {
+    if a <= b {
+        (a.to_string(), b.to_string())
+    } else {
+        (b.to_string(), a.to_string())
+    }
+}
+
+/// Loaded combination rules, keyed by sorted material name pairs.
+/// Fields read by the fabricator in the next PR.
+#[allow(dead_code)]
+#[derive(Resource, Debug, Default)]
+pub(crate) struct CombinationRules {
+    pub default_rule: PropertyRule,
+    pub pair_rules: HashMap<(String, String), PairRuleSet>,
+}
+
+impl CombinationRules {
+    /// Look up the rule set for a pair, falling back to the default for each property.
+    /// Used by the fabricator's tick_processing system in the next PR.
+    #[allow(dead_code)]
+    pub(crate) fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
+        let key = pair_key(name_a, name_b);
+        if let Some(rules) = self.pair_rules.get(&key) {
+            rules.clone()
+        } else {
+            let d = &self.default_rule;
+            PairRuleSet {
+                density: d.clone(),
+                thermal_resistance: d.clone(),
+                reactivity: d.clone(),
+                conductivity: d.clone(),
+                toxicity: d.clone(),
+            }
+        }
+    }
+}
+
+// ── Loading ─────────────────────────────────────────────────────────────
+
+const CONFIG_PATH: &str = "assets/config/combinations.toml";
+
+fn load_combination_rules(mut commands: Commands) {
+    let rules = if Path::new(CONFIG_PATH).exists() {
+        match fs::read_to_string(CONFIG_PATH) {
+            Ok(contents) => match toml::from_str::<CombinationFile>(&contents) {
+                Ok(file) => {
+                    let default = file.default_rule;
+                    let mut pair_rules = HashMap::new();
+
+                    for entry in file.rules {
+                        let key = pair_key(&entry.material_a, &entry.material_b);
+                        let rule_set = PairRuleSet {
+                            density: entry.density.unwrap_or_else(|| default.clone()),
+                            thermal_resistance: entry
+                                .thermal_resistance
+                                .unwrap_or_else(|| default.clone()),
+                            reactivity: entry.reactivity.unwrap_or_else(|| default.clone()),
+                            conductivity: entry.conductivity.unwrap_or_else(|| default.clone()),
+                            toxicity: entry.toxicity.unwrap_or_else(|| default.clone()),
+                        };
+                        pair_rules.insert(key, rule_set);
+                    }
+
+                    info!(
+                        "Loaded combination rules from {CONFIG_PATH}: {} pair rules",
+                        pair_rules.len()
+                    );
+                    CombinationRules {
+                        default_rule: default,
+                        pair_rules,
+                    }
+                }
+                Err(e) => {
+                    warn!("Malformed {CONFIG_PATH}, using defaults: {e}");
+                    CombinationRules::default()
+                }
+            },
+            Err(e) => {
+                warn!("Could not read {CONFIG_PATH}, using defaults: {e}");
+                CombinationRules::default()
+            }
+        }
+    } else {
+        warn!("{CONFIG_PATH} not found, using default blend rules");
+        CombinationRules::default()
+    };
+
+    commands.insert_resource(rules);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blend_equal_weights() {
+        let rule = PropertyRule::Blend {
+            weight_a: 0.5,
+            weight_b: 0.5,
+        };
+        assert!((rule.apply(0.4, 0.6) - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn blend_weighted() {
+        let rule = PropertyRule::Blend {
+            weight_a: 0.7,
+            weight_b: 0.3,
+        };
+        let result = rule.apply(1.0, 0.0);
+        assert!((result - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn max_rule() {
+        assert!((PropertyRule::Max.apply(0.3, 0.8) - 0.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn min_rule() {
+        assert!((PropertyRule::Min.apply(0.3, 0.8) - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn catalyze_multiplies_max() {
+        let rule = PropertyRule::Catalyze { multiplier: 1.5 };
+        let result = rule.apply(0.4, 0.6);
+        assert!((result - 0.9).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn catalyze_clamps_to_one() {
+        let rule = PropertyRule::Catalyze { multiplier: 2.0 };
+        let result = rule.apply(0.8, 0.9);
+        assert!((result - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn inert_always_returns_point_one() {
+        assert!((PropertyRule::Inert.apply(0.9, 0.8) - 0.1).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn pair_key_is_order_independent() {
+        assert_eq!(pair_key("Ferrite", "Silite"), pair_key("Silite", "Ferrite"));
+    }
+
+    #[test]
+    fn rules_for_returns_default_for_unknown_pair() {
+        let rules = CombinationRules::default();
+        let pair = rules.rules_for("Unknown", "Other");
+        assert_eq!(pair.density, PropertyRule::default());
+    }
+
+    #[test]
+    fn pair_rule_set_all_inert() {
+        let prs = PairRuleSet::all_inert();
+        assert!(prs.is_inert());
+    }
+
+    #[test]
+    fn toml_round_trip_rule_types() {
+        let toml_str = r#"
+[default_rule]
+type = "Blend"
+weight_a = 0.5
+weight_b = 0.5
+
+[[rules]]
+material_a = "A"
+material_b = "B"
+density = { type = "Max" }
+thermal_resistance = { type = "Catalyze", multiplier = 1.3 }
+reactivity = { type = "Min" }
+conductivity = { type = "Inert" }
+toxicity = { type = "Blend", weight_a = 0.6, weight_b = 0.4 }
+"#;
+        let file: CombinationFile = toml::from_str(toml_str).expect("parse");
+        assert_eq!(file.rules.len(), 1);
+        assert_eq!(file.rules[0].density, Some(PropertyRule::Max));
+        assert_eq!(
+            file.rules[0].thermal_resistance,
+            Some(PropertyRule::Catalyze { multiplier: 1.3 })
+        );
+    }
+
+    #[test]
+    fn combinations_toml_parses() {
+        let contents = include_str!("../assets/config/combinations.toml");
+        let file: CombinationFile = toml::from_str(contents).expect("parse combinations.toml");
+        assert!(
+            file.rules.len() >= 5,
+            "expected at least 5 pair rules in combinations.toml"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use bevy::prelude::*;
 
+mod combination;
 mod fabricator;
 mod heat;
 mod input;
@@ -44,5 +45,7 @@ fn main() {
         .add_plugins(heat::HeatPlugin)
         // Fabricator: input/output slots on the workbench for material combination.
         .add_plugins(fabricator::FabricatorPlugin)
+        // Combination: data-driven rules for material pair outcomes.
+        .add_plugins(combination::CombinationPlugin)
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
         .add_plugins(input::InputPlugin)
         // Materials: data-driven material definitions with observable/hidden properties.
         .add_plugins(materials::MaterialPlugin)
+
         // Interaction: raycast, pickup/place, crosshair UI.
         .add_plugins(interaction::InteractionPlugin)
         // Heat: burner on workbench, thermal exposure → property revelation.

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::scene::Shelf;
 
+use crate::scene::Shelf;
 pub(crate) struct MaterialPlugin;
 
 impl Plugin for MaterialPlugin {


### PR DESCRIPTION
## Summary
- Introduce `CombinationPlugin` that loads per-property combination rules from `assets/config/combinations.toml` at startup
- Rule types: Blend (weighted average), Max, Min, Catalyze (multiplier), Inert (waste)
- Pairs without explicit rules fall back to the configurable default blend
- 12 unit tests covering all rule types, TOML parsing, and pair-key symmetry

## Test plan
- [x] `cargo test` — 47 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: verify game launches and combination rules load from log output

Part of Story 3.2 — Combination Engine (#12)