### PR TITLE
feat: rule-driven combination engine replaces placeholder

### DIFF
--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,7 +4,6 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
-Look = "Mouse"
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,6 +4,7 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
+Look = "Mouse"
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -66,19 +66,6 @@ output_height = 0.02
 # How long the fabrication process takes (seconds).
 process_seconds = 2.5
 
-[heat_source]
-# Offset from workbench center — sits on the right side of the bench.
-offset_x = 0.55
-offset_z = 0.0
-radius = 0.1
-# Materials within this distance of the burner are "in the heat zone".
-zone_radius = 1.0
-light_intensity = 40_000.0
-# Seconds of continuous exposure for a material to fully react.
-reaction_seconds = 2.5
-# Seconds of continuous exposure before thermal_resistance is revealed.
-reveal_seconds = 3.5
-
 # Scene tuning — room geometry, lighting, and player spawn.
 # Edit these values instead of changing Rust constants.
 
@@ -107,31 +94,6 @@ spot_inner_angle = 0.28
 spot_outer_angle = 0.48
 spot_height = 2.75
 spot_target_y = 0.45
-
-[furniture]
-workbench_width = 2.0
-workbench_height = 0.88
-workbench_depth = 1.0
-workbench_x = 0.0
-workbench_z = 0.0
-shelf_width = 1.35
-shelf_thickness = 0.07
-shelf_depth = 0.55
-
-[[shelves]]
-x = -3.15
-z = 0.7
-y = 0.92
-
-[[shelves]]
-x = 3.15
-z = -0.7
-y = 0.92
-
-[[shelves]]
-x = 0.6
-z = -3.15
-y = 0.92
 
 [heat_source]
 # Offset from workbench center — sits on the right side of the bench.

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -114,7 +114,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 
 - Epics are GitHub Issues labeled `epic` with stories linked as sub-issues
 - Stories are GitHub Issues labeled `story` with full acceptance criteria, technical notes, dependency links, and implementation order in their body
-- Use the project board (Status: Backlog → Ready → In progress → Blocked → In review → Done) to track progress
+- Use the project board (Status: Backlog → Ready → In progress → In review → Done) to track progress
 - Priority (P0/P1/P2) and Size (XS/S/M/L/XL) fields are available on the board for sprint planning
 
 ### Issue Map
@@ -140,8 +140,6 @@ gh project item-list 1 --owner galamdring --format json
 Filter to items where `status == "Ready"` and `iteration` matches the current iteration. Read the issue body of each Ready story to find its _Implementation Order_ number. Pick the lowest-numbered story — that is the next story to implement.
 
 Skip a story if its dependency is not yet implementable — that is, the dependency is in Backlog, Ready, In progress, or Blocked. If the dependency is In Review or Done, proceed — the code exists on its branch and can be stacked on. The cascading block in Step 3a should have already moved downstream stories to Blocked when appropriate, but check defensively.
-
-In pipeline mode, this step is reached automatically after completing the previous story. The agent does not wait for human instruction between stories.
 
 #### Step 2 — Move to In progress
 
@@ -329,4 +327,4 @@ gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body
 - Manage task status and priorities through the GitHub Project board, not by editing docs
 - Move stories from Backlog to Ready during sprint/iteration planning — agents pick up Ready stories
 
-Last Updated: 2026-03-18
+Last Updated: 2026-03-19

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -221,6 +221,22 @@ When a reviewer requests changes on a lower branch in the stack:
 
 Graphite automatically rebases all branches above the changed one.
 
+#### In-review health check (story ↔ PR linkage)
+
+Run this check periodically (or when a story appears stuck in _In review_) to verify the close-link workflow is healthy:
+
+1. List project items and identify stories currently in _In review_:
+   - `gh project item-list 1 --owner galamdring --format json`
+2. For each story issue `#N`, find referencing PRs:
+   - `gh pr list --state all --search "Closes #N" --repo galamdring/apeiron-cipher`
+3. Validate each matching PR:
+   - `gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body`
+4. Triage results:
+   - No referencing PR found -> fix PR body (`Closes #N`) or open the missing PR.
+   - PR not targeting `main` -> correct base to `main`.
+   - Dependency not merged yet -> keep _In review_ and retain `Depends on #X`.
+   - PR merged but issue still open -> manually investigate issue automation and board sync.
+
 #### Step 5 — Done (automated, never agent-triggered)
 
 _An agent must NEVER move an issue to Done._ The Done transition happens automatically when the PR is merged and the issue is closed by GitHub. The project board has these automations enabled:
@@ -265,6 +281,12 @@ When asked to "check your open PRs for comments," the agent will:
 1. `gh pr list --state open` to find all open PRs
 2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
 3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
+
+If inline reply posting fails due to permissions or readonly execution (for example, HTTP 403/resource not accessible):
+
+1. Continue implementing fixes on the branch.
+2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
+3. Flag the PR as needing a human to post the prepared replies.
 
 ### Useful Commands
 
@@ -321,4 +343,4 @@ gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body
 - Manage task status and priorities through the GitHub Project board, not by editing docs
 - Move stories from Backlog to Ready during sprint/iteration planning — agents pick up Ready stories
 
-Last Updated: 2026-03-19
+Last Updated: 2026-03-20

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -221,22 +221,6 @@ When a reviewer requests changes on a lower branch in the stack:
 
 Graphite automatically rebases all branches above the changed one.
 
-#### In-review health check (story ↔ PR linkage)
-
-Run this check periodically (or when a story appears stuck in _In review_) to verify the close-link workflow is healthy:
-
-1. List project items and identify stories currently in _In review_:
-   - `gh project item-list 1 --owner galamdring --format json`
-2. For each story issue `#N`, find referencing PRs:
-   - `gh pr list --state all --search "Closes #N" --repo galamdring/apeiron-cipher`
-3. Validate each matching PR:
-   - `gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body`
-4. Triage results:
-   - No referencing PR found -> fix PR body (`Closes #N`) or open the missing PR.
-   - PR not targeting `main` -> correct base to `main`.
-   - Dependency not merged yet -> keep _In review_ and retain `Depends on #X`.
-   - PR merged but issue still open -> manually investigate issue automation and board sync.
-
 #### Step 5 — Done (automated, never agent-triggered)
 
 _An agent must NEVER move an issue to Done._ The Done transition happens automatically when the PR is merged and the issue is closed by GitHub. The project board has these automations enabled:
@@ -271,6 +255,16 @@ If inline reply posting fails due to permissions or readonly execution (for exam
 1. Continue implementing fixes on the branch.
 2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
 3. Flag the PR as needing a human to post the prepared replies.
+
+### PR Review Communication
+
+The agent replies to inline PR review comments directly on GitHub using the `gh` API. Because the CLI authenticates as the repo owner, all agent replies are prefixed with **[Indy]** to distinguish them from human comments.
+
+When asked to "check your open PRs for comments," the agent will:
+
+1. `gh pr list --state open` to find all open PRs
+2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
+3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
 
 ### Useful Commands
 

--- a/src/combination.rs
+++ b/src/combination.rs
@@ -39,8 +39,6 @@ pub(crate) enum PropertyRule {
 }
 
 impl PropertyRule {
-    /// Used by the fabricator in the next PR to compute output property values.
-    #[allow(dead_code)]
     pub(crate) fn apply(&self, a: f32, b: f32) -> f32 {
         match self {
             PropertyRule::Blend { weight_a, weight_b } => {
@@ -79,7 +77,7 @@ pub(crate) struct PairRuleSet {
 }
 
 impl PairRuleSet {
-    /// Constructor used by tests and future combination logic.
+    /// Used in tests and by future waste-detection visuals (e.g. grey-out output).
     #[allow(dead_code)]
     pub(crate) fn all_inert() -> Self {
         Self {
@@ -91,7 +89,7 @@ impl PairRuleSet {
         }
     }
 
-    /// Used by the fabricator to detect waste outputs.
+    /// Used in tests and by future waste-detection visuals.
     #[allow(dead_code)]
     pub(crate) fn is_inert(&self) -> bool {
         self.density == PropertyRule::Inert
@@ -140,8 +138,6 @@ fn pair_key(a: &str, b: &str) -> (String, String) {
 }
 
 /// Loaded combination rules, keyed by sorted material name pairs.
-/// Fields read by the fabricator in the next PR.
-#[allow(dead_code)]
 #[derive(Resource, Debug, Default)]
 pub(crate) struct CombinationRules {
     pub default_rule: PropertyRule,
@@ -150,8 +146,6 @@ pub(crate) struct CombinationRules {
 
 impl CombinationRules {
     /// Look up the rule set for a pair, falling back to the default for each property.
-    /// Used by the fabricator's tick_processing system in the next PR.
-    #[allow(dead_code)]
     pub(crate) fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
         let key = pair_key(name_a, name_b);
         if let Some(rules) = self.pair_rules.get(&key) {

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -13,6 +13,7 @@
 
 use bevy::prelude::*;
 
+use crate::combination::CombinationRules;
 use crate::materials::{GameMaterial, MaterialObject, MaterialProperty, PropertyVisibility};
 use crate::scene::{SceneConfig, Workbench};
 
@@ -167,12 +168,13 @@ fn process_activation(
 // ── Processing timer ────────────────────────────────────────────────────
 
 // Bevy systems that handle completion need access to commands, time, config,
-// state, both slot types, material data, and mesh/material assets.
+// state, both slot types, material data, combination rules, and mesh/material assets.
 #[allow(clippy::too_many_arguments)]
 fn tick_processing(
     mut commands: Commands,
     time: Res<Time>,
     cfg: Res<SceneConfig>,
+    rules: Res<CombinationRules>,
     mut state: ResMut<FabricatorState>,
     mut slots: Query<&mut InputSlot>,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
@@ -209,8 +211,8 @@ fn tick_processing(
         }
     }
 
-    // Placeholder combination: average all properties.
-    let output_mat = placeholder_combine(&input_mats[0], &input_mats[1]);
+    // Rule-driven combination.
+    let output_mat = rule_combine(&rules, &input_mats[0], &input_mats[1]);
 
     // Spawn the output material on the output slot.
     let Ok((output_gtf, mut out_slot)) = output_slot.single_mut() else {
@@ -272,16 +274,36 @@ fn apply_processing_visuals(
     }
 }
 
-// ── Placeholder combination (Story 3.2 replaces this) ──────────────────
+// ── Rule-driven combination ──────────────────────────────────────────────
 
-fn blend_prop(a: &MaterialProperty, b: &MaterialProperty) -> MaterialProperty {
-    MaterialProperty {
-        value: ((a.value + b.value) * 0.5).clamp(0.0, 1.0),
-        visibility: PropertyVisibility::Observable,
+use crate::combination::PropertyRule;
+
+/// Determines the output property visibility.
+/// If both inputs have been seen (Observable or Revealed), the output is Observable.
+/// Otherwise, the output is Hidden — the player must discover it again.
+fn output_visibility(a: PropertyVisibility, b: PropertyVisibility) -> PropertyVisibility {
+    match (a, b) {
+        (PropertyVisibility::Hidden, _) | (_, PropertyVisibility::Hidden) => {
+            PropertyVisibility::Hidden
+        }
+        _ => PropertyVisibility::Observable,
     }
 }
 
-fn placeholder_combine(a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
+fn apply_rule(rule: &PropertyRule, a: &MaterialProperty, b: &MaterialProperty) -> MaterialProperty {
+    MaterialProperty {
+        value: rule.apply(a.value, b.value),
+        visibility: output_visibility(a.visibility, b.visibility),
+    }
+}
+
+pub(crate) fn rule_combine(
+    rules: &CombinationRules,
+    a: &GameMaterial,
+    b: &GameMaterial,
+) -> GameMaterial {
+    let pair_rules = rules.rules_for(&a.name, &b.name);
+
     let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);
     let name = format!(
         "{}-{}",
@@ -299,11 +321,15 @@ fn placeholder_combine(a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
         name,
         seed: combined_seed,
         color,
-        density: blend_prop(&a.density, &b.density),
-        thermal_resistance: blend_prop(&a.thermal_resistance, &b.thermal_resistance),
-        reactivity: blend_prop(&a.reactivity, &b.reactivity),
-        conductivity: blend_prop(&a.conductivity, &b.conductivity),
-        toxicity: blend_prop(&a.toxicity, &b.toxicity),
+        density: apply_rule(&pair_rules.density, &a.density, &b.density),
+        thermal_resistance: apply_rule(
+            &pair_rules.thermal_resistance,
+            &a.thermal_resistance,
+            &b.thermal_resistance,
+        ),
+        reactivity: apply_rule(&pair_rules.reactivity, &a.reactivity, &b.reactivity),
+        conductivity: apply_rule(&pair_rules.conductivity, &a.conductivity, &b.conductivity),
+        toxicity: apply_rule(&pair_rules.toxicity, &a.toxicity, &b.toxicity),
     }
 }
 
@@ -312,6 +338,7 @@ fn placeholder_combine(a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::combination::PairRuleSet;
 
     fn test_material(name: &str, seed: u64, density: f32) -> GameMaterial {
         let prop = |v: f32| MaterialProperty {
@@ -333,11 +360,16 @@ mod tests {
         }
     }
 
+    fn default_rules() -> CombinationRules {
+        CombinationRules::default()
+    }
+
     #[test]
-    fn placeholder_combine_averages_properties() {
+    fn rule_combine_default_averages_properties() {
+        let rules = default_rules();
         let a = test_material("Ferrite", 100, 0.8);
         let b = test_material("Silite", 200, 0.2);
-        let result = placeholder_combine(&a, &b);
+        let result = rule_combine(&rules, &a, &b);
 
         assert!((result.density.value - 0.5).abs() < f32::EPSILON);
         assert!((result.thermal_resistance.value - 0.4).abs() < f32::EPSILON);
@@ -345,46 +377,160 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_combine_name_from_inputs() {
+    fn rule_combine_name_from_inputs() {
+        let rules = default_rules();
         let a = test_material("Ferrite", 100, 0.5);
         let b = test_material("Silite", 200, 0.5);
-        let result = placeholder_combine(&a, &b);
+        let result = rule_combine(&rules, &a, &b);
         assert_eq!(result.name, "Ferr-Sili");
     }
 
     #[test]
-    fn placeholder_combine_deterministic() {
+    fn rule_combine_deterministic() {
+        let rules = default_rules();
         let a = test_material("Ferrite", 100, 0.5);
         let b = test_material("Silite", 200, 0.5);
-        let r1 = placeholder_combine(&a, &b);
-        let r2 = placeholder_combine(&a, &b);
+        let r1 = rule_combine(&rules, &a, &b);
+        let r2 = rule_combine(&rules, &a, &b);
         assert_eq!(r1.seed, r2.seed);
         assert!((r1.density.value - r2.density.value).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn placeholder_combine_output_properties_are_observable() {
-        let a = test_material("Ferrite", 100, 0.5);
-        let b = test_material("Silite", 200, 0.5);
-        let result = placeholder_combine(&a, &b);
-        assert_eq!(result.density.visibility, PropertyVisibility::Observable);
-        assert_eq!(
-            result.thermal_resistance.visibility,
-            PropertyVisibility::Observable
+    fn observable_inputs_produce_observable_output() {
+        let a = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Observable,
+        };
+        let b = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Observable,
+        };
+        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        assert_eq!(result.visibility, PropertyVisibility::Observable);
+    }
+
+    #[test]
+    fn hidden_input_produces_hidden_output() {
+        let a = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Observable,
+        };
+        let b = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Hidden,
+        };
+        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        assert_eq!(result.visibility, PropertyVisibility::Hidden);
+    }
+
+    #[test]
+    fn revealed_inputs_produce_observable_output() {
+        let a = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Revealed,
+        };
+        let b = MaterialProperty {
+            value: 0.5,
+            visibility: PropertyVisibility::Revealed,
+        };
+        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        assert_eq!(result.visibility, PropertyVisibility::Observable);
+    }
+
+    #[test]
+    fn catalyze_rule_exceeds_both_inputs() {
+        let rule = PropertyRule::Catalyze { multiplier: 1.5 };
+        let a = MaterialProperty {
+            value: 0.4,
+            visibility: PropertyVisibility::Observable,
+        };
+        let b = MaterialProperty {
+            value: 0.6,
+            visibility: PropertyVisibility::Observable,
+        };
+        let result = apply_rule(&rule, &a, &b);
+        assert!(
+            result.value > a.value && result.value > b.value,
+            "catalyze should exceed both inputs: got {}",
+            result.value
         );
     }
 
     #[test]
-    fn blend_prop_clamps_to_unit() {
+    fn inert_pair_produces_waste() {
+        let mut rules = default_rules();
+        rules
+            .pair_rules
+            .insert(("Alpha".into(), "Beta".into()), PairRuleSet::all_inert());
+
+        let a = test_material("Alpha", 1, 0.8);
+        let b = test_material("Beta", 2, 0.9);
+        let result = rule_combine(&rules, &a, &b);
+
+        assert!(
+            (result.density.value - 0.1).abs() < f32::EPSILON,
+            "inert density: {}",
+            result.density.value
+        );
+        assert!(
+            (result.thermal_resistance.value - 0.1).abs() < f32::EPSILON,
+            "inert thermal_resistance: {}",
+            result.thermal_resistance.value
+        );
+    }
+
+    #[test]
+    fn max_rule_picks_higher_value() {
+        let rule = PropertyRule::Max;
         let a = MaterialProperty {
-            value: 0.9,
-            visibility: PropertyVisibility::Hidden,
+            value: 0.3,
+            visibility: PropertyVisibility::Observable,
         };
         let b = MaterialProperty {
-            value: 0.95,
-            visibility: PropertyVisibility::Hidden,
+            value: 0.7,
+            visibility: PropertyVisibility::Observable,
         };
-        let result = blend_prop(&a, &b);
-        assert!(result.value <= 1.0);
+        let result = apply_rule(&rule, &a, &b);
+        assert!((result.value - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn min_rule_picks_lower_value() {
+        let rule = PropertyRule::Min;
+        let a = MaterialProperty {
+            value: 0.3,
+            visibility: PropertyVisibility::Observable,
+        };
+        let b = MaterialProperty {
+            value: 0.7,
+            visibility: PropertyVisibility::Observable,
+        };
+        let result = apply_rule(&rule, &a, &b);
+        assert!((result.value - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn pair_order_independent() {
+        let mut rules = default_rules();
+        rules.pair_rules.insert(
+            ("Alpha".into(), "Beta".into()),
+            PairRuleSet {
+                density: PropertyRule::Max,
+                thermal_resistance: PropertyRule::Min,
+                reactivity: PropertyRule::Catalyze { multiplier: 1.3 },
+                conductivity: PropertyRule::default(),
+                toxicity: PropertyRule::Inert,
+            },
+        );
+
+        let a = test_material("Alpha", 1, 0.8);
+        let b = test_material("Beta", 2, 0.3);
+        let r1 = rule_combine(&rules, &a, &b);
+        let r2 = rule_combine(&rules, &b, &a);
+
+        assert!((r1.density.value - r2.density.value).abs() < f32::EPSILON);
+        assert!((r1.thermal_resistance.value - r2.thermal_resistance.value).abs() < f32::EPSILON);
+        assert!((r1.toxicity.value - r2.toxicity.value).abs() < f32::EPSILON);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,7 +15,6 @@
 //! settings UI modifies bindings, it updates the resource; a reactive system
 //! rebuilds the `InputMap` and the config is saved back to disk.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -100,12 +99,8 @@ fn default_sensitivity() -> f32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingsConfig {
-    /// DualAxis movement keys: up/down/left/right.
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
-    /// Mouse look — present for completeness but always "Mouse" in practice.
-    #[serde(default = "default_look", rename = "Look")]
-    pub look: String,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
@@ -124,7 +119,6 @@ impl Default for BindingsConfig {
     fn default() -> Self {
         Self {
             movement: MoveBindings::default(),
-            look: default_look(),
             interact: default_interact(),
             examine: default_examine(),
             place: default_place(),
@@ -170,9 +164,6 @@ fn default_left() -> String {
 fn default_right() -> String {
     "D".into()
 }
-fn default_look() -> String {
-    "Mouse".into()
-}
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
 }
@@ -192,63 +183,70 @@ fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
 
-// ── Key name → KeyCode mapping ──────────────────────────────────────────
+// ── Input name parsing ──────────────────────────────────────────────────
 
 /// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
-/// Returns `None` for unrecognised names, which are logged as warnings.
 fn parse_key(name: &str) -> Option<KeyCode> {
-    // Lazily-built lookup table. Covers the keys players are likely to rebind.
-    // Extend as needed — this is the single place key names are resolved.
-    let map: HashMap<&str, KeyCode> = HashMap::from([
-        ("A", KeyCode::KeyA),
-        ("B", KeyCode::KeyB),
-        ("C", KeyCode::KeyC),
-        ("D", KeyCode::KeyD),
-        ("E", KeyCode::KeyE),
-        ("F", KeyCode::KeyF),
-        ("G", KeyCode::KeyG),
-        ("H", KeyCode::KeyH),
-        ("I", KeyCode::KeyI),
-        ("J", KeyCode::KeyJ),
-        ("K", KeyCode::KeyK),
-        ("L", KeyCode::KeyL),
-        ("M", KeyCode::KeyM),
-        ("N", KeyCode::KeyN),
-        ("O", KeyCode::KeyO),
-        ("P", KeyCode::KeyP),
-        ("Q", KeyCode::KeyQ),
-        ("R", KeyCode::KeyR),
-        ("S", KeyCode::KeyS),
-        ("T", KeyCode::KeyT),
-        ("U", KeyCode::KeyU),
-        ("V", KeyCode::KeyV),
-        ("W", KeyCode::KeyW),
-        ("X", KeyCode::KeyX),
-        ("Y", KeyCode::KeyY),
-        ("Z", KeyCode::KeyZ),
-        ("Space", KeyCode::Space),
-        ("Escape", KeyCode::Escape),
-        ("Tab", KeyCode::Tab),
-        ("ShiftLeft", KeyCode::ShiftLeft),
-        ("ShiftRight", KeyCode::ShiftRight),
-        ("ControlLeft", KeyCode::ControlLeft),
-        ("ControlRight", KeyCode::ControlRight),
-        ("Up", KeyCode::ArrowUp),
-        ("Down", KeyCode::ArrowDown),
-        ("Left", KeyCode::ArrowLeft),
-        ("Right", KeyCode::ArrowRight),
-        ("1", KeyCode::Digit1),
-        ("2", KeyCode::Digit2),
-        ("3", KeyCode::Digit3),
-        ("4", KeyCode::Digit4),
-        ("5", KeyCode::Digit5),
-        ("6", KeyCode::Digit6),
-        ("7", KeyCode::Digit7),
-        ("8", KeyCode::Digit8),
-        ("9", KeyCode::Digit9),
-        ("0", KeyCode::Digit0),
-    ]);
-    map.get(name).copied()
+    match name {
+        "A" => Some(KeyCode::KeyA),
+        "B" => Some(KeyCode::KeyB),
+        "C" => Some(KeyCode::KeyC),
+        "D" => Some(KeyCode::KeyD),
+        "E" => Some(KeyCode::KeyE),
+        "F" => Some(KeyCode::KeyF),
+        "G" => Some(KeyCode::KeyG),
+        "H" => Some(KeyCode::KeyH),
+        "I" => Some(KeyCode::KeyI),
+        "J" => Some(KeyCode::KeyJ),
+        "K" => Some(KeyCode::KeyK),
+        "L" => Some(KeyCode::KeyL),
+        "M" => Some(KeyCode::KeyM),
+        "N" => Some(KeyCode::KeyN),
+        "O" => Some(KeyCode::KeyO),
+        "P" => Some(KeyCode::KeyP),
+        "Q" => Some(KeyCode::KeyQ),
+        "R" => Some(KeyCode::KeyR),
+        "S" => Some(KeyCode::KeyS),
+        "T" => Some(KeyCode::KeyT),
+        "U" => Some(KeyCode::KeyU),
+        "V" => Some(KeyCode::KeyV),
+        "W" => Some(KeyCode::KeyW),
+        "X" => Some(KeyCode::KeyX),
+        "Y" => Some(KeyCode::KeyY),
+        "Z" => Some(KeyCode::KeyZ),
+        "Space" => Some(KeyCode::Space),
+        "Escape" => Some(KeyCode::Escape),
+        "Tab" => Some(KeyCode::Tab),
+        "ShiftLeft" => Some(KeyCode::ShiftLeft),
+        "ShiftRight" => Some(KeyCode::ShiftRight),
+        "ControlLeft" => Some(KeyCode::ControlLeft),
+        "ControlRight" => Some(KeyCode::ControlRight),
+        "Up" => Some(KeyCode::ArrowUp),
+        "Down" => Some(KeyCode::ArrowDown),
+        "Left" => Some(KeyCode::ArrowLeft),
+        "Right" => Some(KeyCode::ArrowRight),
+        "1" => Some(KeyCode::Digit1),
+        "2" => Some(KeyCode::Digit2),
+        "3" => Some(KeyCode::Digit3),
+        "4" => Some(KeyCode::Digit4),
+        "5" => Some(KeyCode::Digit5),
+        "6" => Some(KeyCode::Digit6),
+        "7" => Some(KeyCode::Digit7),
+        "8" => Some(KeyCode::Digit8),
+        "9" => Some(KeyCode::Digit9),
+        "0" => Some(KeyCode::Digit0),
+        _ => None,
+    }
+}
+
+/// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
+fn parse_mouse_button(name: &str) -> Option<MouseButton> {
+    match name {
+        "MouseLeft" => Some(MouseButton::Left),
+        "MouseRight" => Some(MouseButton::Right),
+        "MouseMiddle" => Some(MouseButton::Middle),
+        _ => None,
+    }
 }
 
 /// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
@@ -318,13 +316,8 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
     let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
     let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
-
-    let mut input_map = InputMap::default();
-
-    // Movement: WASD as a virtual DPad producing a Vec2.
     input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
 
-    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
     input_map.insert_dual_axis(
         InputAction::Look,
         MouseMove::default()
@@ -332,31 +325,26 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
             .sensitivity_y(config.mouse.sensitivity_y),
     );
 
-    // Button actions — bind each key from the config arrays.
-    insert_button_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
-    insert_button_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
-    insert_button_bindings(&mut input_map, InputAction::Place, &bindings.place);
-    insert_button_bindings(
+    insert_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
+    insert_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
+    insert_bindings(&mut input_map, InputAction::Place, &bindings.place);
+    insert_bindings(
         &mut input_map,
         InputAction::ToggleJournal,
         &bindings.toggle_journal,
     );
-    insert_button_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
-    insert_button_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+    insert_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
+    insert_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
 
     input_map
 }
 
-fn insert_button_bindings(
-    input_map: &mut InputMap<InputAction>,
-    action: InputAction,
-    key_names: &[String],
-) {
-    for name in key_names {
+fn insert_bindings(input_map: &mut InputMap<InputAction>, action: InputAction, names: &[String]) {
+    for name in names {
         if let Some(key) = parse_key(name) {
             input_map.insert(action, key);
-        } else {
-            warn!("Unknown key name '{name}' for action {action:?}, skipping");
+        } else if let Some(button) = parse_mouse_button(name) {
+            input_map.insert(action, button);
         }
     }
 }
@@ -371,13 +359,12 @@ mod tests {
     fn default_config_builds_valid_input_map() {
         let config = InputConfig::default();
         let input_map = build_input_map(&config);
-        // Verify button actions have at least one binding.
         assert!(
-            input_map.get(&InputAction::Interact).is_some(),
+            input_map.get_buttonlike(&InputAction::Interact).is_some(),
             "Interact should have bindings"
         );
         assert!(
-            input_map.get(&InputAction::Pause).is_some(),
+            input_map.get_buttonlike(&InputAction::Pause).is_some(),
             "Pause should have bindings"
         );
     }
@@ -392,6 +379,14 @@ mod tests {
     #[test]
     fn parse_key_returns_none_for_unknown() {
         assert_eq!(parse_key("BananaKey"), None);
+    }
+
+    #[test]
+    fn parse_mouse_button_recognises_buttons() {
+        assert_eq!(parse_mouse_button("MouseLeft"), Some(MouseButton::Left));
+        assert_eq!(parse_mouse_button("MouseRight"), Some(MouseButton::Right));
+        assert_eq!(parse_mouse_button("MouseMiddle"), Some(MouseButton::Middle));
+        assert_eq!(parse_mouse_button("MouseExtra"), None);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,6 +15,7 @@
 //! settings UI modifies bindings, it updates the resource; a reactive system
 //! rebuilds the `InputMap` and the config is saved back to disk.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -99,8 +100,12 @@ fn default_sensitivity() -> f32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingsConfig {
+    /// DualAxis movement keys: up/down/left/right.
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
+    /// Mouse look — present for completeness but always "Mouse" in practice.
+    #[serde(default = "default_look", rename = "Look")]
+    pub look: String,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
@@ -119,6 +124,7 @@ impl Default for BindingsConfig {
     fn default() -> Self {
         Self {
             movement: MoveBindings::default(),
+            look: default_look(),
             interact: default_interact(),
             examine: default_examine(),
             place: default_place(),
@@ -164,6 +170,9 @@ fn default_left() -> String {
 fn default_right() -> String {
     "D".into()
 }
+fn default_look() -> String {
+    "Mouse".into()
+}
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
 }
@@ -183,60 +192,63 @@ fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
 
-// ── Input name parsing ──────────────────────────────────────────────────
+// ── Key name → KeyCode mapping ──────────────────────────────────────────
 
 /// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
+/// Returns `None` for unrecognised names, which are logged as warnings.
 fn parse_key(name: &str) -> Option<KeyCode> {
-    match name {
-        "A" => Some(KeyCode::KeyA),
-        "B" => Some(KeyCode::KeyB),
-        "C" => Some(KeyCode::KeyC),
-        "D" => Some(KeyCode::KeyD),
-        "E" => Some(KeyCode::KeyE),
-        "F" => Some(KeyCode::KeyF),
-        "G" => Some(KeyCode::KeyG),
-        "H" => Some(KeyCode::KeyH),
-        "I" => Some(KeyCode::KeyI),
-        "J" => Some(KeyCode::KeyJ),
-        "K" => Some(KeyCode::KeyK),
-        "L" => Some(KeyCode::KeyL),
-        "M" => Some(KeyCode::KeyM),
-        "N" => Some(KeyCode::KeyN),
-        "O" => Some(KeyCode::KeyO),
-        "P" => Some(KeyCode::KeyP),
-        "Q" => Some(KeyCode::KeyQ),
-        "R" => Some(KeyCode::KeyR),
-        "S" => Some(KeyCode::KeyS),
-        "T" => Some(KeyCode::KeyT),
-        "U" => Some(KeyCode::KeyU),
-        "V" => Some(KeyCode::KeyV),
-        "W" => Some(KeyCode::KeyW),
-        "X" => Some(KeyCode::KeyX),
-        "Y" => Some(KeyCode::KeyY),
-        "Z" => Some(KeyCode::KeyZ),
-        "Space" => Some(KeyCode::Space),
-        "Escape" => Some(KeyCode::Escape),
-        "Tab" => Some(KeyCode::Tab),
-        "ShiftLeft" => Some(KeyCode::ShiftLeft),
-        "ShiftRight" => Some(KeyCode::ShiftRight),
-        "ControlLeft" => Some(KeyCode::ControlLeft),
-        "ControlRight" => Some(KeyCode::ControlRight),
-        "Up" => Some(KeyCode::ArrowUp),
-        "Down" => Some(KeyCode::ArrowDown),
-        "Left" => Some(KeyCode::ArrowLeft),
-        "Right" => Some(KeyCode::ArrowRight),
-        "1" => Some(KeyCode::Digit1),
-        "2" => Some(KeyCode::Digit2),
-        "3" => Some(KeyCode::Digit3),
-        "4" => Some(KeyCode::Digit4),
-        "5" => Some(KeyCode::Digit5),
-        "6" => Some(KeyCode::Digit6),
-        "7" => Some(KeyCode::Digit7),
-        "8" => Some(KeyCode::Digit8),
-        "9" => Some(KeyCode::Digit9),
-        "0" => Some(KeyCode::Digit0),
-        _ => None,
-    }
+    // Lazily-built lookup table. Covers the keys players are likely to rebind.
+    // Extend as needed — this is the single place key names are resolved.
+    let map: HashMap<&str, KeyCode> = HashMap::from([
+        ("A", KeyCode::KeyA),
+        ("B", KeyCode::KeyB),
+        ("C", KeyCode::KeyC),
+        ("D", KeyCode::KeyD),
+        ("E", KeyCode::KeyE),
+        ("F", KeyCode::KeyF),
+        ("G", KeyCode::KeyG),
+        ("H", KeyCode::KeyH),
+        ("I", KeyCode::KeyI),
+        ("J", KeyCode::KeyJ),
+        ("K", KeyCode::KeyK),
+        ("L", KeyCode::KeyL),
+        ("M", KeyCode::KeyM),
+        ("N", KeyCode::KeyN),
+        ("O", KeyCode::KeyO),
+        ("P", KeyCode::KeyP),
+        ("Q", KeyCode::KeyQ),
+        ("R", KeyCode::KeyR),
+        ("S", KeyCode::KeyS),
+        ("T", KeyCode::KeyT),
+        ("U", KeyCode::KeyU),
+        ("V", KeyCode::KeyV),
+        ("W", KeyCode::KeyW),
+        ("X", KeyCode::KeyX),
+        ("Y", KeyCode::KeyY),
+        ("Z", KeyCode::KeyZ),
+        ("Space", KeyCode::Space),
+        ("Escape", KeyCode::Escape),
+        ("Tab", KeyCode::Tab),
+        ("ShiftLeft", KeyCode::ShiftLeft),
+        ("ShiftRight", KeyCode::ShiftRight),
+        ("ControlLeft", KeyCode::ControlLeft),
+        ("ControlRight", KeyCode::ControlRight),
+        ("Up", KeyCode::ArrowUp),
+        ("Down", KeyCode::ArrowDown),
+        ("Left", KeyCode::ArrowLeft),
+        ("Right", KeyCode::ArrowRight),
+        ("1", KeyCode::Digit1),
+        ("2", KeyCode::Digit2),
+        ("3", KeyCode::Digit3),
+        ("4", KeyCode::Digit4),
+        ("5", KeyCode::Digit5),
+        ("6", KeyCode::Digit6),
+        ("7", KeyCode::Digit7),
+        ("8", KeyCode::Digit8),
+        ("9", KeyCode::Digit9),
+        ("0", KeyCode::Digit0),
+    ]);
+    map.get(name).copied()
 }
 
 /// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
@@ -248,6 +260,7 @@ fn parse_mouse_button(name: &str) -> Option<MouseButton> {
         _ => None,
     }
 }
+
 
 // ── Systems ─────────────────────────────────────────────────────────────
 
@@ -305,8 +318,13 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
     let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
     let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
+
+    let mut input_map = InputMap::default();
+
+    // Movement: WASD as a virtual DPad producing a Vec2.
     input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
 
+    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
     input_map.insert_dual_axis(
         InputAction::Look,
         MouseMove::default()
@@ -314,26 +332,31 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
             .sensitivity_y(config.mouse.sensitivity_y),
     );
 
-    insert_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
-    insert_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
-    insert_bindings(&mut input_map, InputAction::Place, &bindings.place);
-    insert_bindings(
+    // Button actions — bind each key from the config arrays.
+    insert_button_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
+    insert_button_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
+    insert_button_bindings(&mut input_map, InputAction::Place, &bindings.place);
+    insert_button_bindings(
         &mut input_map,
         InputAction::ToggleJournal,
         &bindings.toggle_journal,
     );
-    insert_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
-    insert_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+    insert_button_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
+    insert_button_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
 
     input_map
 }
 
-fn insert_bindings(input_map: &mut InputMap<InputAction>, action: InputAction, names: &[String]) {
-    for name in names {
+fn insert_button_bindings(
+    input_map: &mut InputMap<InputAction>,
+    action: InputAction,
+    key_names: &[String],
+) {
+    for name in key_names {
         if let Some(key) = parse_key(name) {
             input_map.insert(action, key);
-        } else if let Some(button) = parse_mouse_button(name) {
-            input_map.insert(action, button);
+        } else {
+            warn!("Unknown key name '{name}' for action {action:?}, skipping");
         }
     }
 }
@@ -348,12 +371,13 @@ mod tests {
     fn default_config_builds_valid_input_map() {
         let config = InputConfig::default();
         let input_map = build_input_map(&config);
+        // Verify button actions have at least one binding.
         assert!(
-            input_map.get_buttonlike(&InputAction::Interact).is_some(),
+            input_map.get(&InputAction::Interact).is_some(),
             "Interact should have bindings"
         );
         assert!(
-            input_map.get_buttonlike(&InputAction::Pause).is_some(),
+            input_map.get(&InputAction::Pause).is_some(),
             "Pause should have bindings"
         );
     }
@@ -368,14 +392,6 @@ mod tests {
     #[test]
     fn parse_key_returns_none_for_unknown() {
         assert_eq!(parse_key("BananaKey"), None);
-    }
-
-    #[test]
-    fn parse_mouse_button_recognises_buttons() {
-        assert_eq!(parse_mouse_button("MouseLeft"), Some(MouseButton::Left));
-        assert_eq!(parse_mouse_button("MouseRight"), Some(MouseButton::Right));
-        assert_eq!(parse_mouse_button("MouseMiddle"), Some(MouseButton::Middle));
-        assert_eq!(parse_mouse_button("MouseExtra"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace `placeholder_combine` with `rule_combine` that uses `CombinationRules` resource
- Per-property rules (Blend/Max/Min/Catalyze/Inert) now drive output computation
- Output visibility derived from input visibility (both seen → Observable, else Hidden)
- 11 new/updated tests covering catalytic, inert, max, min, visibility, and pair-order independence

## Test plan
- [x] `cargo test` — 53 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: combine Ferrite + Phosphite — thermal_resistance should exceed both inputs (catalyze rule)
- [ ] Manual: combine Sulfurite + Osmium — all properties should drop to 0.1 (inert rule)

Part of Story 3.2 — Combination Engine (#12)