### PR TITLE
fix: route cursor capture through input mapping

### DIFF
--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -4,6 +4,7 @@ sensitivity_y = 0.3
 
 [bindings]
 Move = { up = "W", down = "S", left = "A", right = "D" }
+CaptureCursor = ["MouseLeft"]
 Interact = ["E"]
 Examine = ["Q"]
 Place = ["R"]

--- a/src/input.rs
+++ b/src/input.rs
@@ -57,6 +57,7 @@ pub(crate) enum InputAction {
     /// Mouse delta — produces a Vec2 look offset.
     #[actionlike(DualAxis)]
     Look,
+    CaptureCursor,
     Interact,
     Examine,
     Place,
@@ -103,6 +104,8 @@ pub(crate) struct BindingsConfig {
     pub movement: MoveBindings,
     #[serde(default = "default_interact", rename = "Interact")]
     pub interact: Vec<String>,
+    #[serde(default = "default_capture_cursor", rename = "CaptureCursor")]
+    pub capture_cursor: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
     pub examine: Vec<String>,
     #[serde(default = "default_place", rename = "Place")]
@@ -120,6 +123,7 @@ impl Default for BindingsConfig {
         Self {
             movement: MoveBindings::default(),
             interact: default_interact(),
+            capture_cursor: default_capture_cursor(),
             examine: default_examine(),
             place: default_place(),
             toggle_journal: default_toggle_journal(),
@@ -166,6 +170,9 @@ fn default_right() -> String {
 }
 fn default_interact() -> Vec<String> {
     vec!["E".into()]
+}
+fn default_capture_cursor() -> Vec<String> {
+    vec!["MouseLeft".into()]
 }
 fn default_examine() -> Vec<String> {
     vec!["Q".into()]
@@ -315,6 +322,11 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     );
 
     insert_bindings(&mut input_map, InputAction::Interact, &bindings.interact);
+    insert_bindings(
+        &mut input_map,
+        InputAction::CaptureCursor,
+        &bindings.capture_cursor,
+    );
     insert_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
     insert_bindings(&mut input_map, InputAction::Place, &bindings.place);
     insert_bindings(
@@ -351,6 +363,12 @@ mod tests {
         assert!(
             input_map.get_buttonlike(&InputAction::Interact).is_some(),
             "Interact should have bindings"
+        );
+        assert!(
+            input_map
+                .get_buttonlike(&InputAction::CaptureCursor)
+                .is_some(),
+            "CaptureCursor should have bindings"
         );
         assert!(
             input_map.get_buttonlike(&InputAction::Pause).is_some(),
@@ -409,10 +427,12 @@ sensitivity_y = 0.4
 [bindings]
 Move = { up = "I", down = "K", left = "J", right = "L" }
 Interact = ["F"]
+CaptureCursor = ["MouseRight"]
 "#;
         let config: InputConfig = toml::from_str(custom).expect("parse custom");
         assert_eq!(config.bindings.movement.up, "I");
         assert_eq!(config.bindings.interact, vec!["F"]);
+        assert_eq!(config.bindings.capture_cursor, vec!["MouseRight"]);
 
         let input_map = build_input_map(&config);
         let interact_bindings = input_map
@@ -433,17 +453,32 @@ Interact = ["F"]
             1,
             "Default config should bind exactly one key (E) to Interact"
         );
+        let default_capture = default_map
+            .get_buttonlike(&InputAction::CaptureCursor)
+            .expect("Default CaptureCursor should have bindings");
+        assert_eq!(
+            default_capture.len(),
+            1,
+            "Default config should bind exactly one input to CaptureCursor"
+        );
     }
 
     #[test]
     fn mouse_button_bindings_in_config() {
         let config_str = r#"
 [bindings]
+CaptureCursor = ["MouseLeft"]
 Interact = ["MouseLeft"]
 Examine = ["MouseRight"]
 "#;
         let config: InputConfig = toml::from_str(config_str).expect("parse mouse config");
         let input_map = build_input_map(&config);
+        assert!(
+            input_map
+                .get_buttonlike(&InputAction::CaptureCursor)
+                .is_some(),
+            "CaptureCursor should accept MouseButton bindings"
+        );
         assert!(
             input_map.get_buttonlike(&InputAction::Interact).is_some(),
             "Interact should accept MouseButton bindings"

--- a/src/player.rs
+++ b/src/player.rs
@@ -6,7 +6,7 @@
 //! stay level while the camera tilts up and down.
 //!
 //! Systems:
-//! - `cursor_grab`: captures the cursor on left-click, releases on Pause action
+//! - `cursor_grab`: captures the cursor on CaptureCursor action, releases on Pause
 //! - `player_look`: applies mouse delta to yaw (body) and pitch (camera)
 //! - `player_move`: WASD translation relative to facing, clamped to room bounds
 
@@ -70,22 +70,19 @@ pub(crate) fn spawn_player(mut commands: Commands, scene: Res<SceneConfig>) {
         });
 }
 
-/// Captures the cursor on left-click, releases it when the Pause action fires.
-/// Left-click is a raw input because "capture the window" is a UI interaction,
-/// not a game action — it doesn't go through the action mapping.
+/// Captures the cursor when the mapped CaptureCursor action fires, releases it
+/// when the Pause action fires.
 fn cursor_grab(
     mut cursor_options: Single<&mut CursorOptions>,
-    mouse: Res<ButtonInput<MouseButton>>,
     player_query: Query<&ActionState<InputAction>, With<Player>>,
 ) {
-    if mouse.just_pressed(MouseButton::Left) {
-        cursor_options.visible = false;
-        cursor_options.grab_mode = CursorGrabMode::Locked;
-    }
-
     let Ok(action_state) = player_query.single() else {
         return;
     };
+    if action_state.just_pressed(&InputAction::CaptureCursor) {
+        cursor_options.visible = false;
+        cursor_options.grab_mode = CursorGrabMode::Locked;
+    }
     if action_state.just_pressed(&InputAction::Pause) {
         cursor_options.visible = true;
         cursor_options.grab_mode = CursorGrabMode::None;


### PR DESCRIPTION
Closes #51
Depends on #66

## Summary
- add a dedicated `CaptureCursor` input action to the input config and action map
- route cursor capture through the mapped action instead of reading raw left-click in the player controller
- keep pause/release behavior unchanged while restoring the single action-mapped input path promised by Story 1.2

## Testing
- `cargo test input`
- pre-commit checks (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`)
