### PR TITLE
fix: correct material resting height and thermal behavior

### DIFF
--- a/assets/config/scene.toml
+++ b/assets/config/scene.toml
@@ -66,21 +66,6 @@ output_height = 0.02
 # How long the fabrication process takes (seconds).
 process_seconds = 2.5
 
-# Scene tuning — room geometry, lighting, and player spawn.
-# Edit these values instead of changing Rust constants.
-
-[lighting]
-ambient_brightness = 14.0
-directional_illuminance = 1100.0
-directional_shadows = true
-# Spot above workbench — lumens (Bevy PBR units).
-spot_intensity = 280_000.0
-spot_range = 12.0
-spot_inner_angle = 0.28
-spot_outer_angle = 0.48
-spot_height = 2.75
-spot_target_y = 0.45
-
 [heat_source]
 # Offset from workbench center — sits on the right side of the bench.
 offset_x = 0.55

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -15,7 +15,9 @@ use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
 use crate::journal::RecordFabrication;
-use crate::materials::{GameMaterial, MaterialObject, MaterialProperty, PropertyVisibility};
+use crate::materials::{
+    GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, MaterialProperty, PropertyVisibility,
+};
 use crate::scene::{SceneConfig, Workbench};
 
 pub(crate) struct FabricatorPlugin;
@@ -62,12 +64,14 @@ pub(crate) struct InputSlot {
     #[allow(dead_code)]
     pub index: usize,
     pub material: Option<Entity>,
+    pub top_y: f32,
 }
 
 /// Marks the fabricator output receptacle where the combined material appears.
 #[derive(Component, Debug)]
 pub(crate) struct OutputSlot {
     pub material: Option<Entity>,
+    pub top_y: f32,
 }
 
 // ── Slot spawning ───────────────────────────────────────────────────────
@@ -115,6 +119,7 @@ fn spawn_fabricator_slots(
             InputSlot {
                 index: i,
                 material: None,
+                top_y: pos.y + fab.slot_height * 0.5,
             },
             Mesh3d(meshes.add(Cylinder::new(fab.slot_radius, fab.slot_height))),
             MeshMaterial3d(slot_mat.clone()),
@@ -134,7 +139,10 @@ fn spawn_fabricator_slots(
     );
 
     commands.spawn((
-        OutputSlot { material: None },
+        OutputSlot {
+            material: None,
+            top_y: output_pos.y + fab.output_height * 0.5,
+        },
         Mesh3d(meshes.add(Cylinder::new(fab.output_radius, fab.output_height))),
         MeshMaterial3d(output_mat),
         Transform::from_translation(output_pos),
@@ -242,7 +250,11 @@ fn tick_processing(
             output_mat.clone(),
             Mesh3d(mesh),
             MeshMaterial3d(render_mat),
-            Transform::from_xyz(out_pos.x, out_pos.y + 0.1, out_pos.z),
+            Transform::from_xyz(
+                out_pos.x,
+                out_slot.top_y + output_mat.support_height() + MATERIAL_SURFACE_GAP,
+                out_pos.z,
+            ),
         ))
         .id();
 
@@ -389,6 +401,23 @@ pub(crate) fn rule_combine(
 
     let catalytic = has_catalytic_rule(&pair_rules);
     let color = blend_color(&a.color, &b.color, catalytic);
+    let thermal_resistance = apply_rule_with_perturbation(
+        &pair_rules.thermal_resistance,
+        &a.thermal_resistance,
+        &b.thermal_resistance,
+        combined_seed,
+        1,
+    );
+    let conductivity = align_conductivity_with_thermal_behavior(
+        apply_rule_with_perturbation(
+            &pair_rules.conductivity,
+            &a.conductivity,
+            &b.conductivity,
+            combined_seed,
+            3,
+        ),
+        thermal_resistance.value,
+    );
 
     GameMaterial {
         name,
@@ -404,13 +433,7 @@ pub(crate) fn rule_combine(
                 0,
             )
         },
-        thermal_resistance: apply_rule_with_perturbation(
-            &pair_rules.thermal_resistance,
-            &a.thermal_resistance,
-            &b.thermal_resistance,
-            combined_seed,
-            1,
-        ),
+        thermal_resistance,
         reactivity: apply_rule_with_perturbation(
             &pair_rules.reactivity,
             &a.reactivity,
@@ -418,13 +441,7 @@ pub(crate) fn rule_combine(
             combined_seed,
             2,
         ),
-        conductivity: apply_rule_with_perturbation(
-            &pair_rules.conductivity,
-            &a.conductivity,
-            &b.conductivity,
-            combined_seed,
-            3,
-        ),
+        conductivity,
         toxicity: apply_rule_with_perturbation(
             &pair_rules.toxicity,
             &a.toxicity,
@@ -433,6 +450,15 @@ pub(crate) fn rule_combine(
             4,
         ),
     }
+}
+
+fn align_conductivity_with_thermal_behavior(
+    mut conductivity: MaterialProperty,
+    thermal_resistance: f32,
+) -> MaterialProperty {
+    let thermal_conductivity = 1.0 - thermal_resistance;
+    conductivity.value = ((conductivity.value * 2.0) + thermal_conductivity) / 3.0;
+    conductivity
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -735,5 +761,22 @@ mod tests {
         assert!((r1.density.value - r2.density.value).abs() < f32::EPSILON);
         assert!((r1.thermal_resistance.value - r2.thermal_resistance.value).abs() < f32::EPSILON);
         assert!((r1.toxicity.value - r2.toxicity.value).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn fabricated_conductivity_tracks_thermal_conductivity_direction() {
+        let rules = default_rules();
+        let mut a = test_material("Alpha", 1, 0.2);
+        let mut b = test_material("Beta", 2, 0.3);
+        a.thermal_resistance.value = 0.1;
+        b.thermal_resistance.value = 0.2;
+        a.conductivity.value = 0.2;
+        b.conductivity.value = 0.2;
+
+        let result = rule_combine(&rules, &a, &b);
+        assert!(
+            result.conductivity.value > 0.2,
+            "expected conductivity to move upward for a thermally conductive result"
+        );
     }
 }

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -16,7 +16,6 @@
 
 use bevy::prelude::*;
 
-use crate::interaction::HeldItem;
 use crate::journal::RecordThermalObservation;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::ConfidenceTracker;
@@ -67,6 +66,24 @@ fn update_exposure_elapsed(elapsed: f32, in_zone: bool, delta_secs: f32) -> f32 
     } else {
         (elapsed - delta_secs).max(0.0)
     }
+}
+
+fn exposure_rate(thermal_resistance: f32) -> f32 {
+    let thermal_conductivity = 1.0 - thermal_resistance.clamp(0.0, 1.0);
+    0.35 + thermal_conductivity * 1.3
+}
+
+fn update_exposure_elapsed_for_material(
+    elapsed: f32,
+    in_zone: bool,
+    delta_secs: f32,
+    thermal_resistance: f32,
+) -> f32 {
+    update_exposure_elapsed(
+        elapsed,
+        in_zone,
+        delta_secs * exposure_rate(thermal_resistance),
+    )
 }
 
 /// Prevents a single material entity from incrementing confidence more than once.
@@ -132,8 +149,13 @@ fn track_heat_exposure(
     cfg: Res<SceneConfig>,
     heat_query: Query<&GlobalTransform, With<HeatSource>>,
     mut material_query: Query<
-        (Entity, &GlobalTransform, Option<&mut HeatExposure>),
-        (With<MaterialObject>, Without<HeldItem>),
+        (
+            Entity,
+            &GlobalTransform,
+            &GameMaterial,
+            Option<&mut HeatExposure>,
+        ),
+        With<MaterialObject>,
     >,
 ) {
     let Ok(heat_gtf) = heat_query.single() else {
@@ -143,14 +165,19 @@ fn track_heat_exposure(
     let zone_r_sq = cfg.heat_source.zone_radius * cfg.heat_source.zone_radius;
     let dt = time.delta_secs();
 
-    for (entity, mat_gtf, exposure) in &mut material_query {
+    for (entity, mat_gtf, mat, exposure) in &mut material_query {
         let dist_sq = mat_gtf.translation().distance_squared(heat_pos);
         let inside = dist_sq <= zone_r_sq;
 
         match exposure {
             Some(mut exp) => {
                 exp.in_zone = inside;
-                exp.elapsed = update_exposure_elapsed(exp.elapsed, inside, dt);
+                exp.elapsed = update_exposure_elapsed_for_material(
+                    exp.elapsed,
+                    inside,
+                    dt,
+                    mat.thermal_resistance.value,
+                );
             }
             None if inside => {
                 commands.entity(entity).insert(HeatExposure::new());
@@ -324,6 +351,13 @@ mod tests {
     fn exposure_elapsed_never_goes_below_zero() {
         let elapsed = update_exposure_elapsed(0.1, false, 0.25);
         assert!(elapsed.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn low_resistance_materials_change_temperature_faster() {
+        let low = update_exposure_elapsed_for_material(0.0, true, 1.0, 0.1);
+        let high = update_exposure_elapsed_for_material(0.0, true, 1.0, 0.9);
+        assert!(low > high);
     }
 
     #[test]

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -321,6 +321,7 @@ fn process_place(
     scene: Res<SceneConfig>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
+    player_query: Query<&GlobalTransform, With<Player>>,
     surfaces: Query<(Entity, &GlobalTransform), With<Surface>>,
     slot_target: Res<SlotTarget>,
     mut slot_query: Query<(&GlobalTransform, &mut InputSlot)>,
@@ -354,6 +355,9 @@ fn process_place(
         let Ok(cam_gtf) = camera_query.single() else {
             continue;
         };
+        let Ok(player_gtf) = player_query.single() else {
+            continue;
+        };
 
         commands
             .entity(held_entity)
@@ -375,7 +379,7 @@ fn process_place(
                     place_z,
                 )
             } else {
-                floor_drop_position(cam_gtf, &scene, held_material)
+                floor_drop_position(player_gtf, &scene, held_material)
             };
 
         commands
@@ -423,19 +427,19 @@ fn best_surface_for_ray<'a>(
 }
 
 fn floor_drop_position(
-    cam_gtf: &GlobalTransform,
+    player_gtf: &GlobalTransform,
     scene: &SceneConfig,
     material: &GameMaterial,
 ) -> Vec3 {
-    let origin = cam_gtf.translation();
-    let forward = *cam_gtf.forward();
+    let origin = player_gtf.translation();
+    let forward = *player_gtf.forward();
     let forward_xz = Vec3::new(forward.x, 0.0, forward.z).normalize_or_zero();
     let fallback_forward = if forward_xz == Vec3::ZERO {
         Vec3::NEG_Z
     } else {
         forward_xz
     };
-    let mut position = origin + fallback_forward * 1.0;
+    let mut position = origin + fallback_forward * 0.6;
     let margin = scene.room.boundary_margin;
     let max_x = scene.room.half_extent_x - margin;
     let max_z = scene.room.half_extent_z - margin;
@@ -795,9 +799,9 @@ mod tests {
     #[test]
     fn floor_drop_position_clamps_inside_room_bounds() {
         let scene = SceneConfig::default();
-        let cam = GlobalTransform::from(Transform::from_xyz(100.0, 1.7, 100.0));
+        let player = GlobalTransform::from(Transform::from_xyz(100.0, 1.7, 100.0));
         let material = test_material();
-        let dropped = floor_drop_position(&cam, &scene, &material);
+        let dropped = floor_drop_position(&player, &scene, &material);
         let max_x = scene.room.half_extent_x - scene.room.boundary_margin;
         let max_z = scene.room.half_extent_z - scene.room.boundary_margin;
 

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -322,7 +322,8 @@ fn process_place(
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
     player_query: Query<&GlobalTransform, With<Player>>,
-    surfaces: Query<(Entity, &GlobalTransform), With<Surface>>,
+    surfaces: Query<(Entity, &GlobalTransform, &Surface)>,
+    material_positions: Query<(Entity, &GlobalTransform, &GameMaterial), With<MaterialObject>>,
     slot_target: Res<SlotTarget>,
     mut slot_query: Query<(&GlobalTransform, &mut InputSlot)>,
 ) {
@@ -364,23 +365,39 @@ fn process_place(
             .remove::<HeldItem>()
             .remove_parent_in_place();
 
-        let drop_position =
-            if let Some((_entity, surface_gtf)) = best_surface_for_ray(cam_gtf, &surfaces) {
-                let surface_pos = surface_gtf.translation();
-                let cam_pos = cam_gtf.translation();
-                let cam_fwd = *cam_gtf.forward();
+        let drop_position = if let Some((_entity, surface_gtf, surface)) =
+            best_surface_for_ray(cam_gtf, &surfaces)
+        {
+            let surface_pos = surface_gtf.translation();
+            let cam_pos = cam_gtf.translation();
+            let cam_fwd = *cam_gtf.forward();
 
-                let hit = ray_horizontal_intersection(cam_pos, cam_fwd, surface_pos.y);
-                let place_x = hit.map_or(surface_pos.x, |p| p.x);
-                let place_z = hit.map_or(surface_pos.z, |p| p.z);
-                Vec3::new(
-                    place_x,
-                    held_material.resting_center_y(surface_pos.y),
-                    place_z,
+            let hit = ray_horizontal_intersection(cam_pos, cam_fwd, surface_pos.y);
+            let place_x = hit.map_or(surface_pos.x, |p| {
+                p.x.clamp(
+                    surface_pos.x - surface.half_extent_x,
+                    surface_pos.x + surface.half_extent_x,
                 )
+            });
+            let place_z = hit.map_or(surface_pos.z, |p| {
+                p.z.clamp(
+                    surface_pos.z - surface.half_extent_z,
+                    surface_pos.z + surface.half_extent_z,
+                )
+            });
+            let candidate = Vec3::new(
+                place_x,
+                held_material.resting_center_y(surface_pos.y),
+                place_z,
+            );
+            if can_place_material(held_entity, held_material, candidate, &material_positions) {
+                candidate
             } else {
                 floor_drop_position(player_gtf, &scene, held_material)
-            };
+            }
+        } else {
+            floor_drop_position(player_gtf, &scene, held_material)
+        };
 
         commands
             .entity(held_entity)
@@ -406,24 +423,53 @@ fn ray_horizontal_intersection(origin: Vec3, direction: Vec3, plane_y: f32) -> O
 /// center is closest to the intersection point.
 fn best_surface_for_ray<'a>(
     cam_gtf: &GlobalTransform,
-    surfaces: &'a Query<(Entity, &GlobalTransform), With<Surface>>,
-) -> Option<(Entity, &'a GlobalTransform)> {
+    surfaces: &'a Query<(Entity, &GlobalTransform, &Surface)>,
+) -> Option<(Entity, &'a GlobalTransform, &'a Surface)> {
     let origin = cam_gtf.translation();
     let direction = *cam_gtf.forward();
 
     surfaces
         .iter()
-        .filter_map(|(entity, sgtf)| {
+        .filter_map(|(entity, sgtf, surface)| {
             let s_pos = sgtf.translation();
             let hit = ray_horizontal_intersection(origin, direction, s_pos.y)?;
-            let xz_dist = Vec2::new(hit.x - s_pos.x, hit.z - s_pos.z).length();
+            let dx = hit.x - s_pos.x;
+            let dz = hit.z - s_pos.z;
+            if dx.abs() > surface.half_extent_x || dz.abs() > surface.half_extent_z {
+                return None;
+            }
+            let xz_dist = Vec2::new(dx, dz).length();
             if xz_dist > PLACE_REACH {
                 return None;
             }
-            Some((entity, sgtf, xz_dist))
+            Some((entity, sgtf, surface, xz_dist))
         })
-        .min_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(entity, sgtf, _)| (entity, sgtf))
+        .min_by(|a, b| a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(entity, sgtf, surface, _)| (entity, sgtf, surface))
+}
+
+fn can_place_material(
+    held_entity: Entity,
+    held_material: &GameMaterial,
+    candidate: Vec3,
+    material_positions: &Query<(Entity, &GlobalTransform, &GameMaterial), With<MaterialObject>>,
+) -> bool {
+    let held_radius = held_material.footprint_radius();
+    material_positions.iter().all(|(entity, gtf, material)| {
+        if entity == held_entity {
+            return true;
+        }
+
+        let other = gtf.translation();
+        let same_level = (other.y - candidate.y).abs() < 0.25;
+        if !same_level {
+            return true;
+        }
+
+        let required_gap = held_radius + material.footprint_radius();
+        let xz_dist = Vec2::new(other.x - candidate.x, other.z - candidate.z).length();
+        xz_dist >= required_gap
+    })
 }
 
 fn floor_drop_position(

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -432,7 +432,14 @@ fn floor_drop_position(
     material: &GameMaterial,
 ) -> Vec3 {
     let origin = player_gtf.translation();
-    let mut position = Vec3::new(origin.x, 0.0, origin.z);
+    let forward = *player_gtf.forward();
+    let forward_xz = Vec3::new(forward.x, 0.0, forward.z).normalize_or_zero();
+    let fallback_forward = if forward_xz == Vec3::ZERO {
+        Vec3::NEG_Z
+    } else {
+        forward_xz
+    };
+    let mut position = Vec3::new(origin.x, 0.0, origin.z) + fallback_forward * 0.35;
     let margin = scene.room.boundary_margin;
     let max_x = scene.room.half_extent_x - margin;
     let max_z = scene.room.half_extent_z - margin;
@@ -811,7 +818,7 @@ mod tests {
         let dropped = floor_drop_position(&player, &scene, &material);
 
         assert!((dropped.x - 1.25).abs() < f32::EPSILON);
-        assert!((dropped.z + 0.75).abs() < f32::EPSILON);
+        assert!((dropped.z - (-1.10)).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -432,14 +432,7 @@ fn floor_drop_position(
     material: &GameMaterial,
 ) -> Vec3 {
     let origin = player_gtf.translation();
-    let forward = *player_gtf.forward();
-    let forward_xz = Vec3::new(forward.x, 0.0, forward.z).normalize_or_zero();
-    let fallback_forward = if forward_xz == Vec3::ZERO {
-        Vec3::NEG_Z
-    } else {
-        forward_xz
-    };
-    let mut position = origin + fallback_forward * 0.6;
+    let mut position = Vec3::new(origin.x, 0.0, origin.z);
     let margin = scene.room.boundary_margin;
     let max_x = scene.room.half_extent_x - margin;
     let max_z = scene.room.half_extent_z - margin;
@@ -808,6 +801,17 @@ mod tests {
         assert!(dropped.x <= max_x);
         assert!(dropped.z <= max_z);
         assert!((dropped.y - material.resting_center_y(0.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn floor_drop_position_uses_player_floor_position() {
+        let scene = SceneConfig::default();
+        let player = GlobalTransform::from(Transform::from_xyz(1.25, 1.7, -0.75));
+        let material = test_material();
+        let dropped = floor_drop_position(&player, &scene, &material);
+
+        assert!((dropped.x - 1.25).abs() < f32::EPSILON);
+        assert!((dropped.z + 0.75).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -23,10 +23,10 @@ use bevy::prelude::*;
 use crate::fabricator::{ActivateIntent, InputSlot};
 use crate::input::InputAction;
 use crate::journal::RecordEncounter;
-use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
+use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
 use crate::observation::{ConfidenceTracker, describe_thermal_observation};
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
-use crate::scene::Surface;
+use crate::scene::{SceneConfig, Surface};
 
 use leafwing_input_manager::prelude::*;
 
@@ -310,22 +310,23 @@ fn process_pickup(
 }
 
 /// Small gap above the surface so objects sit on top without z-fighting.
-const PLACE_GAP: f32 = 0.1;
 /// Maximum XZ distance from the ray's intersection to a surface center for
 /// placement to be considered valid.
 const PLACE_REACH: f32 = 2.5;
 
+#[allow(clippy::too_many_arguments)]
 fn process_place(
     mut commands: Commands,
     mut reader: MessageReader<PlaceIntent>,
-    held_query: Query<Entity, With<HeldItem>>,
+    scene: Res<SceneConfig>,
+    held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
     surfaces: Query<(Entity, &GlobalTransform), With<Surface>>,
     slot_target: Res<SlotTarget>,
     mut slot_query: Query<(&GlobalTransform, &mut InputSlot)>,
 ) {
     for _intent in reader.read() {
-        let Some(held_entity) = held_query.iter().next() else {
+        let Some((held_entity, held_material)) = held_query.iter().next() else {
             continue;
         };
 
@@ -343,7 +344,7 @@ fn process_place(
                 .remove_parent_in_place()
                 .insert(Transform::from_xyz(
                     slot_pos.x,
-                    slot_pos.y + PLACE_GAP,
+                    slot.top_y + held_material.support_height() + MATERIAL_SURFACE_GAP,
                     slot_pos.z,
                 ));
             continue;
@@ -354,28 +355,32 @@ fn process_place(
             continue;
         };
 
-        let Some((_entity, surface_gtf)) = best_surface_for_ray(cam_gtf, &surfaces) else {
-            continue;
-        };
-
         commands
             .entity(held_entity)
             .remove::<HeldItem>()
             .remove_parent_in_place();
 
-        let surface_pos = surface_gtf.translation();
-        let cam_pos = cam_gtf.translation();
-        let cam_fwd = *cam_gtf.forward();
+        let drop_position =
+            if let Some((_entity, surface_gtf)) = best_surface_for_ray(cam_gtf, &surfaces) {
+                let surface_pos = surface_gtf.translation();
+                let cam_pos = cam_gtf.translation();
+                let cam_fwd = *cam_gtf.forward();
 
-        let hit = ray_horizontal_intersection(cam_pos, cam_fwd, surface_pos.y);
-        let place_x = hit.map_or(surface_pos.x, |p| p.x);
-        let place_z = hit.map_or(surface_pos.z, |p| p.z);
+                let hit = ray_horizontal_intersection(cam_pos, cam_fwd, surface_pos.y);
+                let place_x = hit.map_or(surface_pos.x, |p| p.x);
+                let place_z = hit.map_or(surface_pos.z, |p| p.z);
+                Vec3::new(
+                    place_x,
+                    held_material.resting_center_y(surface_pos.y),
+                    place_z,
+                )
+            } else {
+                floor_drop_position(cam_gtf, &scene, held_material)
+            };
 
-        commands.entity(held_entity).insert(Transform::from_xyz(
-            place_x,
-            surface_pos.y + PLACE_GAP,
-            place_z,
-        ));
+        commands
+            .entity(held_entity)
+            .insert(Transform::from_translation(drop_position));
     }
 }
 
@@ -415,6 +420,29 @@ fn best_surface_for_ray<'a>(
         })
         .min_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(entity, sgtf, _)| (entity, sgtf))
+}
+
+fn floor_drop_position(
+    cam_gtf: &GlobalTransform,
+    scene: &SceneConfig,
+    material: &GameMaterial,
+) -> Vec3 {
+    let origin = cam_gtf.translation();
+    let forward = *cam_gtf.forward();
+    let forward_xz = Vec3::new(forward.x, 0.0, forward.z).normalize_or_zero();
+    let fallback_forward = if forward_xz == Vec3::ZERO {
+        Vec3::NEG_Z
+    } else {
+        forward_xz
+    };
+    let mut position = origin + fallback_forward * 1.0;
+    let margin = scene.room.boundary_margin;
+    let max_x = scene.room.half_extent_x - margin;
+    let max_z = scene.room.half_extent_z - margin;
+    position.x = position.x.clamp(-max_x, max_x);
+    position.z = position.z.clamp(-max_z, max_z);
+    position.y = material.resting_center_y(0.0);
+    position
 }
 
 // ── Held item tracking ───────────────────────────────────────────────────
@@ -762,6 +790,20 @@ mod tests {
         assert!(should_emit_place(false, true, true));
         assert!(!should_emit_place(false, false, true));
         assert!(!should_emit_place(true, false, false));
+    }
+
+    #[test]
+    fn floor_drop_position_clamps_inside_room_bounds() {
+        let scene = SceneConfig::default();
+        let cam = GlobalTransform::from(Transform::from_xyz(100.0, 1.7, 100.0));
+        let material = test_material();
+        let dropped = floor_drop_position(&cam, &scene, &material);
+        let max_x = scene.room.half_extent_x - scene.room.boundary_margin;
+        let max_z = scene.room.half_extent_z - scene.room.boundary_margin;
+
+        assert!(dropped.x <= max_x);
+        assert!(dropped.z <= max_z);
+        assert!((dropped.y - material.resting_center_y(0.0)).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Serialize};
 use crate::scene::Shelf;
 pub(crate) struct MaterialPlugin;
 
+pub(crate) const MATERIAL_SURFACE_GAP: f32 = 0.01;
+
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreStartup, load_material_catalog)
@@ -97,6 +99,22 @@ impl GameMaterial {
         } else {
             meshes.add(Cuboid::new(0.18, 0.18, 0.18))
         }
+    }
+
+    /// Height from the support surface to the entity origin for the selected mesh.
+    pub(crate) fn support_height(&self) -> f32 {
+        let density = self.density.value;
+        if density < 0.3 {
+            0.12
+        } else if density < 0.7 {
+            0.17
+        } else {
+            0.09
+        }
+    }
+
+    pub(crate) fn resting_center_y(&self, surface_y: f32) -> f32 {
+        surface_y + self.support_height() + MATERIAL_SURFACE_GAP
     }
 }
 
@@ -173,7 +191,7 @@ fn spawn_material_objects(
             MeshMaterial3d(render_mat),
             Transform::from_xyz(
                 surface_tf.translation.x + x_offset,
-                surface_tf.translation.y + 0.1,
+                mat.resting_center_y(surface_tf.translation.y),
                 surface_tf.translation.z,
             )
             .with_scale(Vec3::splat(OBJECT_SCALE)),
@@ -257,6 +275,20 @@ mod tests {
             conductivity: prop(0.72, PropertyVisibility::Hidden),
             toxicity: prop(0.05, PropertyVisibility::Hidden),
         }
+    }
+
+    #[test]
+    fn support_height_matches_density_mesh_shape() {
+        let mut light = sample_material();
+        light.density.value = 0.2;
+        assert!((light.support_height() - 0.12).abs() < f32::EPSILON);
+
+        let mut medium = sample_material();
+        medium.density.value = 0.5;
+        assert!((medium.support_height() - 0.17).abs() < f32::EPSILON);
+
+        let heavy = sample_material();
+        assert!((heavy.support_height() - 0.09).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -116,6 +116,17 @@ impl GameMaterial {
     pub(crate) fn resting_center_y(&self, surface_y: f32) -> f32 {
         surface_y + self.support_height() + MATERIAL_SURFACE_GAP
     }
+
+    pub(crate) fn footprint_radius(&self) -> f32 {
+        let density = self.density.value;
+        if density < 0.3 {
+            0.12
+        } else if density < 0.7 {
+            0.10
+        } else {
+            0.13
+        }
+    }
 }
 
 // ── Catalog resource ─────────────────────────────────────────────────────
@@ -289,6 +300,20 @@ mod tests {
 
         let heavy = sample_material();
         assert!((heavy.support_height() - 0.09).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn footprint_radius_matches_density_mesh_shape() {
+        let mut light = sample_material();
+        light.density.value = 0.2;
+        assert!((light.footprint_radius() - 0.12).abs() < f32::EPSILON);
+
+        let mut medium = sample_material();
+        medium.density.value = 0.5;
+        assert!((medium.footprint_radius() - 0.10).abs() < f32::EPSILON);
+
+        let heavy = sample_material();
+        assert!((heavy.footprint_radius() - 0.13).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -30,7 +30,10 @@ pub(crate) struct Workbench;
 /// can be set down. Spawned as its own entity at the true surface Y so
 /// the placement system never needs offset math.
 #[derive(Component)]
-pub(crate) struct Surface;
+pub(crate) struct Surface {
+    pub half_extent_x: f32,
+    pub half_extent_z: f32,
+}
 
 /// Distinguishes storage shelves from the experiment workbench so initial
 /// material spawning only targets shelves.
@@ -531,7 +534,10 @@ fn setup_scene(
     ));
     // Placement plane at the true top of the workbench.
     commands.spawn((
-        Surface,
+        Surface {
+            half_extent_x: fur.workbench_width * 0.5,
+            half_extent_z: fur.workbench_depth * 0.5,
+        },
         Transform::from_xyz(fur.workbench_x, fur.workbench_height, fur.workbench_z),
     ));
 
@@ -554,7 +560,10 @@ fn setup_scene(
         ));
         // Placement plane at the true top of each shelf.
         commands.spawn((
-            Surface,
+            Surface {
+                half_extent_x: shelf_w * 0.5,
+                half_extent_z: shelf_d * 0.5,
+            },
             Shelf,
             Transform::from_xyz(shelf.x, shelf.y, shelf.z),
         ));


### PR DESCRIPTION
Depends on #71

## Summary
- correct material resting height across shelves, slot placement, output placement, and floor drops so shapes sit on visible surfaces instead of intersecting or hovering
- make thermal exposure and cooling rates respond to thermal resistance while keeping observation/reveal behavior intact
- constrain looked-at placement to real bounded surface footprints and reject overlapping placements so minerals cannot be placed into each other or onto invalid off-surface points

## Testing
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
