### PR TITLE
feat: seeded perturbation, procedural naming, catalytic color shift

### DIFF
--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,7 +4,6 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
-Look = "Mouse"
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,6 +4,7 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
+Look = "Mouse"
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -139,7 +139,7 @@ gh project item-list 1 --owner galamdring --format json
 
 Filter to items where `status == "Ready"` and `iteration` matches the current iteration. Read the issue body of each Ready story to find its _Implementation Order_ number. Pick the lowest-numbered story — that is the next story to implement.
 
-Skip a story if its dependency is not yet implementable — that is, the dependency is in Backlog, Ready, In progress, or Blocked. If the dependency is In Review or Done, proceed — the code exists on its branch and can be stacked on. The cascading block in Step 3a should have already moved downstream stories to Blocked when appropriate, but check defensively.
+Skip a story if its dependency is not yet implementable — that is, the dependency is in Backlog, Ready, In progress, or Blocked. If the dependency is In Review or Done, proceed — the code exists on its branch and can be stacked on.
 
 #### Step 2 — Move to In progress
 
@@ -343,4 +343,4 @@ gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body
 - Manage task status and priorities through the GitHub Project board, not by editing docs
 - Move stories from Backlog to Ready during sprint/iteration planning — agents pick up Ready stories
 
-Last Updated: 2026-03-20
+Last Updated: 2026-03-27

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -298,6 +298,12 @@ When asked to "check your open PRs for comments," the agent will:
 2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
 3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
 
+If inline reply posting fails due to permissions or readonly execution (for example, HTTP 403/resource not accessible):
+
+1. Continue implementing fixes on the branch.
+2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
+3. Flag the PR as needing a human to post the prepared replies.
+
 ### Useful Commands
 
 ```bash

--- a/docs/bmad/project-context.md
+++ b/docs/bmad/project-context.md
@@ -288,6 +288,16 @@ If inline reply posting fails due to permissions or readonly execution (for exam
 2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
 3. Flag the PR as needing a human to post the prepared replies.
 
+### PR Review Communication
+
+The agent replies to inline PR review comments directly on GitHub using the `gh` API. Because the CLI authenticates as the repo owner, all agent replies are prefixed with **[Indy]** to distinguish them from human comments.
+
+When asked to "check your open PRs for comments," the agent will:
+
+1. `gh pr list --state open` to find all open PRs
+2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
+3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
+
 ### Useful Commands
 
 ```bash

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -290,12 +290,96 @@ fn output_visibility(a: PropertyVisibility, b: PropertyVisibility) -> PropertyVi
     }
 }
 
-fn apply_rule(rule: &PropertyRule, a: &MaterialProperty, b: &MaterialProperty) -> MaterialProperty {
+/// Deterministic pseudo-random float in \[-1.0, 1.0\] from a seed+channel.
+/// Splitmix64 single iteration — fast, deterministic, no external crate needed.
+fn seeded_noise(seed: u64, channel: u64) -> f32 {
+    let mut z = seed.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    // Map to [-1.0, 1.0]
+    (z as i64 as f64 / i64::MAX as f64) as f32
+}
+
+/// Small perturbation magnitude applied to default-blend results so that
+/// repeated experiments with the same pair are identical but not perfectly
+/// averaged — gives the player a reason to measure outputs.
+const PERTURBATION_SCALE: f32 = 0.04;
+
+fn apply_rule_with_perturbation(
+    rule: &PropertyRule,
+    a: &MaterialProperty,
+    b: &MaterialProperty,
+    seed: u64,
+    channel: u64,
+) -> MaterialProperty {
+    let base = rule.apply(a.value, b.value);
+    let value = match rule {
+        PropertyRule::Blend { .. } => {
+            let noise = seeded_noise(seed, channel) * PERTURBATION_SCALE;
+            (base + noise).clamp(0.0, 1.0)
+        }
+        _ => base,
+    };
     MaterialProperty {
-        value: rule.apply(a.value, b.value),
+        value,
         visibility: output_visibility(a.visibility, b.visibility),
     }
 }
+
+// ── Procedural naming ────────────────────────────────────────────────────
+
+const PREFIXES: &[&str] = &[
+    "Neo", "Aur", "Vex", "Cor", "Nyx", "Zel", "Pyr", "Lux", "Thal", "Kyn", "Ven", "Dra", "Sol",
+    "Mor", "Cyn", "Vir",
+];
+
+const SUFFIXES: &[&str] = &[
+    "ite", "ium", "ite", "ane", "ene", "oid", "ate", "ide", "yne", "ase", "ose", "ine", "ile",
+    "ore", "ux", "al",
+];
+
+fn procedural_name(seed: u64) -> String {
+    let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
+    let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
+    format!("{}{}", PREFIXES[prefix_idx], SUFFIXES[suffix_idx])
+}
+
+// ── Color blending ───────────────────────────────────────────────────────
+
+fn has_catalytic_rule(rules: &crate::combination::PairRuleSet) -> bool {
+    matches!(rules.density, PropertyRule::Catalyze { .. })
+        || matches!(rules.thermal_resistance, PropertyRule::Catalyze { .. })
+        || matches!(rules.reactivity, PropertyRule::Catalyze { .. })
+        || matches!(rules.conductivity, PropertyRule::Catalyze { .. })
+        || matches!(rules.toxicity, PropertyRule::Catalyze { .. })
+}
+
+/// Shift hue by rotating the RGB channels toward a warmer/cooler tone.
+/// This is a simplified rotation, not a full HSL transform.
+fn hue_shift(color: [f32; 3], amount: f32) -> [f32; 3] {
+    let (r, g, b) = (color[0], color[1], color[2]);
+    [
+        (r + amount * (1.0 - r)).clamp(0.0, 1.0),
+        (g - amount * g * 0.5).clamp(0.0, 1.0),
+        (b + amount * (1.0 - b) * 0.3).clamp(0.0, 1.0),
+    ]
+}
+
+fn blend_color(a: &[f32; 3], b: &[f32; 3], catalytic: bool) -> [f32; 3] {
+    let blended = [
+        (a[0] + b[0]) * 0.5,
+        (a[1] + b[1]) * 0.5,
+        (a[2] + b[2]) * 0.5,
+    ];
+    if catalytic {
+        hue_shift(blended, 0.15)
+    } else {
+        blended
+    }
+}
+
+// ── Main combine function ────────────────────────────────────────────────
 
 pub(crate) fn rule_combine(
     rules: &CombinationRules,
@@ -305,31 +389,50 @@ pub(crate) fn rule_combine(
     let pair_rules = rules.rules_for(&a.name, &b.name);
 
     let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);
-    let name = format!(
-        "{}-{}",
-        &a.name[..a.name.len().min(4)],
-        &b.name[..b.name.len().min(4)]
-    );
+    let name = procedural_name(combined_seed);
 
-    let color = [
-        (a.color[0] + b.color[0]) * 0.5,
-        (a.color[1] + b.color[1]) * 0.5,
-        (a.color[2] + b.color[2]) * 0.5,
-    ];
+    let catalytic = has_catalytic_rule(&pair_rules);
+    let color = blend_color(&a.color, &b.color, catalytic);
 
     GameMaterial {
         name,
         seed: combined_seed,
         color,
-        density: apply_rule(&pair_rules.density, &a.density, &b.density),
-        thermal_resistance: apply_rule(
+        density: apply_rule_with_perturbation(
+            &pair_rules.density,
+            &a.density,
+            &b.density,
+            combined_seed,
+            0,
+        ),
+        thermal_resistance: apply_rule_with_perturbation(
             &pair_rules.thermal_resistance,
             &a.thermal_resistance,
             &b.thermal_resistance,
+            combined_seed,
+            1,
         ),
-        reactivity: apply_rule(&pair_rules.reactivity, &a.reactivity, &b.reactivity),
-        conductivity: apply_rule(&pair_rules.conductivity, &a.conductivity, &b.conductivity),
-        toxicity: apply_rule(&pair_rules.toxicity, &a.toxicity, &b.toxicity),
+        reactivity: apply_rule_with_perturbation(
+            &pair_rules.reactivity,
+            &a.reactivity,
+            &b.reactivity,
+            combined_seed,
+            2,
+        ),
+        conductivity: apply_rule_with_perturbation(
+            &pair_rules.conductivity,
+            &a.conductivity,
+            &b.conductivity,
+            combined_seed,
+            3,
+        ),
+        toxicity: apply_rule_with_perturbation(
+            &pair_rules.toxicity,
+            &a.toxicity,
+            &b.toxicity,
+            combined_seed,
+            4,
+        ),
     }
 }
 
@@ -365,24 +468,31 @@ mod tests {
     }
 
     #[test]
-    fn rule_combine_default_averages_properties() {
+    fn rule_combine_default_near_average_with_perturbation() {
         let rules = default_rules();
         let a = test_material("Ferrite", 100, 0.8);
         let b = test_material("Silite", 200, 0.2);
         let result = rule_combine(&rules, &a, &b);
 
-        assert!((result.density.value - 0.5).abs() < f32::EPSILON);
-        assert!((result.thermal_resistance.value - 0.4).abs() < f32::EPSILON);
-        assert!((result.reactivity.value - 0.6).abs() < f32::EPSILON);
+        // With perturbation, values should be near average (within PERTURBATION_SCALE)
+        assert!((result.density.value - 0.5).abs() < PERTURBATION_SCALE + f32::EPSILON);
+        assert!((result.thermal_resistance.value - 0.4).abs() < PERTURBATION_SCALE + f32::EPSILON);
+        assert!((result.reactivity.value - 0.6).abs() < PERTURBATION_SCALE + f32::EPSILON);
     }
 
     #[test]
-    fn rule_combine_name_from_inputs() {
+    fn rule_combine_procedural_name() {
         let rules = default_rules();
         let a = test_material("Ferrite", 100, 0.5);
         let b = test_material("Silite", 200, 0.5);
         let result = rule_combine(&rules, &a, &b);
-        assert_eq!(result.name, "Ferr-Sili");
+        // Procedural name should not be empty and should not contain a dash
+        assert!(!result.name.is_empty());
+        assert!(
+            !result.name.contains('-'),
+            "procedural names should not use dash format: {}",
+            result.name
+        );
     }
 
     #[test]
@@ -393,7 +503,98 @@ mod tests {
         let r1 = rule_combine(&rules, &a, &b);
         let r2 = rule_combine(&rules, &a, &b);
         assert_eq!(r1.seed, r2.seed);
+        assert_eq!(r1.name, r2.name);
         assert!((r1.density.value - r2.density.value).abs() < f32::EPSILON);
+        assert!((r1.thermal_resistance.value - r2.thermal_resistance.value).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn seeded_noise_deterministic() {
+        let a = seeded_noise(12345, 0);
+        let b = seeded_noise(12345, 0);
+        assert!((a - b).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn seeded_noise_varies_by_channel() {
+        let a = seeded_noise(12345, 0);
+        let b = seeded_noise(12345, 1);
+        assert!(
+            (a - b).abs() > f32::EPSILON,
+            "different channels should produce different noise"
+        );
+    }
+
+    #[test]
+    fn procedural_name_deterministic() {
+        assert_eq!(procedural_name(42), procedural_name(42));
+    }
+
+    #[test]
+    fn procedural_name_varies_by_seed() {
+        assert_ne!(procedural_name(1000), procedural_name(999_999));
+    }
+
+    #[test]
+    fn catalytic_pair_shifts_color_hue() {
+        let mut rules = default_rules();
+        rules.pair_rules.insert(
+            ("Aaa".into(), "Bbb".into()),
+            PairRuleSet {
+                density: PropertyRule::Catalyze { multiplier: 1.5 },
+                thermal_resistance: PropertyRule::default(),
+                reactivity: PropertyRule::default(),
+                conductivity: PropertyRule::default(),
+                toxicity: PropertyRule::default(),
+            },
+        );
+
+        let a = test_material("Aaa", 1, 0.5);
+        let b = test_material("Bbb", 2, 0.5);
+        let result = rule_combine(&rules, &a, &b);
+
+        let plain_blend = [
+            (a.color[0] + b.color[0]) * 0.5,
+            (a.color[1] + b.color[1]) * 0.5,
+            (a.color[2] + b.color[2]) * 0.5,
+        ];
+        let shifted = result.color != plain_blend;
+        assert!(
+            shifted,
+            "catalytic pair should shift color hue from plain blend"
+        );
+    }
+
+    #[test]
+    fn non_catalytic_pair_blends_color_evenly() {
+        let rules = default_rules();
+        let a = test_material("Xxx", 1, 0.5);
+        let b = test_material("Yyy", 2, 0.5);
+        let result = rule_combine(&rules, &a, &b);
+
+        for i in 0..3 {
+            let expected = (a.color[i] + b.color[i]) * 0.5;
+            assert!(
+                (result.color[i] - expected).abs() < f32::EPSILON,
+                "channel {i}: expected {expected}, got {}",
+                result.color[i]
+            );
+        }
+    }
+
+    #[test]
+    fn perturbation_not_applied_to_non_blend_rules() {
+        let rule = PropertyRule::Max;
+        let a = MaterialProperty {
+            value: 0.3,
+            visibility: PropertyVisibility::Observable,
+        };
+        let b = MaterialProperty {
+            value: 0.7,
+            visibility: PropertyVisibility::Observable,
+        };
+        let result = apply_rule_with_perturbation(&rule, &a, &b, 42, 0);
+        assert!((result.value - 0.7).abs() < f32::EPSILON);
     }
 
     #[test]
@@ -406,7 +607,7 @@ mod tests {
             value: 0.5,
             visibility: PropertyVisibility::Observable,
         };
-        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        let result = apply_rule_with_perturbation(&PropertyRule::default(), &a, &b, 1, 0);
         assert_eq!(result.visibility, PropertyVisibility::Observable);
     }
 
@@ -420,7 +621,7 @@ mod tests {
             value: 0.5,
             visibility: PropertyVisibility::Hidden,
         };
-        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        let result = apply_rule_with_perturbation(&PropertyRule::default(), &a, &b, 1, 0);
         assert_eq!(result.visibility, PropertyVisibility::Hidden);
     }
 
@@ -434,7 +635,7 @@ mod tests {
             value: 0.5,
             visibility: PropertyVisibility::Revealed,
         };
-        let result = apply_rule(&PropertyRule::default(), &a, &b);
+        let result = apply_rule_with_perturbation(&PropertyRule::default(), &a, &b, 1, 0);
         assert_eq!(result.visibility, PropertyVisibility::Observable);
     }
 
@@ -449,7 +650,7 @@ mod tests {
             value: 0.6,
             visibility: PropertyVisibility::Observable,
         };
-        let result = apply_rule(&rule, &a, &b);
+        let result = apply_rule_with_perturbation(&rule, &a, &b, 1, 0);
         assert!(
             result.value > a.value && result.value > b.value,
             "catalyze should exceed both inputs: got {}",
@@ -491,7 +692,7 @@ mod tests {
             value: 0.7,
             visibility: PropertyVisibility::Observable,
         };
-        let result = apply_rule(&rule, &a, &b);
+        let result = apply_rule_with_perturbation(&rule, &a, &b, 1, 0);
         assert!((result.value - 0.7).abs() < f32::EPSILON);
     }
 
@@ -506,7 +707,7 @@ mod tests {
             value: 0.7,
             visibility: PropertyVisibility::Observable,
         };
-        let result = apply_rule(&rule, &a, &b);
+        let result = apply_rule_with_perturbation(&rule, &a, &b, 1, 0);
         assert!((result.value - 0.3).abs() < f32::EPSILON);
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,7 +15,6 @@
 //! settings UI modifies bindings, it updates the resource; a reactive system
 //! rebuilds the `InputMap` and the config is saved back to disk.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -100,12 +99,8 @@ fn default_sensitivity() -> f32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingsConfig {
-    /// DualAxis movement keys: up/down/left/right.
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
-    /// Mouse look — present for completeness but always "Mouse" in practice.
-    #[serde(default = "default_look", rename = "Look")]
-    pub look: String,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
@@ -124,7 +119,6 @@ impl Default for BindingsConfig {
     fn default() -> Self {
         Self {
             movement: MoveBindings::default(),
-            look: default_look(),
             interact: default_interact(),
             examine: default_examine(),
             place: default_place(),
@@ -170,9 +164,6 @@ fn default_left() -> String {
 fn default_right() -> String {
     "D".into()
 }
-fn default_look() -> String {
-    "Mouse".into()
-}
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
 }
@@ -192,63 +183,70 @@ fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
 
-// ── Key name → KeyCode mapping ──────────────────────────────────────────
+// ── Input name parsing ──────────────────────────────────────────────────
 
 /// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
-/// Returns `None` for unrecognised names, which are logged as warnings.
 fn parse_key(name: &str) -> Option<KeyCode> {
-    // Lazily-built lookup table. Covers the keys players are likely to rebind.
-    // Extend as needed — this is the single place key names are resolved.
-    let map: HashMap<&str, KeyCode> = HashMap::from([
-        ("A", KeyCode::KeyA),
-        ("B", KeyCode::KeyB),
-        ("C", KeyCode::KeyC),
-        ("D", KeyCode::KeyD),
-        ("E", KeyCode::KeyE),
-        ("F", KeyCode::KeyF),
-        ("G", KeyCode::KeyG),
-        ("H", KeyCode::KeyH),
-        ("I", KeyCode::KeyI),
-        ("J", KeyCode::KeyJ),
-        ("K", KeyCode::KeyK),
-        ("L", KeyCode::KeyL),
-        ("M", KeyCode::KeyM),
-        ("N", KeyCode::KeyN),
-        ("O", KeyCode::KeyO),
-        ("P", KeyCode::KeyP),
-        ("Q", KeyCode::KeyQ),
-        ("R", KeyCode::KeyR),
-        ("S", KeyCode::KeyS),
-        ("T", KeyCode::KeyT),
-        ("U", KeyCode::KeyU),
-        ("V", KeyCode::KeyV),
-        ("W", KeyCode::KeyW),
-        ("X", KeyCode::KeyX),
-        ("Y", KeyCode::KeyY),
-        ("Z", KeyCode::KeyZ),
-        ("Space", KeyCode::Space),
-        ("Escape", KeyCode::Escape),
-        ("Tab", KeyCode::Tab),
-        ("ShiftLeft", KeyCode::ShiftLeft),
-        ("ShiftRight", KeyCode::ShiftRight),
-        ("ControlLeft", KeyCode::ControlLeft),
-        ("ControlRight", KeyCode::ControlRight),
-        ("Up", KeyCode::ArrowUp),
-        ("Down", KeyCode::ArrowDown),
-        ("Left", KeyCode::ArrowLeft),
-        ("Right", KeyCode::ArrowRight),
-        ("1", KeyCode::Digit1),
-        ("2", KeyCode::Digit2),
-        ("3", KeyCode::Digit3),
-        ("4", KeyCode::Digit4),
-        ("5", KeyCode::Digit5),
-        ("6", KeyCode::Digit6),
-        ("7", KeyCode::Digit7),
-        ("8", KeyCode::Digit8),
-        ("9", KeyCode::Digit9),
-        ("0", KeyCode::Digit0),
-    ]);
-    map.get(name).copied()
+    match name {
+        "A" => Some(KeyCode::KeyA),
+        "B" => Some(KeyCode::KeyB),
+        "C" => Some(KeyCode::KeyC),
+        "D" => Some(KeyCode::KeyD),
+        "E" => Some(KeyCode::KeyE),
+        "F" => Some(KeyCode::KeyF),
+        "G" => Some(KeyCode::KeyG),
+        "H" => Some(KeyCode::KeyH),
+        "I" => Some(KeyCode::KeyI),
+        "J" => Some(KeyCode::KeyJ),
+        "K" => Some(KeyCode::KeyK),
+        "L" => Some(KeyCode::KeyL),
+        "M" => Some(KeyCode::KeyM),
+        "N" => Some(KeyCode::KeyN),
+        "O" => Some(KeyCode::KeyO),
+        "P" => Some(KeyCode::KeyP),
+        "Q" => Some(KeyCode::KeyQ),
+        "R" => Some(KeyCode::KeyR),
+        "S" => Some(KeyCode::KeyS),
+        "T" => Some(KeyCode::KeyT),
+        "U" => Some(KeyCode::KeyU),
+        "V" => Some(KeyCode::KeyV),
+        "W" => Some(KeyCode::KeyW),
+        "X" => Some(KeyCode::KeyX),
+        "Y" => Some(KeyCode::KeyY),
+        "Z" => Some(KeyCode::KeyZ),
+        "Space" => Some(KeyCode::Space),
+        "Escape" => Some(KeyCode::Escape),
+        "Tab" => Some(KeyCode::Tab),
+        "ShiftLeft" => Some(KeyCode::ShiftLeft),
+        "ShiftRight" => Some(KeyCode::ShiftRight),
+        "ControlLeft" => Some(KeyCode::ControlLeft),
+        "ControlRight" => Some(KeyCode::ControlRight),
+        "Up" => Some(KeyCode::ArrowUp),
+        "Down" => Some(KeyCode::ArrowDown),
+        "Left" => Some(KeyCode::ArrowLeft),
+        "Right" => Some(KeyCode::ArrowRight),
+        "1" => Some(KeyCode::Digit1),
+        "2" => Some(KeyCode::Digit2),
+        "3" => Some(KeyCode::Digit3),
+        "4" => Some(KeyCode::Digit4),
+        "5" => Some(KeyCode::Digit5),
+        "6" => Some(KeyCode::Digit6),
+        "7" => Some(KeyCode::Digit7),
+        "8" => Some(KeyCode::Digit8),
+        "9" => Some(KeyCode::Digit9),
+        "0" => Some(KeyCode::Digit0),
+        _ => None,
+    }
+}
+
+/// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
+fn parse_mouse_button(name: &str) -> Option<MouseButton> {
+    match name {
+        "MouseLeft" => Some(MouseButton::Left),
+        "MouseRight" => Some(MouseButton::Right),
+        "MouseMiddle" => Some(MouseButton::Middle),
+        _ => None,
+    }
 }
 
 // ── Systems ─────────────────────────────────────────────────────────────
@@ -301,18 +299,14 @@ pub(crate) fn attach_input_map_to_player(
 /// Separated from the system so it can be called when rebinding too.
 pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let bindings = &config.bindings;
+    let mut input_map = InputMap::default();
 
     let up = parse_key(&bindings.movement.up).unwrap_or(KeyCode::KeyW);
     let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
     let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
     let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
-
-    let mut input_map = InputMap::default();
-
-    // Movement: WASD as a virtual DPad producing a Vec2.
     input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
 
-    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
     input_map.insert_dual_axis(
         InputAction::Look,
         MouseMove::default()

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,6 +15,7 @@
 //! settings UI modifies bindings, it updates the resource; a reactive system
 //! rebuilds the `InputMap` and the config is saved back to disk.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -99,8 +100,12 @@ fn default_sensitivity() -> f32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingsConfig {
+    /// DualAxis movement keys: up/down/left/right.
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
+    /// Mouse look — present for completeness but always "Mouse" in practice.
+    #[serde(default = "default_look", rename = "Look")]
+    pub look: String,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
@@ -119,6 +124,7 @@ impl Default for BindingsConfig {
     fn default() -> Self {
         Self {
             movement: MoveBindings::default(),
+            look: default_look(),
             interact: default_interact(),
             examine: default_examine(),
             place: default_place(),
@@ -164,6 +170,9 @@ fn default_left() -> String {
 fn default_right() -> String {
     "D".into()
 }
+fn default_look() -> String {
+    "Mouse".into()
+}
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
 }
@@ -183,82 +192,64 @@ fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
 
-// ── Input name parsing ──────────────────────────────────────────────────
+// ── Key name → KeyCode mapping ──────────────────────────────────────────
 
 /// Translates user-friendly key names from the TOML config into Bevy `KeyCode`s.
+/// Returns `None` for unrecognised names, which are logged as warnings.
 fn parse_key(name: &str) -> Option<KeyCode> {
-    match name {
-        "A" => Some(KeyCode::KeyA),
-        "B" => Some(KeyCode::KeyB),
-        "C" => Some(KeyCode::KeyC),
-        "D" => Some(KeyCode::KeyD),
-        "E" => Some(KeyCode::KeyE),
-        "F" => Some(KeyCode::KeyF),
-        "G" => Some(KeyCode::KeyG),
-        "H" => Some(KeyCode::KeyH),
-        "I" => Some(KeyCode::KeyI),
-        "J" => Some(KeyCode::KeyJ),
-        "K" => Some(KeyCode::KeyK),
-        "L" => Some(KeyCode::KeyL),
-        "M" => Some(KeyCode::KeyM),
-        "N" => Some(KeyCode::KeyN),
-        "O" => Some(KeyCode::KeyO),
-        "P" => Some(KeyCode::KeyP),
-        "Q" => Some(KeyCode::KeyQ),
-        "R" => Some(KeyCode::KeyR),
-        "S" => Some(KeyCode::KeyS),
-        "T" => Some(KeyCode::KeyT),
-        "U" => Some(KeyCode::KeyU),
-        "V" => Some(KeyCode::KeyV),
-        "W" => Some(KeyCode::KeyW),
-        "X" => Some(KeyCode::KeyX),
-        "Y" => Some(KeyCode::KeyY),
-        "Z" => Some(KeyCode::KeyZ),
-        "Space" => Some(KeyCode::Space),
-        "Escape" => Some(KeyCode::Escape),
-        "Tab" => Some(KeyCode::Tab),
-        "ShiftLeft" => Some(KeyCode::ShiftLeft),
-        "ShiftRight" => Some(KeyCode::ShiftRight),
-        "ControlLeft" => Some(KeyCode::ControlLeft),
-        "ControlRight" => Some(KeyCode::ControlRight),
-        "Up" => Some(KeyCode::ArrowUp),
-        "Down" => Some(KeyCode::ArrowDown),
-        "Left" => Some(KeyCode::ArrowLeft),
-        "Right" => Some(KeyCode::ArrowRight),
-        "1" => Some(KeyCode::Digit1),
-        "2" => Some(KeyCode::Digit2),
-        "3" => Some(KeyCode::Digit3),
-        "4" => Some(KeyCode::Digit4),
-        "5" => Some(KeyCode::Digit5),
-        "6" => Some(KeyCode::Digit6),
-        "7" => Some(KeyCode::Digit7),
-        "8" => Some(KeyCode::Digit8),
-        "9" => Some(KeyCode::Digit9),
-        "0" => Some(KeyCode::Digit0),
-        _ => None,
-    }
+    // Lazily-built lookup table. Covers the keys players are likely to rebind.
+    // Extend as needed — this is the single place key names are resolved.
+    let map: HashMap<&str, KeyCode> = HashMap::from([
+        ("A", KeyCode::KeyA),
+        ("B", KeyCode::KeyB),
+        ("C", KeyCode::KeyC),
+        ("D", KeyCode::KeyD),
+        ("E", KeyCode::KeyE),
+        ("F", KeyCode::KeyF),
+        ("G", KeyCode::KeyG),
+        ("H", KeyCode::KeyH),
+        ("I", KeyCode::KeyI),
+        ("J", KeyCode::KeyJ),
+        ("K", KeyCode::KeyK),
+        ("L", KeyCode::KeyL),
+        ("M", KeyCode::KeyM),
+        ("N", KeyCode::KeyN),
+        ("O", KeyCode::KeyO),
+        ("P", KeyCode::KeyP),
+        ("Q", KeyCode::KeyQ),
+        ("R", KeyCode::KeyR),
+        ("S", KeyCode::KeyS),
+        ("T", KeyCode::KeyT),
+        ("U", KeyCode::KeyU),
+        ("V", KeyCode::KeyV),
+        ("W", KeyCode::KeyW),
+        ("X", KeyCode::KeyX),
+        ("Y", KeyCode::KeyY),
+        ("Z", KeyCode::KeyZ),
+        ("Space", KeyCode::Space),
+        ("Escape", KeyCode::Escape),
+        ("Tab", KeyCode::Tab),
+        ("ShiftLeft", KeyCode::ShiftLeft),
+        ("ShiftRight", KeyCode::ShiftRight),
+        ("ControlLeft", KeyCode::ControlLeft),
+        ("ControlRight", KeyCode::ControlRight),
+        ("Up", KeyCode::ArrowUp),
+        ("Down", KeyCode::ArrowDown),
+        ("Left", KeyCode::ArrowLeft),
+        ("Right", KeyCode::ArrowRight),
+        ("1", KeyCode::Digit1),
+        ("2", KeyCode::Digit2),
+        ("3", KeyCode::Digit3),
+        ("4", KeyCode::Digit4),
+        ("5", KeyCode::Digit5),
+        ("6", KeyCode::Digit6),
+        ("7", KeyCode::Digit7),
+        ("8", KeyCode::Digit8),
+        ("9", KeyCode::Digit9),
+        ("0", KeyCode::Digit0),
+    ]);
+    map.get(name).copied()
 }
-
-/// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
-fn parse_mouse_button(name: &str) -> Option<MouseButton> {
-    match name {
-        "MouseLeft" => Some(MouseButton::Left),
-        "MouseRight" => Some(MouseButton::Right),
-        "MouseMiddle" => Some(MouseButton::Middle),
-        _ => None,
-    }
-}
-
-/// Translates mouse button names from the TOML config into Bevy `MouseButton`s.
-fn parse_mouse_button(name: &str) -> Option<MouseButton> {
-    match name {
-        "MouseLeft" => Some(MouseButton::Left),
-        "MouseRight" => Some(MouseButton::Right),
-        "MouseMiddle" => Some(MouseButton::Middle),
-        _ => None,
-    }
-}
-
 
 // ── Systems ─────────────────────────────────────────────────────────────
 
@@ -310,14 +301,18 @@ pub(crate) fn attach_input_map_to_player(
 /// Separated from the system so it can be called when rebinding too.
 pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let bindings = &config.bindings;
-    let mut input_map = InputMap::default();
 
     let up = parse_key(&bindings.movement.up).unwrap_or(KeyCode::KeyW);
     let down = parse_key(&bindings.movement.down).unwrap_or(KeyCode::KeyS);
     let left = parse_key(&bindings.movement.left).unwrap_or(KeyCode::KeyA);
     let right = parse_key(&bindings.movement.right).unwrap_or(KeyCode::KeyD);
+
+    let mut input_map = InputMap::default();
+
+    // Movement: WASD as a virtual DPad producing a Vec2.
     input_map.insert_dual_axis(InputAction::Move, VirtualDPad::new(up, down, left, right));
 
+    // Mouse look: DualAxis from mouse motion with configurable sensitivity.
     input_map.insert_dual_axis(
         InputAction::Look,
         MouseMove::default()


### PR DESCRIPTION
## Summary
- Default blend outputs now include a small deterministic perturbation (splitmix64 per-channel noise) so results are reproducible but not perfectly averaged
- Output materials receive procedural names from prefix/suffix tables indexed by combined seed
- Color blending applies a warm hue shift when any catalytic rule is in the pair's rule set
- Non-blend rules (Max/Min/Catalyze/Inert) remain exact — no perturbation

## Test plan
- [x] `cargo test` — 60 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: combine same pair twice, verify identical output
- [ ] Manual: combine Ferrite + Phosphite (catalytic), verify output has a warm-shifted color
- [ ] Manual: combine an unknown pair, verify output name is a procedural word (not "Ferr-Sili" format)

Closes #12