### PR TITLE
fix: use captured-mode helper across gameplay input gates

### DIFF
--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -19,14 +19,13 @@
 
 use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility};
 use bevy::prelude::*;
-use bevy::window::CursorGrabMode;
 
 use crate::fabricator::{ActivateIntent, InputSlot};
 use crate::input::InputAction;
 use crate::journal::RecordEncounter;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::{ConfidenceTracker, describe_thermal_observation};
-use crate::player::{Player, PlayerCamera};
+use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::Surface;
 
 use leafwing_input_manager::prelude::*;
@@ -221,7 +220,7 @@ fn emit_pickup_intent(
     cursor_options: Single<&bevy::window::CursorOptions>,
     mut writer: MessageWriter<PickupIntent>,
 ) {
-    if cursor_options.grab_mode != CursorGrabMode::Locked {
+    if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
     let Ok(action) = player_query.single() else {
@@ -237,7 +236,7 @@ fn emit_place_intent(
     cursor_options: Single<&bevy::window::CursorOptions>,
     mut writer: MessageWriter<PlaceIntent>,
 ) {
-    if cursor_options.grab_mode != CursorGrabMode::Locked {
+    if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
     let Ok(action) = player_query.single() else {
@@ -253,7 +252,7 @@ fn emit_activate_intent(
     cursor_options: Single<&bevy::window::CursorOptions>,
     mut writer: MessageWriter<ActivateIntent>,
 ) {
-    if cursor_options.grab_mode != CursorGrabMode::Locked {
+    if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
     let Ok(action) = player_query.single() else {
@@ -475,7 +474,7 @@ fn emit_examine_intent(
     cursor_options: Single<&bevy::window::CursorOptions>,
     mut writer: MessageWriter<ExamineIntent>,
 ) {
-    if cursor_options.grab_mode != CursorGrabMode::Locked {
+    if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
     let Ok(action) = player_query.single() else {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -9,13 +9,12 @@
 use std::collections::BTreeMap;
 
 use bevy::prelude::*;
-use bevy::window::CursorGrabMode;
 use leafwing_input_manager::prelude::*;
 
 use crate::input::InputAction;
 use crate::materials::GameMaterial;
 use crate::observation::{ConfidenceLevel, describe_thermal_observation};
-use crate::player::{Player, spawn_player};
+use crate::player::{Player, cursor_is_captured, spawn_player};
 
 pub(crate) struct JournalPlugin;
 
@@ -155,7 +154,7 @@ fn emit_toggle_journal_intent(
     cursor_options: Single<&bevy::window::CursorOptions>,
     mut writer: MessageWriter<ToggleJournalIntent>,
 ) {
-    if cursor_options.grab_mode == CursorGrabMode::None {
+    if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
 


### PR DESCRIPTION
Closes #52
Depends on #68

## Summary
- replace interaction and journal input gates that were still hard-coded to `Locked`
- use the shared captured-mode helper so gameplay input remains active when the platform/backend falls back to `Confined`
- keep `None` as the only uncaptured state that disables gameplay input

## Testing
- `cargo test interaction`
- `cargo test journal`
- pre-commit checks (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`)
