### PR TITLE
feat: add Story 3.4 discovery journal

### DIFF
--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -69,12 +69,6 @@ process_seconds = 2.5
 # Scene tuning — room geometry, lighting, and player spawn.
 # Edit these values instead of changing Rust constants.
 
-[player]
-eye_height = 1.7
-spawn_x = 0.0
-spawn_z = 2.0
-move_speed = 5.0
-
 [lighting]
 ambient_brightness = 14.0
 directional_illuminance = 1100.0

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -14,6 +14,7 @@
 use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
+use crate::journal::RecordFabrication;
 use crate::materials::{GameMaterial, MaterialObject, MaterialProperty, PropertyVisibility};
 use crate::scene::{SceneConfig, Workbench};
 
@@ -175,6 +176,7 @@ fn tick_processing(
     time: Res<Time>,
     cfg: Res<SceneConfig>,
     rules: Res<CombinationRules>,
+    mut journal_writer: MessageWriter<RecordFabrication>,
     mut state: ResMut<FabricatorState>,
     mut slots: Query<&mut InputSlot>,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
@@ -213,6 +215,11 @@ fn tick_processing(
 
     // Rule-driven combination.
     let output_mat = rule_combine(&rules, &input_mats[0], &input_mats[1]);
+    journal_writer.write(RecordFabrication {
+        output_material: output_mat.clone(),
+        input_a: input_mats[0].name.clone(),
+        input_b: input_mats[1].name.clone(),
+    });
 
     // Spawn the output material on the output slot.
     let Ok((output_gtf, mut out_slot)) = output_slot.single_mut() else {

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -215,11 +215,6 @@ fn tick_processing(
 
     // Rule-driven combination.
     let output_mat = rule_combine(&rules, &input_mats[0], &input_mats[1]);
-    journal_writer.write(RecordFabrication {
-        output_material: output_mat.clone(),
-        input_a: input_mats[0].name.clone(),
-        input_b: input_mats[1].name.clone(),
-    });
 
     // Spawn the output material on the output slot.
     let Ok((output_gtf, mut out_slot)) = output_slot.single_mut() else {
@@ -252,6 +247,12 @@ fn tick_processing(
         .id();
 
     out_slot.material = Some(output_entity);
+
+    journal_writer.write(RecordFabrication {
+        output_material: output_mat.clone(),
+        input_a: input_mats[0].name.clone(),
+        input_b: input_mats[1].name.clone(),
+    });
 
     info!("Fabrication complete — produced '{}'", output_mat.name);
     *state = FabricatorState::Idle;

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -17,6 +17,7 @@
 use bevy::prelude::*;
 
 use crate::interaction::HeldItem;
+use crate::journal::RecordThermalObservation;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::ConfidenceTracker;
 use crate::scene::{SceneConfig, Workbench};
@@ -227,6 +228,7 @@ fn reveal_thermal_property(
     mut commands: Commands,
     cfg: Res<SceneConfig>,
     mut tracker: ResMut<ConfidenceTracker>,
+    mut journal_writer: MessageWriter<RecordThermalObservation>,
     mut material_query: Query<
         (
             Entity,
@@ -255,6 +257,12 @@ fn reveal_thermal_property(
         if recorded.is_none() {
             let count = tracker.record(mat.seed, "thermal_resistance");
             commands.entity(entity).insert(ThermalObservationRecorded);
+            journal_writer.write(RecordThermalObservation {
+                seed: mat.seed,
+                name: mat.name.clone(),
+                thermal_resistance: mat.thermal_resistance.value,
+                confidence: tracker.level(mat.seed, "thermal_resistance"),
+            });
             info!(
                 "'{}' thermal observation recorded (count = {})",
                 mat.name, count

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -23,8 +23,9 @@ use bevy::window::CursorGrabMode;
 
 use crate::fabricator::{ActivateIntent, InputSlot};
 use crate::input::InputAction;
+use crate::journal::RecordEncounter;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
-use crate::observation::{ConfidenceLevel, ConfidenceTracker};
+use crate::observation::{ConfidenceTracker, describe_thermal_observation};
 use crate::player::{Player, PlayerCamera};
 use crate::scene::Surface;
 
@@ -491,11 +492,21 @@ fn process_examine(
     mut reader: MessageReader<ExamineIntent>,
     mut state: ResMut<ExamineState>,
     target: Res<InteractionTarget>,
-    held_query: Query<(), With<HeldItem>>,
+    held_query: Query<&GameMaterial, With<HeldItem>>,
+    material_query: Query<&GameMaterial, With<MaterialObject>>,
+    mut encounter_writer: MessageWriter<RecordEncounter>,
 ) {
     for _intent in reader.read() {
-        if held_query.iter().next().is_some() || target.entity.is_some() {
+        let held_material = held_query.iter().next();
+        let targeted_material = target
+            .entity
+            .and_then(|entity| material_query.get(entity).ok());
+
+        if let Some(mat) = held_material.or(targeted_material) {
             state.visible = !state.visible;
+            encounter_writer.write(RecordEncounter {
+                material: mat.clone(),
+            });
         } else {
             state.visible = false;
         }
@@ -574,33 +585,6 @@ fn describe_density(value: f32) -> &'static str {
         "Very heavy"
     } else {
         "Extremely dense"
-    }
-}
-
-fn describe_thermal_behavior(value: f32) -> &'static str {
-    if value < 0.25 {
-        "soften quickly under heat"
-    } else if value < 0.5 {
-        "change noticeably under heat"
-    } else if value < 0.75 {
-        "hold together under heat"
-    } else {
-        "barely react to heat"
-    }
-}
-
-fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
-    let behavior = describe_thermal_behavior(value);
-    match confidence {
-        ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
-        ConfidenceLevel::Observed => {
-            let mut chars = behavior.chars();
-            let Some(first) = chars.next() else {
-                return String::new();
-            };
-            format!("{}{}", first.to_uppercase(), chars.as_str())
-        }
-        ConfidenceLevel::Confident => format!("Reliably {behavior}"),
     }
 }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -24,6 +24,7 @@ impl Plugin for JournalPlugin {
         app.add_message::<RecordEncounter>()
             .add_message::<RecordFabrication>()
             .add_message::<RecordThermalObservation>()
+            .add_message::<ToggleJournalIntent>()
             .init_resource::<JournalUiState>()
             .add_systems(
                 Startup,

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,383 @@
+//! Discovery journal — player-owned record of observed materials and outcomes.
+//!
+//! The journal is a lightweight UI overlay that records what the player has
+//! personally encountered: surface observations from examination, thermal test
+//! results from environmental exposure, and fabrication history from the
+//! fabricator. Unknown properties are omitted entirely rather than shown as
+//! placeholders.
+
+use std::collections::BTreeMap;
+
+use bevy::prelude::*;
+use bevy::window::CursorGrabMode;
+use leafwing_input_manager::prelude::*;
+
+use crate::input::InputAction;
+use crate::materials::GameMaterial;
+use crate::observation::{ConfidenceLevel, describe_thermal_observation};
+use crate::player::{Player, spawn_player};
+
+pub(crate) struct JournalPlugin;
+
+impl Plugin for JournalPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<RecordEncounter>()
+            .add_message::<RecordFabrication>()
+            .add_message::<RecordThermalObservation>()
+            .init_resource::<JournalUiState>()
+            .add_systems(
+                Startup,
+                (
+                    attach_journal_to_player.after(spawn_player),
+                    spawn_journal_ui,
+                ),
+            )
+            .add_systems(
+                Update,
+                (
+                    emit_toggle_journal_intent,
+                    toggle_journal_visibility.after(emit_toggle_journal_intent),
+                    apply_encounter_records,
+                    apply_fabrication_records,
+                    apply_thermal_records,
+                    render_journal
+                        .after(apply_encounter_records)
+                        .after(apply_fabrication_records)
+                        .after(apply_thermal_records),
+                ),
+            );
+    }
+}
+
+// ── Messages ────────────────────────────────────────────────────────────
+
+#[derive(Message, Clone)]
+pub(crate) struct RecordEncounter {
+    pub material: GameMaterial,
+}
+
+#[derive(Message, Clone)]
+pub(crate) struct RecordFabrication {
+    pub output_material: GameMaterial,
+    pub input_a: String,
+    pub input_b: String,
+}
+
+#[derive(Message, Clone)]
+pub(crate) struct RecordThermalObservation {
+    pub seed: u64,
+    pub name: String,
+    pub thermal_resistance: f32,
+    pub confidence: ConfidenceLevel,
+}
+
+// ── Player-owned journal data ───────────────────────────────────────────
+
+#[derive(Component, Default)]
+pub(crate) struct Journal {
+    entries: BTreeMap<u64, JournalEntry>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct JournalEntry {
+    name: String,
+    surface_observations: Vec<String>,
+    thermal_observation: Option<String>,
+    fabrication_history: Vec<String>,
+}
+
+impl Journal {
+    fn ensure_entry(&mut self, seed: u64, name: &str) -> &mut JournalEntry {
+        self.entries.entry(seed).or_insert_with(|| JournalEntry {
+            name: name.to_string(),
+            ..default()
+        })
+    }
+}
+
+// ── UI state ────────────────────────────────────────────────────────────
+
+#[derive(Resource, Default)]
+struct JournalUiState {
+    visible: bool,
+}
+
+#[derive(Message)]
+struct ToggleJournalIntent;
+
+#[derive(Component)]
+struct JournalPanel;
+
+#[derive(Component)]
+struct JournalText;
+
+fn attach_journal_to_player(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
+    let Ok(player) = player_query.single() else {
+        return;
+    };
+    commands.entity(player).insert(Journal::default());
+}
+
+fn spawn_journal_ui(mut commands: Commands) {
+    commands
+        .spawn((
+            JournalPanel,
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(24.0),
+                left: Val::Px(24.0),
+                width: Val::Px(460.0),
+                max_height: Val::Percent(80.0),
+                padding: UiRect::all(Val::Px(16.0)),
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.07, 0.07, 0.09, 0.92)),
+            Visibility::Hidden,
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                JournalText,
+                Text::new(""),
+                TextFont {
+                    font_size: 16.0,
+                    ..default()
+                },
+                TextColor(Color::srgba(0.92, 0.92, 0.88, 1.0)),
+            ));
+        });
+}
+
+// ── Input ───────────────────────────────────────────────────────────────
+
+fn emit_toggle_journal_intent(
+    player_query: Query<&ActionState<InputAction>, With<Player>>,
+    cursor_options: Single<&bevy::window::CursorOptions>,
+    mut writer: MessageWriter<ToggleJournalIntent>,
+) {
+    if cursor_options.grab_mode == CursorGrabMode::None {
+        return;
+    }
+
+    let Ok(action) = player_query.single() else {
+        return;
+    };
+    if action.just_pressed(&InputAction::ToggleJournal) {
+        writer.write(ToggleJournalIntent);
+    }
+}
+
+fn toggle_journal_visibility(
+    mut reader: MessageReader<ToggleJournalIntent>,
+    mut state: ResMut<JournalUiState>,
+) {
+    for _ in reader.read() {
+        state.visible = !state.visible;
+    }
+}
+
+// ── Record ingestion ────────────────────────────────────────────────────
+
+fn apply_encounter_records(
+    mut reader: MessageReader<RecordEncounter>,
+    mut player_query: Query<&mut Journal, With<Player>>,
+) {
+    let Ok(mut journal) = player_query.single_mut() else {
+        return;
+    };
+
+    for event in reader.read() {
+        let entry = journal.ensure_entry(event.material.seed, &event.material.name);
+        if entry.surface_observations.is_empty() {
+            entry.surface_observations = vec![
+                format!("Color: {}", describe_color(&event.material.color)),
+                format!("Weight: {}", describe_density(event.material.density.value)),
+            ];
+        }
+    }
+}
+
+fn apply_fabrication_records(
+    mut reader: MessageReader<RecordFabrication>,
+    mut player_query: Query<&mut Journal, With<Player>>,
+) {
+    let Ok(mut journal) = player_query.single_mut() else {
+        return;
+    };
+
+    for event in reader.read() {
+        let entry = journal.ensure_entry(event.output_material.seed, &event.output_material.name);
+        if entry.surface_observations.is_empty() {
+            entry.surface_observations = vec![
+                format!("Color: {}", describe_color(&event.output_material.color)),
+                format!(
+                    "Weight: {}",
+                    describe_density(event.output_material.density.value)
+                ),
+            ];
+        }
+        let history = format!(
+            "Combined {} + {} -> {}",
+            event.input_a, event.input_b, event.output_material.name
+        );
+        if !entry.fabrication_history.contains(&history) {
+            entry.fabrication_history.push(history);
+        }
+    }
+}
+
+fn apply_thermal_records(
+    mut reader: MessageReader<RecordThermalObservation>,
+    mut player_query: Query<&mut Journal, With<Player>>,
+) {
+    let Ok(mut journal) = player_query.single_mut() else {
+        return;
+    };
+
+    for event in reader.read() {
+        let entry = journal.ensure_entry(event.seed, &event.name);
+        entry.thermal_observation = Some(describe_thermal_observation(
+            event.thermal_resistance,
+            event.confidence,
+        ));
+    }
+}
+
+// ── Rendering ───────────────────────────────────────────────────────────
+
+fn render_journal(
+    state: Res<JournalUiState>,
+    player_query: Query<&Journal, With<Player>>,
+    mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
+    mut text_query: Query<&mut Text, With<JournalText>>,
+) {
+    let Ok(mut panel_vis) = panel_query.single_mut() else {
+        return;
+    };
+    let Ok(mut text) = text_query.single_mut() else {
+        return;
+    };
+
+    if !state.visible {
+        *panel_vis = Visibility::Hidden;
+        return;
+    }
+
+    let Ok(journal) = player_query.single() else {
+        *panel_vis = Visibility::Hidden;
+        return;
+    };
+
+    *panel_vis = Visibility::Visible;
+    text.0 = build_journal_text(journal);
+}
+
+fn build_journal_text(journal: &Journal) -> String {
+    if journal.entries.is_empty() {
+        return "Journal\n\nNo observations yet.".to_string();
+    }
+
+    let mut out = vec!["Journal".to_string()];
+    let mut entries: Vec<&JournalEntry> = journal.entries.values().collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for entry in entries {
+        out.push(String::new());
+        out.push(entry.name.clone());
+
+        for obs in &entry.surface_observations {
+            out.push(format!("Surface: {obs}"));
+        }
+
+        if let Some(thermal) = &entry.thermal_observation {
+            out.push(format!("Heat: {thermal}"));
+        }
+
+        for history in &entry.fabrication_history {
+            out.push(history.clone());
+        }
+    }
+
+    out.join("\n")
+}
+
+// ── Descriptive language ────────────────────────────────────────────────
+
+fn describe_density(value: f32) -> &'static str {
+    if value < 0.15 {
+        "Almost weightless"
+    } else if value < 0.3 {
+        "Very light"
+    } else if value < 0.45 {
+        "Light"
+    } else if value < 0.55 {
+        "Medium weight"
+    } else if value < 0.7 {
+        "Heavy"
+    } else if value < 0.85 {
+        "Very heavy"
+    } else {
+        "Extremely dense"
+    }
+}
+
+fn describe_color(color: &[f32; 3]) -> &'static str {
+    let [r, g, b] = *color;
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+
+    if max - min < 0.08 {
+        if max < 0.25 {
+            "Dark mineral grey"
+        } else if max < 0.7 {
+            "Muted stone grey"
+        } else {
+            "Pale chalk grey"
+        }
+    } else if r >= g && r >= b {
+        "Warm rust tone"
+    } else if g >= r && g >= b {
+        "Verdant green tone"
+    } else {
+        "Cool blue tone"
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_omits_unknown_properties() {
+        let mut journal = Journal::default();
+        let entry = journal.ensure_entry(1, "Ferrite");
+        entry.surface_observations.push("Weight: Heavy".into());
+
+        let text = build_journal_text(&journal);
+        assert!(text.contains("Weight: Heavy"));
+        assert!(!text.contains("Heat:"));
+    }
+
+    #[test]
+    fn journal_includes_fabrication_history() {
+        let mut journal = Journal::default();
+        let entry = journal.ensure_entry(2, "Neoite");
+        entry
+            .fabrication_history
+            .push("Combined Ferrite + Silite -> Neoite".into());
+
+        let text = build_journal_text(&journal);
+        assert!(text.contains("Combined Ferrite + Silite -> Neoite"));
+    }
+
+    #[test]
+    fn journal_shows_thermal_observation_when_present() {
+        let mut journal = Journal::default();
+        let entry = journal.ensure_entry(3, "TestMat");
+        entry.thermal_observation = Some("Reliably hold together under heat".into());
+
+        let text = build_journal_text(&journal);
+        assert!(text.contains("Heat: Reliably hold together under heat"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod fabricator;
 mod heat;
 mod input;
 mod interaction;
+mod journal;
 mod materials;
 mod observation;
 mod player;
@@ -49,5 +50,7 @@ fn main() {
         .add_plugins(combination::CombinationPlugin)
         // Observation: confidence tracking for player knowledge.
         .add_plugins(observation::ObservationPlugin)
+        // Journal: player-owned record of observations and fabrication history.
+        .add_plugins(journal::JournalPlugin)
         .run();
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -52,6 +52,33 @@ impl ConfidenceLevel {
     }
 }
 
+pub(crate) fn describe_thermal_behavior(value: f32) -> &'static str {
+    if value < 0.25 {
+        "soften quickly under heat"
+    } else if value < 0.5 {
+        "change noticeably under heat"
+    } else if value < 0.75 {
+        "hold together under heat"
+    } else {
+        "barely react to heat"
+    }
+}
+
+pub(crate) fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
+    let behavior = describe_thermal_behavior(value);
+    match confidence {
+        ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
+        ConfidenceLevel::Observed => {
+            let mut chars = behavior.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            format!("{}{}", first.to_uppercase(), chars.as_str())
+        }
+        ConfidenceLevel::Confident => format!("Reliably {behavior}"),
+    }
+}
+
 // ── Tracker resource ─────────────────────────────────────────────────────
 
 /// Canonical key: (material seed, property name).


### PR DESCRIPTION
Part of #15

Stacks on the current Graphite tip to avoid disturbing the open stack.

This PR adds the remaining Epic 3 journal slice:
- a toggleable journal overlay on the player
- journal entries for personally encountered materials
- thermal observation language that strengthens with confidence
- fabrication history lines in the form `Combined A + B -> C`
- omission of unobserved properties rather than showing unknown placeholders

Validation:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`