### PR TITLE
feat: continue Story 3.3 with fabricated thermal observation

### DIFF
--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -278,18 +278,6 @@ fn apply_processing_visuals(
 
 use crate::combination::PropertyRule;
 
-/// Determines the output property visibility.
-/// If both inputs have been seen (Observable or Revealed), the output is Observable.
-/// Otherwise, the output is Hidden — the player must discover it again.
-fn output_visibility(a: PropertyVisibility, b: PropertyVisibility) -> PropertyVisibility {
-    match (a, b) {
-        (PropertyVisibility::Hidden, _) | (_, PropertyVisibility::Hidden) => {
-            PropertyVisibility::Hidden
-        }
-        _ => PropertyVisibility::Observable,
-    }
-}
-
 /// Deterministic pseudo-random float in \[-1.0, 1.0\] from a seed+channel.
 /// Splitmix64 single iteration — fast, deterministic, no external crate needed.
 fn seeded_noise(seed: u64, channel: u64) -> f32 {
@@ -323,7 +311,7 @@ fn apply_rule_with_perturbation(
     };
     MaterialProperty {
         value,
-        visibility: output_visibility(a.visibility, b.visibility),
+        visibility: PropertyVisibility::Hidden,
     }
 }
 
@@ -398,13 +386,16 @@ pub(crate) fn rule_combine(
         name,
         seed: combined_seed,
         color,
-        density: apply_rule_with_perturbation(
-            &pair_rules.density,
-            &a.density,
-            &b.density,
-            combined_seed,
-            0,
-        ),
+        density: MaterialProperty {
+            visibility: PropertyVisibility::Observable,
+            ..apply_rule_with_perturbation(
+                &pair_rules.density,
+                &a.density,
+                &b.density,
+                combined_seed,
+                0,
+            )
+        },
         thermal_resistance: apply_rule_with_perturbation(
             &pair_rules.thermal_resistance,
             &a.thermal_resistance,
@@ -598,20 +589,6 @@ mod tests {
     }
 
     #[test]
-    fn observable_inputs_produce_observable_output() {
-        let a = MaterialProperty {
-            value: 0.5,
-            visibility: PropertyVisibility::Observable,
-        };
-        let b = MaterialProperty {
-            value: 0.5,
-            visibility: PropertyVisibility::Observable,
-        };
-        let result = apply_rule_with_perturbation(&PropertyRule::default(), &a, &b, 1, 0);
-        assert_eq!(result.visibility, PropertyVisibility::Observable);
-    }
-
-    #[test]
     fn hidden_input_produces_hidden_output() {
         let a = MaterialProperty {
             value: 0.5,
@@ -626,17 +603,34 @@ mod tests {
     }
 
     #[test]
-    fn revealed_inputs_produce_observable_output() {
+    fn non_surface_output_properties_remain_hidden_even_if_inputs_were_known() {
         let a = MaterialProperty {
             value: 0.5,
-            visibility: PropertyVisibility::Revealed,
+            visibility: PropertyVisibility::Observable,
         };
         let b = MaterialProperty {
             value: 0.5,
             visibility: PropertyVisibility::Revealed,
         };
         let result = apply_rule_with_perturbation(&PropertyRule::default(), &a, &b, 1, 0);
-        assert_eq!(result.visibility, PropertyVisibility::Observable);
+        assert_eq!(result.visibility, PropertyVisibility::Hidden);
+    }
+
+    #[test]
+    fn fabricated_density_remains_surface_observable() {
+        let rules = default_rules();
+        let a = test_material("Ferrite", 100, 0.8);
+        let b = test_material("Silite", 200, 0.2);
+        let result = rule_combine(&rules, &a, &b);
+
+        assert_eq!(result.density.visibility, PropertyVisibility::Observable);
+        assert_eq!(
+            result.thermal_resistance.visibility,
+            PropertyVisibility::Hidden
+        );
+        assert_eq!(result.reactivity.visibility, PropertyVisibility::Hidden);
+        assert_eq!(result.conductivity.visibility, PropertyVisibility::Hidden);
+        assert_eq!(result.toxicity.visibility, PropertyVisibility::Hidden);
     }
 
     #[test]

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -18,6 +18,7 @@ use bevy::prelude::*;
 
 use crate::interaction::HeldItem;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
+use crate::observation::ConfidenceTracker;
 use crate::scene::{SceneConfig, Workbench};
 
 pub(crate) struct HeatPlugin;
@@ -58,6 +59,10 @@ impl HeatExposure {
         }
     }
 }
+
+/// Prevents a single material entity from incrementing confidence more than once.
+#[derive(Component)]
+struct ThermalObservationRecorded;
 
 // ── Spawn ───────────────────────────────────────────────────────────────
 
@@ -219,19 +224,40 @@ fn apply_thermal_reaction(
 // ── Property revelation ─────────────────────────────────────────────────
 
 fn reveal_thermal_property(
+    mut commands: Commands,
     cfg: Res<SceneConfig>,
-    mut material_query: Query<(&HeatExposure, &mut GameMaterial), With<MaterialObject>>,
+    mut tracker: ResMut<ConfidenceTracker>,
+    mut material_query: Query<
+        (
+            Entity,
+            &HeatExposure,
+            &mut GameMaterial,
+            Option<&ThermalObservationRecorded>,
+        ),
+        With<MaterialObject>,
+    >,
 ) {
     let reveal_secs = cfg.heat_source.reveal_seconds;
 
-    for (exp, mut mat) in &mut material_query {
-        if exp.elapsed >= reveal_secs
-            && mat.thermal_resistance.visibility == PropertyVisibility::Hidden
-        {
+    for (entity, exp, mut mat, recorded) in &mut material_query {
+        if exp.elapsed < reveal_secs {
+            continue;
+        }
+
+        if mat.thermal_resistance.visibility == PropertyVisibility::Hidden {
             mat.thermal_resistance.visibility = PropertyVisibility::Revealed;
             info!(
                 "'{}' thermal resistance revealed after {:.1}s exposure",
                 mat.name, exp.elapsed
+            );
+        }
+
+        if recorded.is_none() {
+            let count = tracker.record(mat.seed, "thermal_resistance");
+            commands.entity(entity).insert(ThermalObservationRecorded);
+            info!(
+                "'{}' thermal observation recorded (count = {})",
+                mat.name, count
             );
         }
     }

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -24,6 +24,7 @@ use bevy::window::CursorGrabMode;
 use crate::fabricator::{ActivateIntent, InputSlot};
 use crate::input::InputAction;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
+use crate::observation::{ConfidenceLevel, ConfidenceTracker};
 use crate::player::{Player, PlayerCamera};
 use crate::scene::Surface;
 
@@ -504,6 +505,7 @@ fn process_examine(
 fn update_examine_panel(
     state: Res<ExamineState>,
     target: Res<InteractionTarget>,
+    tracker: Res<ConfidenceTracker>,
     held_query: Query<&GameMaterial, With<HeldItem>>,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     mut panel_query: Query<&mut Visibility, With<ExaminePanel>>,
@@ -533,7 +535,7 @@ fn update_examine_panel(
     };
 
     *vis = Visibility::Visible;
-    text.0 = build_examine_text(mat);
+    text.0 = build_examine_text(mat, &tracker);
 }
 
 // ── Property description ─────────────────────────────────────────────────
@@ -575,17 +577,39 @@ fn describe_density(value: f32) -> &'static str {
     }
 }
 
-fn build_examine_text(mat: &GameMaterial) -> String {
+fn describe_thermal_behavior(value: f32) -> &'static str {
+    if value < 0.25 {
+        "soften quickly under heat"
+    } else if value < 0.5 {
+        "change noticeably under heat"
+    } else if value < 0.75 {
+        "hold together under heat"
+    } else {
+        "barely react to heat"
+    }
+}
+
+fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
+    let behavior = describe_thermal_behavior(value);
+    match confidence {
+        ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
+        ConfidenceLevel::Observed => {
+            let mut chars = behavior.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            format!("{}{}", first.to_uppercase(), chars.as_str())
+        }
+        ConfidenceLevel::Confident => format!("Reliably {behavior}"),
+    }
+}
+
+fn build_examine_text(mat: &GameMaterial, tracker: &ConfidenceTracker) -> String {
     let mut lines = vec![mat.name.clone()];
     lines.push(String::new());
 
     append_prop(&mut lines, "Weight", &mat.density, describe_density);
-    append_prop(
-        &mut lines,
-        "Heat resistance",
-        &mat.thermal_resistance,
-        describe_value,
-    );
+    append_thermal_prop(&mut lines, mat, tracker);
     append_prop(&mut lines, "Reactivity", &mat.reactivity, describe_value);
     append_prop(
         &mut lines,
@@ -610,6 +634,18 @@ fn append_prop(
         lines.push(format!("{label}: {}", describer(prop.value)));
     } else {
         lines.push(format!("{label}: ???"));
+    }
+}
+
+fn append_thermal_prop(lines: &mut Vec<String>, mat: &GameMaterial, tracker: &ConfidenceTracker) {
+    match mat.thermal_resistance.visibility {
+        PropertyVisibility::Hidden => lines.push("Heat response: ???".to_string()),
+        PropertyVisibility::Observable | PropertyVisibility::Revealed => {
+            let confidence = tracker.level(mat.seed, "thermal_resistance");
+            let description =
+                describe_thermal_observation(mat.thermal_resistance.value, confidence);
+            lines.push(format!("Heat response: {description}"));
+        }
     }
 }
 
@@ -673,12 +709,13 @@ mod tests {
     #[test]
     fn examine_text_shows_observable_and_revealed_hides_hidden() {
         let mat = test_material();
-        let text = build_examine_text(&mat);
+        let tracker = ConfidenceTracker::default();
+        let text = build_examine_text(&mat, &tracker);
 
         assert!(text.contains("TestMat"));
         assert!(text.contains("Weight: Very heavy"));
         assert!(text.contains("Conductivity: Very high"));
-        assert!(text.contains("Heat resistance: ???"));
+        assert!(text.contains("Heat response: ???"));
         assert!(text.contains("Reactivity: ???"));
         assert!(text.contains("Toxicity: ???"));
     }
@@ -686,8 +723,29 @@ mod tests {
     #[test]
     fn examine_text_name_is_first_line() {
         let mat = test_material();
-        let text = build_examine_text(&mat);
+        let tracker = ConfidenceTracker::default();
+        let text = build_examine_text(&mat, &tracker);
         let first_line = text.lines().next().unwrap();
         assert_eq!(first_line, "TestMat");
+    }
+
+    #[test]
+    fn examine_text_uses_confidence_language_for_revealed_heat_response() {
+        let mut mat = test_material();
+        mat.thermal_resistance.visibility = PropertyVisibility::Revealed;
+
+        let mut tracker = ConfidenceTracker::default();
+        let tentative = build_examine_text(&mat, &tracker);
+        assert!(tentative.contains("Heat response: Seemed to hold together under heat"));
+
+        tracker.record(mat.seed, "thermal_resistance");
+        tracker.record(mat.seed, "thermal_resistance");
+        let observed = build_examine_text(&mat, &tracker);
+        assert!(observed.contains("Heat response: Hold together under heat"));
+
+        tracker.record(mat.seed, "thermal_resistance");
+        tracker.record(mat.seed, "thermal_resistance");
+        let confident = build_examine_text(&mat, &tracker);
+        assert!(confident.contains("Heat response: Reliably hold together under heat"));
     }
 }


### PR DESCRIPTION
Part of #14

Stacks on the current Graphite tip to avoid disturbing the open stack.

This slice of Story 3.3:
- keeps fabricated outputs from exposing non-surface properties on first examine
- records thermal observations into `ConfidenceTracker` when a fabricated material completes a meaningful heat test
- shows consequence-style heat response language in the examine panel as confidence grows

Validation:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`