### PR TITLE
feat: kanban board deployment — Docker image, CI publish, runtime config

### DIFF
--- a/.github/workflows/kanban-publish.yml
+++ b/.github/workflows/kanban-publish.yml
@@ -33,13 +33,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get short SHA
+        if: github.event_name == 'pull_request'
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build and push (PR)
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: ./kanban
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/apeiron-kanban:${{ github.sha }}
+          tags: ghcr.io/${{ github.repository_owner }}/apeiron-kanban:${{ steps.sha.outputs.short }}
 
       - name: Run semantic-release
         if: github.event_name == 'push'

--- a/.github/workflows/kanban-publish.yml
+++ b/.github/workflows/kanban-publish.yml
@@ -1,0 +1,65 @@
+name: Publish Kanban Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "kanban/**"
+  pull_request:
+    paths:
+      - "kanban/**"
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./kanban
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/apeiron-kanban:${{ github.sha }}
+
+      - name: Run semantic-release
+        if: github.event_name == 'push'
+        id: semrel
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          working_directory: ./kanban
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (main)
+        if: github.event_name == 'push' && steps.semrel.outputs.new_release_published == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./kanban
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/apeiron-kanban:${{ steps.semrel.outputs.new_release_version }}
+            ghcr.io/${{ github.repository_owner }}/apeiron-kanban:latest

--- a/infra/n8n/docker-compose.yml
+++ b/infra/n8n/docker-compose.yml
@@ -44,6 +44,14 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
 
+  kanban:
+    image: ghcr.io/galamdring/apeiron-kanban:latest
+    restart: unless-stopped
+    # Serves on port 80 internally — point the Cloudflare tunnel at http://kanban:80
+    # To override config for a custom deployment, mount your own config.json:
+    # volumes:
+    #   - ./kanban-config.json:/usr/share/nginx/html/config.json:ro
+
   cloudflared:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
@@ -52,6 +60,7 @@ services:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     depends_on:
       - n8n
+      - kanban
 
 volumes:
   n8n_data:

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -3,12 +3,16 @@
 #
 # Configure your GitHub App with:
 #   - Homepage URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban
-#   - Callback URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
+#   - Callback URL:        <your n8n webhook URL> (swap for orchestrator URL when ready)
 #   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook
 #   - Webhook secret:      <random string, also set as WEBHOOK_SECRET on the server>
 #   - Permissions:         Issues (read/write), Pull requests (read), Metadata (read)
 #   - Subscribe to events: Issues, Issue comment, Label
 #
 # Only the Client ID lives in the frontend. The Client Secret lives ONLY in
-# the orchestrator environment as GITHUB_CLIENT_SECRET.
+# the n8n workflow (or orchestrator environment) as GITHUB_CLIENT_SECRET.
 VITE_GITHUB_CLIENT_ID=your_github_app_client_id_here
+
+# OAuth callback URL — point at n8n webhook for now, swap to orchestrator when ready:
+# VITE_AUTH_CALLBACK_URL=https://your-n8n-instance.com/webhook/kanban/auth/callback
+VITE_AUTH_CALLBACK_URL=https://your-n8n-instance.com/webhook/kanban/auth/callback

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -3,8 +3,8 @@
 #
 # Configure your GitHub App with:
 #   - Homepage URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban
-#   - Callback URL:        https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback
-#   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook/github
+#   - Callback URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
+#   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook
 #   - Webhook secret:      <random string, also set as WEBHOOK_SECRET in n8n>
 #   - Permissions:         Issues (read/write), Pull requests (read), Metadata (read)
 #   - Subscribe to events: Issues, Issue comment, Label
@@ -20,4 +20,4 @@ VITE_GITHUB_CLIENT_ID=your_github_app_client_id_here
 
 # OAuth callback URL — currently handled by n8n, will be handled by the
 # orchestrator once it is stood up behind the tunnel.
-VITE_AUTH_CALLBACK_URL=https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback
+VITE_AUTH_CALLBACK_URL=https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -3,16 +3,21 @@
 #
 # Configure your GitHub App with:
 #   - Homepage URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban
-#   - Callback URL:        <your n8n webhook URL> (swap for orchestrator URL when ready)
-#   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook
-#   - Webhook secret:      <random string, also set as WEBHOOK_SECRET on the server>
+#   - Callback URL:        https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback
+#   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook/github
+#   - Webhook secret:      <random string, also set as WEBHOOK_SECRET in n8n>
 #   - Permissions:         Issues (read/write), Pull requests (read), Metadata (read)
 #   - Subscribe to events: Issues, Issue comment, Label
 #
+# The OAuth callback is currently handled by an n8n workflow at the URL above.
+# When the orchestrator is stood up behind the tunnel, the tunnel will be
+# repointed and the same URL will be handled by the orchestrator instead —
+# no frontend changes needed.
+#
 # Only the Client ID lives in the frontend. The Client Secret lives ONLY in
-# the n8n workflow (or orchestrator environment) as GITHUB_CLIENT_SECRET.
+# the n8n workflow credential (or later, the orchestrator environment).
 VITE_GITHUB_CLIENT_ID=your_github_app_client_id_here
 
-# OAuth callback URL — point at n8n webhook for now, swap to orchestrator when ready:
-# VITE_AUTH_CALLBACK_URL=https://your-n8n-instance.com/webhook/kanban/auth/callback
-VITE_AUTH_CALLBACK_URL=https://your-n8n-instance.com/webhook/kanban/auth/callback
+# OAuth callback URL — currently handled by n8n, will be handled by the
+# orchestrator once it is stood up behind the tunnel.
+VITE_AUTH_CALLBACK_URL=https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -1,11 +1,14 @@
-# GitHub App Client ID (preferred - supports both user login and webhooks)
+# GitHub App Client ID
 # Create at: https://github.com/settings/apps/new
-# Set the following on your GitHub App:
-#   - Webhook URL: https://apeiron-orchestrator.lukemckechnie.com/webhooks/github
-#   - Callback URL: https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
-#   - Permissions: Issues (read/write), Pull requests (read), Metadata (read)
+#
+# Configure your GitHub App with:
+#   - Homepage URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban
+#   - Callback URL:        https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
+#   - Webhook URL:         https://apeiron-orchestrator.lukemckechnie.com/webhook
+#   - Webhook secret:      <random string, also set as WEBHOOK_SECRET on the server>
+#   - Permissions:         Issues (read/write), Pull requests (read), Metadata (read)
 #   - Subscribe to events: Issues, Issue comment, Label
 #
-# For the OAuth device flow (current), only the Client ID is needed in the frontend.
-# The Client Secret lives only in the orchestrator backend for the web flow exchange.
+# Only the Client ID lives in the frontend. The Client Secret lives ONLY in
+# the orchestrator environment as GITHUB_CLIENT_SECRET.
 VITE_GITHUB_CLIENT_ID=your_github_app_client_id_here

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -1,1 +1,11 @@
-VITE_GITHUB_CLIENT_ID=your_oauth_app_client_id_here
+# GitHub App Client ID (preferred - supports both user login and webhooks)
+# Create at: https://github.com/settings/apps/new
+# Set the following on your GitHub App:
+#   - Webhook URL: https://apeiron-orchestrator.lukemckechnie.com/webhooks/github
+#   - Callback URL: https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
+#   - Permissions: Issues (read/write), Pull requests (read), Metadata (read)
+#   - Subscribe to events: Issues, Issue comment, Label
+#
+# For the OAuth device flow (current), only the Client ID is needed in the frontend.
+# The Client Secret lives only in the orchestrator backend for the web flow exchange.
+VITE_GITHUB_CLIENT_ID=your_github_app_client_id_here

--- a/kanban/.env.example
+++ b/kanban/.env.example
@@ -1,0 +1,1 @@
+VITE_GITHUB_CLIENT_ID=your_oauth_app_client_id_here

--- a/kanban/.releaserc.json
+++ b/kanban/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "tagFormat": "kanban-v${version}",
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/kanban/Dockerfile
+++ b/kanban/Dockerfile
@@ -1,0 +1,26 @@
+# ---- build stage ----
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+# ---- serve stage ----
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# SPA routing: all paths serve index.html so react-router-dom handles them
+RUN printf 'server {\n\
+    listen 80;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / {\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/kanban/index.html
+++ b/kanban/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GitHub Kanban</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; height: 100vh; }
+      #root { height: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/kanban/package.json
+++ b/kanban/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "github-kanban",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "axios": "^1.6.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "vite": "^5.2.11"
+  }
+}

--- a/kanban/public/config.json
+++ b/kanban/public/config.json
@@ -1,0 +1,4 @@
+{
+  "githubClientId": "Iv23lisdJkaJCknZAoUS",
+  "authCallbackUrl": "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback"
+}

--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Header from "./components/Header";
 import Sidebar from "./components/Sidebar";
 import Board from "./components/Board";
 import IssueDetail from "./components/IssueDetail";
 import LoginScreen from "./components/LoginScreen";
+import { parseTokenFromHash, fetchAuthenticatedUser } from "./api/auth";
 import { useIssueStore } from "./store/issues";
 import { useAuthStore } from "./store/auth";
 
@@ -19,19 +20,64 @@ const styles = {
     flex: 1,
     overflow: "hidden",
   },
+  loading: {
+    height: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "#0d1117",
+    color: "#8b949e",
+    fontSize: 14,
+  },
 };
 
 export default function App() {
-  const { token, user } = useAuthStore();
+  const { token, user, setAuth } = useAuthStore();
   const selectedIssue = useIssueStore((s) => s.selectedIssue);
+  const [bootstrapping, setBootstrapping] = useState(true);
+  const [hashError, setHashError] = useState(null);
 
   const [repo, setRepo] = useState(() => {
     return localStorage.getItem("gh_kanban_repo") || "";
   });
 
-  // If not logged in, show the login screen
+  useEffect(() => {
+    async function handleCallback() {
+      const { token: hashToken, error: hashErr } = parseTokenFromHash();
+
+      if (hashErr) {
+        setHashError(hashErr);
+        window.history.replaceState(null, "", window.location.pathname);
+        setBootstrapping(false);
+        return;
+      }
+
+      if (hashToken) {
+        try {
+          const userData = await fetchAuthenticatedUser(hashToken);
+          setAuth(hashToken, userData);
+        } catch (e) {
+          setHashError("Failed to fetch user profile after login");
+        }
+        // Clean the hash so the token doesn't sit in the address bar
+        window.history.replaceState(null, "", window.location.pathname);
+        setBootstrapping(false);
+        return;
+      }
+
+      // No hash — normal load, existing session (if any) is already in the store
+      setBootstrapping(false);
+    }
+
+    handleCallback();
+  }, []);
+
+  if (bootstrapping) {
+    return <div style={styles.loading}>Loading…</div>;
+  }
+
   if (!token || !user) {
-    return <LoginScreen />;
+    return <LoginScreen error={hashError} />;
   }
 
   function handleRepoChange(newRepo) {

--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -3,7 +3,9 @@ import Header from "./components/Header";
 import Sidebar from "./components/Sidebar";
 import Board from "./components/Board";
 import IssueDetail from "./components/IssueDetail";
+import LoginScreen from "./components/LoginScreen";
 import { useIssueStore } from "./store/issues";
+import { useAuthStore } from "./store/auth";
 
 const styles = {
   app: {
@@ -20,19 +22,21 @@ const styles = {
 };
 
 export default function App() {
+  const { token, user } = useAuthStore();
+  const selectedIssue = useIssueStore((s) => s.selectedIssue);
+
   const [repo, setRepo] = useState(() => {
     return localStorage.getItem("gh_kanban_repo") || "";
   });
-  const [token, setToken] = useState(() => {
-    return localStorage.getItem("gh_kanban_token") || "";
-  });
-  const selectedIssue = useIssueStore((s) => s.selectedIssue);
 
-  function handleRepoChange(newRepo, newToken) {
+  // If not logged in, show the login screen
+  if (!token || !user) {
+    return <LoginScreen />;
+  }
+
+  function handleRepoChange(newRepo) {
     setRepo(newRepo);
-    setToken(newToken);
     localStorage.setItem("gh_kanban_repo", newRepo);
-    localStorage.setItem("gh_kanban_token", newToken);
   }
 
   return (

--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -31,7 +31,7 @@ const styles = {
   },
 };
 
-export default function App() {
+export default function App({ config }) {
   const { token, user, setAuth } = useAuthStore();
   const selectedIssue = useIssueStore((s) => s.selectedIssue);
   const [bootstrapping, setBootstrapping] = useState(true);
@@ -77,7 +77,7 @@ export default function App() {
   }
 
   if (!token || !user) {
-    return <LoginScreen error={hashError} />;
+    return <LoginScreen error={hashError} config={config} />;
   }
 
   function handleRepoChange(newRepo) {

--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import Header from "./components/Header";
+import Sidebar from "./components/Sidebar";
+import Board from "./components/Board";
+import IssueDetail from "./components/IssueDetail";
+import { useIssueStore } from "./store/issues";
+
+const styles = {
+  app: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100vh",
+    overflow: "hidden",
+  },
+  body: {
+    display: "flex",
+    flex: 1,
+    overflow: "hidden",
+  },
+};
+
+export default function App() {
+  const [repo, setRepo] = useState(() => {
+    return localStorage.getItem("gh_kanban_repo") || "";
+  });
+  const [token, setToken] = useState(() => {
+    return localStorage.getItem("gh_kanban_token") || "";
+  });
+  const selectedIssue = useIssueStore((s) => s.selectedIssue);
+
+  function handleRepoChange(newRepo, newToken) {
+    setRepo(newRepo);
+    setToken(newToken);
+    localStorage.setItem("gh_kanban_repo", newRepo);
+    localStorage.setItem("gh_kanban_token", newToken);
+  }
+
+  return (
+    <div style={styles.app}>
+      <Header repo={repo} onRepoChange={handleRepoChange} />
+      <div style={styles.body}>
+        <Sidebar />
+        <Board repo={repo} token={token} />
+      </div>
+      {selectedIssue && <IssueDetail repo={repo} token={token} />}
+    </div>
+  );
+}

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -2,12 +2,12 @@ import axios from "axios";
 
 const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
 
-// OAuth callback URL — currently handled by an n8n workflow.
-// When the orchestrator is stood up behind the tunnel this URL will be handled
-// by the orchestrator instead, with no frontend changes needed.
+// n8n enforces a /webhook/ prefix on all webhook nodes.
+// When the orchestrator is stood up behind the tunnel this URL will change to:
+// https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
 const CALLBACK_URL =
   import.meta.env.VITE_AUTH_CALLBACK_URL ||
-  "https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback";
+  "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback";
 
 /**
  * Redirect the browser to GitHub's OAuth authorisation page.

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -1,83 +1,38 @@
 import axios from "axios";
 
 const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
-
-// GitHub requires device flow requests to go through a proxy or backend
-// because browsers can't POST to github.com directly (CORS). We use a
-// small Vite dev proxy (see vite.config.js) that forwards /github-oauth
-// to https://github.com.
-const gh = axios.create({ baseURL: "/" });
+const CALLBACK_URL = "https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback";
 
 /**
- * Step 1 — request a device + user code pair.
- * Returns { device_code, user_code, verification_uri, expires_in, interval }
+ * Redirect the browser to GitHub's OAuth authorisation page.
+ * GitHub will redirect back to CALLBACK_URL?code=... after the user approves.
+ * The orchestrator backend exchanges the code for a token and redirects to
+ * the frontend with #token=... in the hash.
  */
-export async function requestDeviceCode() {
-  const { data } = await gh.post(
-    "/github-oauth/login/device/code",
-    { client_id: CLIENT_ID, scope: "repo" },
-    { headers: { Accept: "application/json" } }
-  );
-  return data;
+export function redirectToGitHubLogin() {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    redirect_uri: CALLBACK_URL,
+    scope: "repo",
+  });
+  window.location.href = `https://github.com/login/oauth/authorize?${params}`;
 }
 
 /**
- * Step 2 — poll until the user authorises or the code expires.
- * Resolves with the access token string on success.
- * Rejects with an error message on failure/expiry.
+ * After GitHub redirects back to the frontend with #token=... or #error=...,
+ * parse the hash and return { token, error }.
  */
-export async function pollForToken(deviceCode, intervalSeconds) {
-  const delay = (ms) => new Promise((r) => setTimeout(r, ms));
-  const pollInterval = Math.max(intervalSeconds, 5) * 1000;
-
-  while (true) {
-    await delay(pollInterval);
-    try {
-      const { data } = await gh.post(
-        "/github-oauth/login/oauth/access_token",
-        {
-          client_id: CLIENT_ID,
-          device_code: deviceCode,
-          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-        },
-        { headers: { Accept: "application/json" } }
-      );
-
-      if (data.access_token) {
-        return data.access_token;
-      }
-
-      if (data.error === "authorization_pending") {
-        // User hasn't approved yet — keep polling
-        continue;
-      }
-
-      if (data.error === "slow_down") {
-        // GitHub asked us to back off — add 5 extra seconds
-        await delay(5000);
-        continue;
-      }
-
-      if (data.error === "expired_token") {
-        throw new Error("Login code expired. Please try again.");
-      }
-
-      if (data.error === "access_denied") {
-        throw new Error("Access denied. You cancelled the login.");
-      }
-
-      throw new Error(data.error_description || data.error || "Login failed");
-    } catch (e) {
-      if (e?.response) {
-        throw new Error(e.response.data?.error_description || "Login failed");
-      }
-      throw e;
-    }
-  }
+export function parseTokenFromHash() {
+  const hash = window.location.hash.slice(1);
+  const params = new URLSearchParams(hash);
+  return {
+    token: params.get("token") || null,
+    error: params.get("error") || null,
+  };
 }
 
 /**
- * Fetch the authenticated user's login from the GitHub API.
+ * Fetch the authenticated user's profile from the GitHub API.
  */
 export async function fetchAuthenticatedUser(token) {
   const { data } = await axios.get("https://api.github.com/user", {

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -1,13 +1,17 @@
 import axios from "axios";
 
 const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
-const CALLBACK_URL = "https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback";
+
+// Points at the n8n webhook that handles the OAuth code exchange.
+// When the orchestrator is ready, change this to:
+// https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
+const CALLBACK_URL = import.meta.env.VITE_AUTH_CALLBACK_URL;
 
 /**
  * Redirect the browser to GitHub's OAuth authorisation page.
  * GitHub will redirect back to CALLBACK_URL?code=... after the user approves.
- * The orchestrator backend exchanges the code for a token and redirects to
- * the frontend with #token=... in the hash.
+ * The callback handler (n8n or orchestrator) exchanges the code for a token
+ * and redirects to the frontend with #token=... in the hash.
  */
 export function redirectToGitHubLogin() {
   const params = new URLSearchParams({

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -1,0 +1,90 @@
+import axios from "axios";
+
+const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
+
+// GitHub requires device flow requests to go through a proxy or backend
+// because browsers can't POST to github.com directly (CORS). We use a
+// small Vite dev proxy (see vite.config.js) that forwards /github-oauth
+// to https://github.com.
+const gh = axios.create({ baseURL: "/" });
+
+/**
+ * Step 1 — request a device + user code pair.
+ * Returns { device_code, user_code, verification_uri, expires_in, interval }
+ */
+export async function requestDeviceCode() {
+  const { data } = await gh.post(
+    "/github-oauth/login/device/code",
+    { client_id: CLIENT_ID, scope: "repo" },
+    { headers: { Accept: "application/json" } }
+  );
+  return data;
+}
+
+/**
+ * Step 2 — poll until the user authorises or the code expires.
+ * Resolves with the access token string on success.
+ * Rejects with an error message on failure/expiry.
+ */
+export async function pollForToken(deviceCode, intervalSeconds) {
+  const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+  const pollInterval = Math.max(intervalSeconds, 5) * 1000;
+
+  while (true) {
+    await delay(pollInterval);
+    try {
+      const { data } = await gh.post(
+        "/github-oauth/login/oauth/access_token",
+        {
+          client_id: CLIENT_ID,
+          device_code: deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        },
+        { headers: { Accept: "application/json" } }
+      );
+
+      if (data.access_token) {
+        return data.access_token;
+      }
+
+      if (data.error === "authorization_pending") {
+        // User hasn't approved yet — keep polling
+        continue;
+      }
+
+      if (data.error === "slow_down") {
+        // GitHub asked us to back off — add 5 extra seconds
+        await delay(5000);
+        continue;
+      }
+
+      if (data.error === "expired_token") {
+        throw new Error("Login code expired. Please try again.");
+      }
+
+      if (data.error === "access_denied") {
+        throw new Error("Access denied. You cancelled the login.");
+      }
+
+      throw new Error(data.error_description || data.error || "Login failed");
+    } catch (e) {
+      if (e?.response) {
+        throw new Error(e.response.data?.error_description || "Login failed");
+      }
+      throw e;
+    }
+  }
+}
+
+/**
+ * Fetch the authenticated user's login from the GitHub API.
+ */
+export async function fetchAuthenticatedUser(token) {
+  const { data } = await axios.get("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+  return data;
+}

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -7,7 +7,7 @@ const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
 // by the orchestrator instead, with no frontend changes needed.
 const CALLBACK_URL =
   import.meta.env.VITE_AUTH_CALLBACK_URL ||
-  "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback";
+  "https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback";
 
 /**
  * Redirect the browser to GitHub's OAuth authorisation page.

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -1,33 +1,14 @@
 import axios from "axios";
 
-const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
-
-// n8n enforces a /webhook/ prefix on all webhook nodes.
-// When the orchestrator is stood up behind the tunnel this URL will change to:
-// https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
-const CALLBACK_URL =
-  import.meta.env.VITE_AUTH_CALLBACK_URL ||
-  "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback";
-
-/**
- * Redirect the browser to GitHub's OAuth authorisation page.
- * GitHub will redirect back to CALLBACK_URL?code=... after the user approves.
- * The callback handler (n8n or orchestrator) exchanges the code for a token
- * and redirects to the frontend with #token=... in the hash.
- */
-export function redirectToGitHubLogin() {
+export function redirectToGitHubLogin(config) {
   const params = new URLSearchParams({
-    client_id: CLIENT_ID,
-    redirect_uri: CALLBACK_URL,
+    client_id: config.githubClientId,
+    redirect_uri: config.authCallbackUrl,
     scope: "repo",
   });
   window.location.href = `https://github.com/login/oauth/authorize?${params}`;
 }
 
-/**
- * After GitHub redirects back to the frontend with #token=... or #error=...,
- * parse the hash and return { token, error }.
- */
 export function parseTokenFromHash() {
   const hash = window.location.hash.slice(1);
   const params = new URLSearchParams(hash);
@@ -37,9 +18,6 @@ export function parseTokenFromHash() {
   };
 }
 
-/**
- * Fetch the authenticated user's profile from the GitHub API.
- */
 export async function fetchAuthenticatedUser(token) {
   const { data } = await axios.get("https://api.github.com/user", {
     headers: {

--- a/kanban/src/api/auth.js
+++ b/kanban/src/api/auth.js
@@ -2,10 +2,12 @@ import axios from "axios";
 
 const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID;
 
-// Points at the n8n webhook that handles the OAuth code exchange.
-// When the orchestrator is ready, change this to:
-// https://apeiron-orchestrator.lukemckechnie.com/kanban/auth/callback
-const CALLBACK_URL = import.meta.env.VITE_AUTH_CALLBACK_URL;
+// OAuth callback URL — currently handled by an n8n workflow.
+// When the orchestrator is stood up behind the tunnel this URL will be handled
+// by the orchestrator instead, with no frontend changes needed.
+const CALLBACK_URL =
+  import.meta.env.VITE_AUTH_CALLBACK_URL ||
+  "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback";
 
 /**
  * Redirect the browser to GitHub's OAuth authorisation page.

--- a/kanban/src/api/config.js
+++ b/kanban/src/api/config.js
@@ -1,0 +1,6 @@
+const configPromise = fetch("/config.json").then((res) => {
+  if (!res.ok) throw new Error(`Failed to load /config.json: ${res.status}`);
+  return res.json();
+});
+
+export default configPromise;

--- a/kanban/src/api/github.js
+++ b/kanban/src/api/github.js
@@ -1,0 +1,75 @@
+import axios from "axios";
+
+function client(token) {
+  return axios.create({
+    baseURL: "https://api.github.com",
+    headers: {
+      Authorization: token ? `Bearer ${token}` : undefined,
+      Accept: "application/vnd.github+json",
+    },
+  });
+}
+
+export async function fetchAllIssues(owner, repo, token) {
+  const gh = client(token);
+  let page = 1;
+  const all = [];
+  while (true) {
+    const { data } = await gh.get(`/repos/${owner}/${repo}/issues`, {
+      params: { state: "all", per_page: 100, page },
+    });
+    if (data.length === 0) break;
+    all.push(...data.filter((i) => !i.pull_request));
+    if (data.length < 100) break;
+    page++;
+  }
+  return all;
+}
+
+export async function setIssueState(owner, repo, number, state, token) {
+  const gh = client(token);
+  const { data } = await gh.patch(`/repos/${owner}/${repo}/issues/${number}`, {
+    state,
+  });
+  return data;
+}
+
+export async function setIssueLabels(owner, repo, number, labels, token) {
+  const gh = client(token);
+  const { data } = await gh.patch(`/repos/${owner}/${repo}/issues/${number}`, {
+    labels,
+  });
+  return data;
+}
+
+export async function createComment(owner, repo, number, body, token) {
+  const gh = client(token);
+  const { data } = await gh.post(
+    `/repos/${owner}/${repo}/issues/${number}/comments`,
+    { body }
+  );
+  return data;
+}
+
+export async function fetchComments(owner, repo, number, token) {
+  const gh = client(token);
+  const { data } = await gh.get(
+    `/repos/${owner}/${repo}/issues/${number}/comments`
+  );
+  return data;
+}
+
+export async function createIssue(owner, repo, payload, token) {
+  const gh = client(token);
+  const { data } = await gh.post(`/repos/${owner}/${repo}/issues`, payload);
+  return data;
+}
+
+export async function updateIssue(owner, repo, number, payload, token) {
+  const gh = client(token);
+  const { data } = await gh.patch(
+    `/repos/${owner}/${repo}/issues/${number}`,
+    payload
+  );
+  return data;
+}

--- a/kanban/src/components/Board.jsx
+++ b/kanban/src/components/Board.jsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  closestCenter,
+} from "@dnd-kit/core";
+import { useIssueStore, COLUMNS } from "../store/issues";
+import { setIssueState, setIssueLabels } from "../api/github";
+import Column from "./Column";
+import IssueCard from "./IssueCard";
+
+const s = {
+  board: {
+    display: "flex",
+    flex: 1,
+    gap: 16,
+    padding: 20,
+    overflowX: "auto",
+    overflowY: "hidden",
+    alignItems: "flex-start",
+  },
+};
+
+export default function Board({ repo, token }) {
+  const { filteredIssues, moveIssue, updateIssueInStore } = useIssueStore();
+  const [activeIssue, setActiveIssue] = useState(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  const issues = filteredIssues();
+
+  const columnIssues = {};
+  COLUMNS.forEach((col) => {
+    columnIssues[col] = issues.filter((i) => {
+      return useIssueStore.getState().getColumn(i) === col;
+    });
+  });
+
+  function handleDragStart(event) {
+    const issue = issues.find(
+      (i) => String(i.number) === String(event.active.id)
+    );
+    setActiveIssue(issue || null);
+  }
+
+  async function handleDragEnd(event) {
+    const { active, over } = event;
+    setActiveIssue(null);
+    if (!over) return;
+
+    const issueNumber = Number(active.id);
+    const targetColumn = String(over.id);
+
+    if (!COLUMNS.includes(targetColumn)) return;
+
+    const issue = issues.find((i) => i.number === issueNumber);
+    if (!issue) return;
+
+    const currentColumn = useIssueStore.getState().getColumn(issue);
+    if (currentColumn === targetColumn) return;
+
+    moveIssue(issueNumber, targetColumn);
+
+    if (repo && repo.includes("/")) {
+      const [owner, repoName] = repo.split("/");
+      try {
+        let labels = (issue.labels || []).map((l) => l.name || l);
+        labels = labels.filter(
+          (l) => !["in progress", "in review"].includes(l.toLowerCase())
+        );
+        if (targetColumn === "In Progress") labels.push("in progress");
+        if (targetColumn === "In Review") labels.push("in review");
+
+        const newState = targetColumn === "Done" ? "closed" : "open";
+
+        const updated = await setIssueState(
+          owner,
+          repoName,
+          issueNumber,
+          newState,
+          token
+        );
+        await setIssueLabels(owner, repoName, issueNumber, labels, token);
+        updateIssueInStore({
+          ...updated,
+          labels: labels.map((n) => ({ name: n })),
+        });
+      } catch (err) {
+        console.error("Failed to persist move:", err);
+      }
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div style={s.board}>
+        {COLUMNS.map((col) => (
+          <Column key={col} title={col} issues={columnIssues[col] || []} />
+        ))}
+      </div>
+      <DragOverlay>
+        {activeIssue ? <IssueCard issue={activeIssue} overlay /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/kanban/src/components/Board.jsx
+++ b/kanban/src/components/Board.jsx
@@ -7,7 +7,7 @@ import {
   DragOverlay,
   closestCenter,
 } from "@dnd-kit/core";
-import { useIssueStore, COLUMNS } from "../store/issues";
+import { useIssueStore, COLUMNS, ALL_COLUMN_LABELS, COLUMN_LABELS } from "../store/issues";
 import { setIssueState, setIssueLabels } from "../api/github";
 import Column from "./Column";
 import IssueCard from "./IssueCard";
@@ -63,19 +63,20 @@ export default function Board({ repo, token }) {
     const currentColumn = useIssueStore.getState().getColumn(issue);
     if (currentColumn === targetColumn) return;
 
+    // Optimistic update
     moveIssue(issueNumber, targetColumn);
 
     if (repo && repo.includes("/")) {
       const [owner, repoName] = repo.split("/");
       try {
-        let labels = (issue.labels || []).map((l) => l.name || l);
-        labels = labels.filter(
-          (l) => !["in progress", "in review"].includes(l.toLowerCase())
-        );
-        if (targetColumn === "In Progress") labels.push("in progress");
-        if (targetColumn === "In Review") labels.push("in review");
+        let labels = (issue.labels || [])
+          .map((l) => l.name || l)
+          .filter((l) => !ALL_COLUMN_LABELS.includes(l.toLowerCase()));
 
-        const newState = targetColumn === "Done" ? "closed" : "open";
+        const colLabel = COLUMN_LABELS[targetColumn];
+        if (colLabel) labels.push(colLabel);
+
+        const newState = targetColumn === "Complete" ? "closed" : "open";
 
         const updated = await setIssueState(
           owner,

--- a/kanban/src/components/Column.jsx
+++ b/kanban/src/components/Column.jsx
@@ -4,10 +4,13 @@ import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import IssueCard from "./IssueCard";
 
 const COLUMN_COLOR = {
+  Triage: "#e3b341",
   Backlog: "#8b949e",
-  "In Progress": "#58a6ff",
+  Ready: "#58a6ff",
+  "In Progress": "#1f6feb",
   "In Review": "#a371f7",
-  Done: "#3fb950",
+  "Sign Off": "#db6d28",
+  Complete: "#3fb950",
 };
 
 const s = {
@@ -15,20 +18,21 @@ const s = {
     background: isOver ? "#1c2128" : "#161b22",
     border: `1px solid ${isOver ? "#388bfd" : "#30363d"}`,
     borderRadius: 10,
-    minWidth: 260,
-    width: 280,
+    minWidth: 220,
+    width: 240,
     maxHeight: "100%",
     display: "flex",
     flexDirection: "column",
     transition: "background .15s, border .15s",
+    flexShrink: 0,
   }),
-  header: () => ({
+  header: {
     display: "flex",
     alignItems: "center",
     gap: 8,
     padding: "12px 14px 10px",
     borderBottom: "1px solid #30363d",
-  }),
+  },
   dot: (col) => ({
     width: 10,
     height: 10,
@@ -59,7 +63,7 @@ export default function Column({ title, issues }) {
 
   return (
     <div style={s.column(isOver)}>
-      <div style={s.header(title)}>
+      <div style={s.header}>
         <span style={s.dot(title)} />
         <span style={s.title}>{title}</span>
         <span style={s.count}>{issues.length}</span>

--- a/kanban/src/components/Column.jsx
+++ b/kanban/src/components/Column.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import IssueCard from "./IssueCard";
+
+const COLUMN_COLOR = {
+  Backlog: "#8b949e",
+  "In Progress": "#58a6ff",
+  "In Review": "#a371f7",
+  Done: "#3fb950",
+};
+
+const s = {
+  column: (isOver) => ({
+    background: isOver ? "#1c2128" : "#161b22",
+    border: `1px solid ${isOver ? "#388bfd" : "#30363d"}`,
+    borderRadius: 10,
+    minWidth: 260,
+    width: 280,
+    maxHeight: "100%",
+    display: "flex",
+    flexDirection: "column",
+    transition: "background .15s, border .15s",
+  }),
+  header: () => ({
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    padding: "12px 14px 10px",
+    borderBottom: "1px solid #30363d",
+  }),
+  dot: (col) => ({
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    background: COLUMN_COLOR[col] || "#8b949e",
+    flexShrink: 0,
+  }),
+  title: { fontWeight: 700, fontSize: 14, flex: 1 },
+  count: { fontSize: 12, color: "#8b949e" },
+  body: {
+    padding: "10px 10px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    overflowY: "auto",
+    flex: 1,
+  },
+  empty: {
+    color: "#484f58",
+    fontSize: 13,
+    textAlign: "center",
+    padding: "20px 0",
+  },
+};
+
+export default function Column({ title, issues }) {
+  const { setNodeRef, isOver } = useDroppable({ id: title });
+
+  return (
+    <div style={s.column(isOver)}>
+      <div style={s.header(title)}>
+        <span style={s.dot(title)} />
+        <span style={s.title}>{title}</span>
+        <span style={s.count}>{issues.length}</span>
+      </div>
+      <SortableContext
+        items={issues.map((i) => String(i.number))}
+        strategy={verticalListSortingStrategy}
+      >
+        <div ref={setNodeRef} style={s.body}>
+          {issues.length === 0 && <span style={s.empty}>No issues</span>}
+          {issues.map((issue) => (
+            <IssueCard key={issue.number} issue={issue} />
+          ))}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}

--- a/kanban/src/components/Header.jsx
+++ b/kanban/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useIssueStore } from "../store/issues";
+import { useAuthStore } from "../store/auth";
 import { fetchAllIssues } from "../api/github";
 
 const s = {
@@ -32,16 +33,38 @@ const s = {
     fontWeight: 600,
     fontSize: 14,
   },
+  signOutBtn: {
+    background: "none",
+    color: "#8b949e",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    padding: "6px 14px",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 13,
+    marginLeft: "auto",
+  },
   error: { color: "#f85149", fontSize: 13 },
   info: { color: "#8b949e", fontSize: 13 },
+  avatar: {
+    width: 28,
+    height: 28,
+    borderRadius: "50%",
+    border: "1px solid #30363d",
+  },
+  userInfo: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    marginLeft: "auto",
+  },
+  userName: { fontSize: 13, color: "#e6edf3" },
 };
 
 export default function Header({ repo, onRepoChange }) {
   const [repoInput, setRepoInput] = useState(repo || "");
-  const [tokenInput, setTokenInput] = useState(
-    () => localStorage.getItem("gh_kanban_token") || ""
-  );
   const { setIssues, setLoading, setError, loading, error } = useIssueStore();
+  const { token, user, clearAuth } = useAuthStore();
 
   async function handleLoad() {
     const trimmed = repoInput.trim();
@@ -53,9 +76,9 @@ export default function Header({ repo, onRepoChange }) {
     setError(null);
     setLoading(true);
     try {
-      const issues = await fetchAllIssues(owner, repoName, tokenInput.trim());
+      const issues = await fetchAllIssues(owner, repoName, token);
       setIssues(issues);
-      onRepoChange(trimmed, tokenInput.trim());
+      onRepoChange(trimmed);
     } catch (e) {
       setError(e?.response?.data?.message || e.message || "Failed to load");
     } finally {
@@ -73,14 +96,6 @@ export default function Header({ repo, onRepoChange }) {
         onChange={(e) => setRepoInput(e.target.value)}
         onKeyDown={(e) => e.key === "Enter" && handleLoad()}
       />
-      <input
-        style={{ ...s.input, width: 240 }}
-        placeholder="GitHub token (for private repos / writes)"
-        type="password"
-        value={tokenInput}
-        onChange={(e) => setTokenInput(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && handleLoad()}
-      />
       <button style={s.btn} onClick={handleLoad} disabled={loading}>
         {loading ? "Loading…" : "Load"}
       </button>
@@ -88,6 +103,15 @@ export default function Header({ repo, onRepoChange }) {
       {!error && !loading && repo && (
         <span style={s.info}>Loaded: {repo}</span>
       )}
+      <div style={s.userInfo}>
+        {user?.avatar_url && (
+          <img src={user.avatar_url} alt={user.login} style={s.avatar} />
+        )}
+        <span style={s.userName}>{user?.login}</span>
+        <button style={s.signOutBtn} onClick={clearAuth}>
+          Sign out
+        </button>
+      </div>
     </header>
   );
 }

--- a/kanban/src/components/Header.jsx
+++ b/kanban/src/components/Header.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { useIssueStore } from "../store/issues";
+import { fetchAllIssues } from "../api/github";
+
+const s = {
+  header: {
+    background: "#161b22",
+    borderBottom: "1px solid #30363d",
+    padding: "12px 20px",
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    flexWrap: "wrap",
+  },
+  title: { fontWeight: 700, fontSize: 18, color: "#58a6ff", marginRight: 8 },
+  input: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "6px 10px",
+    fontSize: 14,
+    outline: "none",
+  },
+  btn: {
+    background: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    padding: "6px 16px",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 14,
+  },
+  error: { color: "#f85149", fontSize: 13 },
+  info: { color: "#8b949e", fontSize: 13 },
+};
+
+export default function Header({ repo, onRepoChange }) {
+  const [repoInput, setRepoInput] = useState(repo || "");
+  const [tokenInput, setTokenInput] = useState(
+    () => localStorage.getItem("gh_kanban_token") || ""
+  );
+  const { setIssues, setLoading, setError, loading, error } = useIssueStore();
+
+  async function handleLoad() {
+    const trimmed = repoInput.trim();
+    if (!trimmed.includes("/")) {
+      setError("Enter repo as owner/repo");
+      return;
+    }
+    const [owner, repoName] = trimmed.split("/");
+    setError(null);
+    setLoading(true);
+    try {
+      const issues = await fetchAllIssues(owner, repoName, tokenInput.trim());
+      setIssues(issues);
+      onRepoChange(trimmed, tokenInput.trim());
+    } catch (e) {
+      setError(e?.response?.data?.message || e.message || "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <header style={s.header}>
+      <span style={s.title}>GitHub Kanban</span>
+      <input
+        style={{ ...s.input, width: 220 }}
+        placeholder="owner/repo"
+        value={repoInput}
+        onChange={(e) => setRepoInput(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && handleLoad()}
+      />
+      <input
+        style={{ ...s.input, width: 240 }}
+        placeholder="GitHub token (for private repos / writes)"
+        type="password"
+        value={tokenInput}
+        onChange={(e) => setTokenInput(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && handleLoad()}
+      />
+      <button style={s.btn} onClick={handleLoad} disabled={loading}>
+        {loading ? "Loading…" : "Load"}
+      </button>
+      {error && <span style={s.error}>{error}</span>}
+      {!error && !loading && repo && (
+        <span style={s.info}>Loaded: {repo}</span>
+      )}
+    </header>
+  );
+}

--- a/kanban/src/components/IssueCard.jsx
+++ b/kanban/src/components/IssueCard.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useIssueStore, issueType } from "../store/issues";
+
+const TYPE_COLOR = {
+  epic: "#a371f7",
+  story: "#58a6ff",
+  bug: "#f85149",
+  task: "#3fb950",
+};
+
+const SKIP_LABELS = new Set([
+  "epic",
+  "story",
+  "bug",
+  "task",
+  "in progress",
+  "in review",
+]);
+
+const s = {
+  card: (isDragging, overlay) => ({
+    background: isDragging ? "#1c2128" : "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 8,
+    padding: "10px 12px",
+    cursor: "grab",
+    opacity: isDragging && !overlay ? 0.4 : 1,
+    boxShadow: overlay ? "0 8px 24px #0008" : "none",
+    transition: "background .1s",
+    userSelect: "none",
+  }),
+  top: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 4,
+  },
+  typeBadge: (type) => ({
+    fontSize: 10,
+    fontWeight: 700,
+    background: TYPE_COLOR[type] + "33",
+    color: TYPE_COLOR[type],
+    borderRadius: 4,
+    padding: "1px 6px",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  }),
+  number: { color: "#8b949e", fontSize: 11, marginLeft: "auto" },
+  title: { fontSize: 13, color: "#e6edf3", lineHeight: 1.4 },
+  labels: { display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 },
+  label: (color) => ({
+    fontSize: 10,
+    borderRadius: 20,
+    padding: "1px 7px",
+    background: `#${color}33`,
+    color: `#${color}`,
+    border: `1px solid #${color}66`,
+  }),
+  assignee: { fontSize: 11, color: "#8b949e", marginTop: 4 },
+};
+
+export default function IssueCard({ issue, overlay }) {
+  const selectIssue = useIssueStore((st) => st.selectIssue);
+  const type = issueType(issue);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: String(issue.number) });
+
+  const style = overlay
+    ? s.card(false, true)
+    : {
+        ...s.card(isDragging, false),
+        transform: CSS.Transform.toString(transform),
+        transition,
+      };
+
+  const displayLabels = (issue.labels || []).filter(
+    (l) => !SKIP_LABELS.has((l.name || "").toLowerCase())
+  );
+
+  function handleClick() {
+    if (isDragging) return;
+    selectIssue(issue);
+  }
+
+  return (
+    <div
+      ref={overlay ? undefined : setNodeRef}
+      style={style}
+      {...(overlay ? {} : { ...attributes, ...listeners })}
+      onClick={handleClick}
+    >
+      <div style={s.top}>
+        <span style={s.typeBadge(type)}>{type}</span>
+        <span style={s.number}>#{issue.number}</span>
+      </div>
+      <div style={s.title}>{issue.title}</div>
+      {displayLabels.length > 0 && (
+        <div style={s.labels}>
+          {displayLabels.map((label) => (
+            <span
+              key={label.id || label.name}
+              style={s.label(label.color || "8b949e")}
+            >
+              {label.name}
+            </span>
+          ))}
+        </div>
+      )}
+      {issue.assignee && (
+        <div style={s.assignee}>@ {issue.assignee.login}</div>
+      )}
+    </div>
+  );
+}

--- a/kanban/src/components/IssueDetail.jsx
+++ b/kanban/src/components/IssueDetail.jsx
@@ -3,6 +3,8 @@ import {
   useIssueStore,
   TYPES,
   COLUMNS,
+  ALL_COLUMN_LABELS,
+  COLUMN_LABELS,
   issueType,
   issueColumn,
 } from "../store/issues";
@@ -125,6 +127,7 @@ const s = {
     fontSize: 13,
     color: "#e6edf3",
     lineHeight: 1.5,
+    marginBottom: 10,
   },
   commentMeta: { fontSize: 11, color: "#8b949e", marginBottom: 4 },
   commentInput: {
@@ -189,18 +192,19 @@ export default function IssueDetail({ repo, token }) {
     setSaving(true);
     setSaveError(null);
     try {
+      // Strip type and all column labels, then re-add chosen ones
       let labels = (issue.labels || [])
         .map((l) => l.name || l)
         .filter(
           (l) =>
             !TYPES.includes(l.toLowerCase()) &&
-            !["in progress", "in review"].includes(l.toLowerCase())
+            !ALL_COLUMN_LABELS.includes(l.toLowerCase())
         );
       labels.push(type);
-      if (column === "In Progress") labels.push("in progress");
-      if (column === "In Review") labels.push("in review");
+      const colLabel = COLUMN_LABELS[column];
+      if (colLabel) labels.push(colLabel);
 
-      const newState = column === "Done" ? "closed" : "open";
+      const newState = column === "Complete" ? "closed" : "open";
 
       const updated = await updateIssue(
         owner,
@@ -283,14 +287,12 @@ export default function IssueDetail({ repo, token }) {
             </button>
 
             <div>
-              <div style={s.fieldLabel}>
-                Comments ({comments.length})
-              </div>
+              <div style={s.fieldLabel}>Comments ({comments.length})</div>
               {commentsLoading && (
                 <div style={{ color: "#8b949e", fontSize: 13 }}>Loading…</div>
               )}
               {comments.map((c) => (
-                <div key={c.id} style={{ marginBottom: 10 }}>
+                <div key={c.id}>
                   <div style={s.commentMeta}>
                     {c.user.login} ·{" "}
                     {new Date(c.created_at).toLocaleString()}

--- a/kanban/src/components/IssueDetail.jsx
+++ b/kanban/src/components/IssueDetail.jsx
@@ -1,0 +1,392 @@
+import React, { useEffect, useState } from "react";
+import {
+  useIssueStore,
+  TYPES,
+  COLUMNS,
+  issueType,
+  issueColumn,
+} from "../store/issues";
+import { updateIssue, fetchComments, createComment } from "../api/github";
+
+const s = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    background: "#0009",
+    zIndex: 100,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modal: {
+    background: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 12,
+    width: "min(720px, 95vw)",
+    maxHeight: "90vh",
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+  },
+  header: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 12,
+    padding: "16px 20px 12px",
+    borderBottom: "1px solid #30363d",
+  },
+  titleInput: {
+    background: "transparent",
+    border: "none",
+    color: "#e6edf3",
+    fontSize: 18,
+    fontWeight: 700,
+    flex: 1,
+    outline: "none",
+    resize: "none",
+    lineHeight: 1.4,
+    fontFamily: "inherit",
+  },
+  closeBtn: {
+    background: "none",
+    border: "none",
+    color: "#8b949e",
+    fontSize: 22,
+    cursor: "pointer",
+    padding: "0 4px",
+    lineHeight: 1,
+  },
+  body: { display: "flex", flex: 1, overflow: "hidden" },
+  main: {
+    flex: 1,
+    padding: "16px 20px",
+    overflowY: "auto",
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+  },
+  aside: {
+    width: 200,
+    borderLeft: "1px solid #30363d",
+    padding: "16px 14px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+    overflowY: "auto",
+  },
+  fieldLabel: {
+    fontSize: 11,
+    color: "#8b949e",
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  select: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "5px 8px",
+    fontSize: 13,
+    outline: "none",
+    width: "100%",
+  },
+  textarea: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "8px 10px",
+    fontSize: 13,
+    outline: "none",
+    width: "100%",
+    minHeight: 120,
+    resize: "vertical",
+    fontFamily: "inherit",
+    lineHeight: 1.5,
+  },
+  saveBtn: {
+    background: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    padding: "6px 16px",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 13,
+    alignSelf: "flex-start",
+  },
+  commentBox: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 8,
+    padding: "10px 12px",
+    fontSize: 13,
+    color: "#e6edf3",
+    lineHeight: 1.5,
+  },
+  commentMeta: { fontSize: 11, color: "#8b949e", marginBottom: 4 },
+  commentInput: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "8px 10px",
+    fontSize: 13,
+    outline: "none",
+    width: "100%",
+    minHeight: 72,
+    resize: "vertical",
+    fontFamily: "inherit",
+  },
+  commentBtn: {
+    background: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    padding: "6px 14px",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 13,
+    marginTop: 6,
+    alignSelf: "flex-end",
+  },
+  link: { color: "#58a6ff", fontSize: 12, textDecoration: "none" },
+  err: { color: "#f85149", fontSize: 12 },
+};
+
+export default function IssueDetail({ repo, token }) {
+  const { selectedIssue, clearSelectedIssue, updateIssueInStore, moveIssue } =
+    useIssueStore();
+  const issue = selectedIssue;
+
+  const [title, setTitle] = useState(issue.title);
+  const [body, setBody] = useState(issue.body || "");
+  const [type, setType] = useState(issueType(issue));
+  const [column, setColumn] = useState(issueColumn(issue));
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+
+  const [comments, setComments] = useState([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [newComment, setNewComment] = useState("");
+  const [postingComment, setPostingComment] = useState(false);
+
+  const [owner, repoName] = (repo || "/").split("/");
+
+  useEffect(() => {
+    if (!repo || !repo.includes("/")) return;
+    setCommentsLoading(true);
+    fetchComments(owner, repoName, issue.number, token)
+      .then(setComments)
+      .catch(() => {})
+      .finally(() => setCommentsLoading(false));
+  }, [issue.number, repo]);
+
+  async function handleSave() {
+    if (!repo || !repo.includes("/")) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      let labels = (issue.labels || [])
+        .map((l) => l.name || l)
+        .filter(
+          (l) =>
+            !TYPES.includes(l.toLowerCase()) &&
+            !["in progress", "in review"].includes(l.toLowerCase())
+        );
+      labels.push(type);
+      if (column === "In Progress") labels.push("in progress");
+      if (column === "In Review") labels.push("in review");
+
+      const newState = column === "Done" ? "closed" : "open";
+
+      const updated = await updateIssue(
+        owner,
+        repoName,
+        issue.number,
+        { title, body, labels, state: newState },
+        token
+      );
+
+      updateIssueInStore(updated);
+      moveIssue(issue.number, column);
+    } catch (e) {
+      setSaveError(e?.response?.data?.message || e.message || "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePostComment() {
+    if (!newComment.trim() || !repo || !repo.includes("/")) return;
+    setPostingComment(true);
+    try {
+      const comment = await createComment(
+        owner,
+        repoName,
+        issue.number,
+        newComment.trim(),
+        token
+      );
+      setComments((c) => [...c, comment]);
+      setNewComment("");
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setPostingComment(false);
+    }
+  }
+
+  return (
+    <div
+      style={s.overlay}
+      onClick={(e) => e.target === e.currentTarget && clearSelectedIssue()}
+    >
+      <div style={s.modal}>
+        <div style={s.header}>
+          <textarea
+            style={s.titleInput}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            rows={1}
+          />
+          <a
+            href={issue.html_url}
+            target="_blank"
+            rel="noreferrer"
+            style={{ ...s.link, whiteSpace: "nowrap" }}
+          >
+            #{issue.number} ↗
+          </a>
+          <button style={s.closeBtn} onClick={clearSelectedIssue}>
+            ✕
+          </button>
+        </div>
+
+        <div style={s.body}>
+          <div style={s.main}>
+            <div>
+              <div style={s.fieldLabel}>Description</div>
+              <textarea
+                style={s.textarea}
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder="No description"
+              />
+            </div>
+
+            {saveError && <span style={s.err}>{saveError}</span>}
+            <button style={s.saveBtn} onClick={handleSave} disabled={saving}>
+              {saving ? "Saving…" : "Save Changes"}
+            </button>
+
+            <div>
+              <div style={s.fieldLabel}>
+                Comments ({comments.length})
+              </div>
+              {commentsLoading && (
+                <div style={{ color: "#8b949e", fontSize: 13 }}>Loading…</div>
+              )}
+              {comments.map((c) => (
+                <div key={c.id} style={{ marginBottom: 10 }}>
+                  <div style={s.commentMeta}>
+                    {c.user.login} ·{" "}
+                    {new Date(c.created_at).toLocaleString()}
+                  </div>
+                  <div style={s.commentBox}>{c.body}</div>
+                </div>
+              ))}
+              <textarea
+                style={s.commentInput}
+                placeholder="Leave a comment…"
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+              />
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button
+                  style={s.commentBtn}
+                  onClick={handlePostComment}
+                  disabled={postingComment || !newComment.trim()}
+                >
+                  {postingComment ? "Posting…" : "Comment"}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <aside style={s.aside}>
+            <div>
+              <div style={s.fieldLabel}>Type</div>
+              <select
+                style={s.select}
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+              >
+                {TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <div style={s.fieldLabel}>Column</div>
+              <select
+                style={s.select}
+                value={column}
+                onChange={(e) => setColumn(e.target.value)}
+              >
+                {COLUMNS.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <div style={s.fieldLabel}>Assignee</div>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: issue.assignee ? "#e6edf3" : "#484f58",
+                }}
+              >
+                {issue.assignee ? `@${issue.assignee.login}` : "Unassigned"}
+              </div>
+            </div>
+
+            <div>
+              <div style={s.fieldLabel}>Milestone</div>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: issue.milestone ? "#e6edf3" : "#484f58",
+                }}
+              >
+                {issue.milestone ? issue.milestone.title : "None"}
+              </div>
+            </div>
+
+            <div>
+              <div style={s.fieldLabel}>Created</div>
+              <div style={{ fontSize: 12, color: "#8b949e" }}>
+                {new Date(issue.created_at).toLocaleDateString()}
+              </div>
+            </div>
+
+            <div>
+              <div style={s.fieldLabel}>Updated</div>
+              <div style={{ fontSize: 12, color: "#8b949e" }}>
+                {new Date(issue.updated_at).toLocaleDateString()}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kanban/src/components/LoginScreen.jsx
+++ b/kanban/src/components/LoginScreen.jsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
-import { requestDeviceCode, pollForToken, fetchAuthenticatedUser } from "../api/auth";
-import { useAuthStore } from "../store/auth";
+import React from "react";
+import { redirectToGitHubLogin } from "../api/auth";
 
 const s = {
   wrap: {
@@ -43,126 +42,27 @@ const s = {
     fontSize: 15,
     width: "100%",
   },
-  codeBox: {
-    background: "#0d1117",
-    border: "1px solid #388bfd",
-    borderRadius: 8,
-    padding: "14px 24px",
-    fontSize: 28,
-    fontWeight: 700,
-    letterSpacing: 6,
-    color: "#58a6ff",
-    textAlign: "center",
-    fontFamily: "monospace",
-  },
-  link: {
-    color: "#58a6ff",
-    fontSize: 14,
-  },
-  status: {
-    fontSize: 13,
-    color: "#8b949e",
-    textAlign: "center",
-  },
   err: {
     fontSize: 13,
     color: "#f85149",
     textAlign: "center",
   },
-  copyBtn: {
-    background: "none",
-    border: "1px solid #30363d",
-    borderRadius: 6,
-    color: "#8b949e",
-    fontSize: 12,
-    padding: "4px 12px",
-    cursor: "pointer",
-  },
 };
 
-export default function LoginScreen() {
-  const setAuth = useAuthStore((s) => s.setAuth);
-  const [step, setStep] = useState("idle"); // idle | waiting | polling | error
-  const [userCode, setUserCode] = useState("");
-  const [verificationUri, setVerificationUri] = useState("");
-  const [error, setError] = useState(null);
-  const [copied, setCopied] = useState(false);
-
-  async function handleLogin() {
-    setError(null);
-    setStep("waiting");
-    try {
-      const { device_code, user_code, verification_uri, interval } =
-        await requestDeviceCode();
-      setUserCode(user_code);
-      setVerificationUri(verification_uri);
-      setStep("polling");
-
-      const token = await pollForToken(device_code, interval);
-      const user = await fetchAuthenticatedUser(token);
-      setAuth(token, user);
-    } catch (e) {
-      setError(e.message || "Login failed");
-      setStep("error");
-    }
-  }
-
-  function handleCopy() {
-    navigator.clipboard.writeText(userCode).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }
-
+export default function LoginScreen({ error }) {
   return (
     <div style={s.wrap}>
       <div style={s.card}>
         <div style={s.title}>GitHub Kanban</div>
-
-        {step === "idle" && (
-          <>
-            <div style={s.subtitle}>
-              Sign in with GitHub to manage your issues on a Kanban board.
-            </div>
-            <button style={s.btn} onClick={handleLogin}>
-              Sign in with GitHub
-            </button>
-          </>
+        <div style={s.subtitle}>
+          Sign in with GitHub to manage your issues on a Kanban board.
+        </div>
+        {error && (
+          <div style={s.err}>Login failed: {decodeURIComponent(error)}</div>
         )}
-
-        {step === "waiting" && (
-          <div style={s.status}>Requesting login code…</div>
-        )}
-
-        {step === "polling" && (
-          <>
-            <div style={s.subtitle}>
-              Copy this code, then click the link below and paste it in.
-            </div>
-            <div style={s.codeBox}>{userCode}</div>
-            <button style={s.copyBtn} onClick={handleCopy}>
-              {copied ? "Copied!" : "Copy code"}
-            </button>
-            <a
-              href={verificationUri}
-              target="_blank"
-              rel="noreferrer"
-              style={s.link}
-            >
-              {verificationUri} ↗
-            </a>
-            <div style={s.status}>Waiting for you to approve…</div>
-          </>
-        )}
-
-        {step === "error" && (
-          <>
-            <div style={s.err}>{error}</div>
-            <button style={s.btn} onClick={handleLogin}>
-              Try again
-            </button>
-          </>
-        )}
+        <button style={s.btn} onClick={redirectToGitHubLogin}>
+          Sign in with GitHub
+        </button>
       </div>
     </div>
   );

--- a/kanban/src/components/LoginScreen.jsx
+++ b/kanban/src/components/LoginScreen.jsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import { requestDeviceCode, pollForToken, fetchAuthenticatedUser } from "../api/auth";
+import { useAuthStore } from "../store/auth";
+
+const s = {
+  wrap: {
+    height: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "#0d1117",
+  },
+  card: {
+    background: "#161b22",
+    border: "1px solid #30363d",
+    borderRadius: 12,
+    padding: "40px 48px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 20,
+    minWidth: 340,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 700,
+    color: "#58a6ff",
+  },
+  subtitle: {
+    fontSize: 14,
+    color: "#8b949e",
+    textAlign: "center",
+    lineHeight: 1.5,
+  },
+  btn: {
+    background: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    padding: "10px 28px",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 15,
+    width: "100%",
+  },
+  codeBox: {
+    background: "#0d1117",
+    border: "1px solid #388bfd",
+    borderRadius: 8,
+    padding: "14px 24px",
+    fontSize: 28,
+    fontWeight: 700,
+    letterSpacing: 6,
+    color: "#58a6ff",
+    textAlign: "center",
+    fontFamily: "monospace",
+  },
+  link: {
+    color: "#58a6ff",
+    fontSize: 14,
+  },
+  status: {
+    fontSize: 13,
+    color: "#8b949e",
+    textAlign: "center",
+  },
+  err: {
+    fontSize: 13,
+    color: "#f85149",
+    textAlign: "center",
+  },
+  copyBtn: {
+    background: "none",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#8b949e",
+    fontSize: 12,
+    padding: "4px 12px",
+    cursor: "pointer",
+  },
+};
+
+export default function LoginScreen() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const [step, setStep] = useState("idle"); // idle | waiting | polling | error
+  const [userCode, setUserCode] = useState("");
+  const [verificationUri, setVerificationUri] = useState("");
+  const [error, setError] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  async function handleLogin() {
+    setError(null);
+    setStep("waiting");
+    try {
+      const { device_code, user_code, verification_uri, interval } =
+        await requestDeviceCode();
+      setUserCode(user_code);
+      setVerificationUri(verification_uri);
+      setStep("polling");
+
+      const token = await pollForToken(device_code, interval);
+      const user = await fetchAuthenticatedUser(token);
+      setAuth(token, user);
+    } catch (e) {
+      setError(e.message || "Login failed");
+      setStep("error");
+    }
+  }
+
+  function handleCopy() {
+    navigator.clipboard.writeText(userCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div style={s.wrap}>
+      <div style={s.card}>
+        <div style={s.title}>GitHub Kanban</div>
+
+        {step === "idle" && (
+          <>
+            <div style={s.subtitle}>
+              Sign in with GitHub to manage your issues on a Kanban board.
+            </div>
+            <button style={s.btn} onClick={handleLogin}>
+              Sign in with GitHub
+            </button>
+          </>
+        )}
+
+        {step === "waiting" && (
+          <div style={s.status}>Requesting login code…</div>
+        )}
+
+        {step === "polling" && (
+          <>
+            <div style={s.subtitle}>
+              Copy this code, then click the link below and paste it in.
+            </div>
+            <div style={s.codeBox}>{userCode}</div>
+            <button style={s.copyBtn} onClick={handleCopy}>
+              {copied ? "Copied!" : "Copy code"}
+            </button>
+            <a
+              href={verificationUri}
+              target="_blank"
+              rel="noreferrer"
+              style={s.link}
+            >
+              {verificationUri} ↗
+            </a>
+            <div style={s.status}>Waiting for you to approve…</div>
+          </>
+        )}
+
+        {step === "error" && (
+          <>
+            <div style={s.err}>{error}</div>
+            <button style={s.btn} onClick={handleLogin}>
+              Try again
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/kanban/src/components/LoginScreen.jsx
+++ b/kanban/src/components/LoginScreen.jsx
@@ -49,7 +49,7 @@ const s = {
   },
 };
 
-export default function LoginScreen({ error }) {
+export default function LoginScreen({ error, config }) {
   return (
     <div style={s.wrap}>
       <div style={s.card}>
@@ -60,7 +60,7 @@ export default function LoginScreen({ error }) {
         {error && (
           <div style={s.err}>Login failed: {decodeURIComponent(error)}</div>
         )}
-        <button style={s.btn} onClick={redirectToGitHubLogin}>
+        <button style={s.btn} onClick={() => redirectToGitHubLogin(config)}>
           Sign in with GitHub
         </button>
       </div>

--- a/kanban/src/components/NewIssueForm.jsx
+++ b/kanban/src/components/NewIssueForm.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+import { useIssueStore, TYPES } from "../store/issues";
+import { createIssue } from "../api/github";
+
+const s = {
+  section: { display: "flex", flexDirection: "column", gap: 8 },
+  heading: {
+    color: "#8b949e",
+    fontSize: 11,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  input: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "5px 8px",
+    fontSize: 13,
+    outline: "none",
+    width: "100%",
+  },
+  select: {
+    background: "#0d1117",
+    border: "1px solid #30363d",
+    borderRadius: 6,
+    color: "#e6edf3",
+    padding: "5px 8px",
+    fontSize: 13,
+    outline: "none",
+    width: "100%",
+  },
+  btn: {
+    background: "#238636",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    padding: "6px 0",
+    cursor: "pointer",
+    fontWeight: 600,
+    fontSize: 13,
+    width: "100%",
+    marginTop: 2,
+  },
+  err: { color: "#f85149", fontSize: 12 },
+};
+
+export default function NewIssueForm() {
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState("task");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const addIssueToStore = useIssueStore((st) => st.addIssueToStore);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    const repo = localStorage.getItem("gh_kanban_repo") || "";
+    const token = localStorage.getItem("gh_kanban_token") || "";
+    if (!repo.includes("/")) {
+      setError("Load a repo first");
+      return;
+    }
+    const [owner, repoName] = repo.split("/");
+    setSaving(true);
+    setError(null);
+    try {
+      const issue = await createIssue(
+        owner,
+        repoName,
+        { title: title.trim(), labels: [type] },
+        token
+      );
+      addIssueToStore(issue);
+      setTitle("");
+    } catch (e) {
+      setError(e?.response?.data?.message || e.message || "Failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form style={s.section} onSubmit={handleSubmit}>
+      <span style={s.heading}>New Issue</span>
+      <input
+        style={s.input}
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <select
+        style={s.select}
+        value={type}
+        onChange={(e) => setType(e.target.value)}
+      >
+        {TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </option>
+        ))}
+      </select>
+      {error && <span style={s.err}>{error}</span>}
+      <button style={s.btn} type="submit" disabled={saving}>
+        {saving ? "Creating…" : "+ Create"}
+      </button>
+    </form>
+  );
+}

--- a/kanban/src/components/Sidebar.jsx
+++ b/kanban/src/components/Sidebar.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useIssueStore, TYPES, issueType, COLUMNS, issueColumn } from "../store/issues";
+import NewIssueForm from "./NewIssueForm";
+
+const TYPE_COLOR = {
+  epic: "#a371f7",
+  story: "#58a6ff",
+  bug: "#f85149",
+  task: "#3fb950",
+};
+
+const s = {
+  sidebar: {
+    width: 200,
+    minWidth: 180,
+    background: "#161b22",
+    borderRight: "1px solid #30363d",
+    padding: "16px 12px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 24,
+    overflowY: "auto",
+  },
+  section: { display: "flex", flexDirection: "column", gap: 8 },
+  heading: {
+    color: "#8b949e",
+    fontSize: 11,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  typeRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    cursor: "pointer",
+    userSelect: "none",
+    padding: "4px 0",
+  },
+  dot: (color) => ({
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    background: color,
+    flexShrink: 0,
+  }),
+  label: (active) => ({
+    fontSize: 14,
+    color: active ? "#e6edf3" : "#484f58",
+    transition: "color .15s",
+  }),
+  count: {
+    marginLeft: "auto",
+    fontSize: 12,
+    color: "#8b949e",
+  },
+};
+
+export default function Sidebar() {
+  const { activeTypes, toggleType, issues, filteredIssues } = useIssueStore();
+  const filtered = filteredIssues();
+
+  const countByType = {};
+  TYPES.forEach((t) => {
+    countByType[t] = issues.filter((i) => issueType(i) === t).length;
+  });
+
+  const countByColumn = {};
+  COLUMNS.forEach((col) => {
+    countByColumn[col] = filtered.filter(
+      (i) => issueColumn(i) === col
+    ).length;
+  });
+
+  return (
+    <aside style={s.sidebar}>
+      <div style={s.section}>
+        <span style={s.heading}>Issue Types</span>
+        {TYPES.map((type) => (
+          <div
+            key={type}
+            style={s.typeRow}
+            onClick={() => toggleType(type)}
+            title={activeTypes.has(type) ? "Hide" : "Show"}
+          >
+            <span style={s.dot(TYPE_COLOR[type])} />
+            <span style={s.label(activeTypes.has(type))}>
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </span>
+            <span style={s.count}>{countByType[type]}</span>
+          </div>
+        ))}
+      </div>
+
+      <div style={s.section}>
+        <span style={s.heading}>Columns</span>
+        {COLUMNS.map((col) => (
+          <div key={col} style={{ ...s.typeRow, cursor: "default" }}>
+            <span style={s.label(true)}>{col}</span>
+            <span style={s.count}>{countByColumn[col] ?? 0}</span>
+          </div>
+        ))}
+      </div>
+
+      <NewIssueForm />
+    </aside>
+  );
+}

--- a/kanban/src/components/Sidebar.jsx
+++ b/kanban/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useIssueStore, TYPES, issueType, COLUMNS, issueColumn } from "../store/issues";
+import { useIssueStore, TYPES, issueType, COLUMNS } from "../store/issues";
 import NewIssueForm from "./NewIssueForm";
 
 const TYPE_COLOR = {
@@ -7,6 +7,16 @@ const TYPE_COLOR = {
   story: "#58a6ff",
   bug: "#f85149",
   task: "#3fb950",
+};
+
+const COLUMN_COLOR = {
+  Triage: "#e3b341",
+  Backlog: "#8b949e",
+  Ready: "#58a6ff",
+  "In Progress": "#1f6feb",
+  "In Review": "#a371f7",
+  "Sign Off": "#db6d28",
+  Complete: "#3fb950",
 };
 
 const s = {
@@ -68,7 +78,7 @@ export default function Sidebar() {
   const countByColumn = {};
   COLUMNS.forEach((col) => {
     countByColumn[col] = filtered.filter(
-      (i) => issueColumn(i) === col
+      (i) => useIssueStore.getState().getColumn(i) === col
     ).length;
   });
 
@@ -96,6 +106,7 @@ export default function Sidebar() {
         <span style={s.heading}>Columns</span>
         {COLUMNS.map((col) => (
           <div key={col} style={{ ...s.typeRow, cursor: "default" }}>
+            <span style={s.dot(COLUMN_COLOR[col])} />
             <span style={s.label(true)}>{col}</span>
             <span style={s.count}>{countByColumn[col] ?? 0}</span>
           </div>

--- a/kanban/src/main.jsx
+++ b/kanban/src/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/kanban/src/main.jsx
+++ b/kanban/src/main.jsx
@@ -1,9 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import configPromise from "./api/config";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+configPromise.then((config) => {
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.StrictMode>
+      <App config={config} />
+    </React.StrictMode>
+  );
+}).catch((e) => {
+  document.getElementById("root").textContent = `Failed to load config: ${e.message}`;
+});

--- a/kanban/src/store/auth.js
+++ b/kanban/src/store/auth.js
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+const TOKEN_KEY = "gh_kanban_token";
+const USER_KEY = "gh_kanban_user";
+
+export const useAuthStore = create((set) => ({
+  token: localStorage.getItem(TOKEN_KEY) || null,
+  user: (() => {
+    try {
+      const raw = localStorage.getItem(USER_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  })(),
+
+  setAuth(token, user) {
+    localStorage.setItem(TOKEN_KEY, token);
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+    set({ token, user });
+  },
+
+  clearAuth() {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+    set({ token: null, user: null });
+  },
+}));

--- a/kanban/src/store/issues.js
+++ b/kanban/src/store/issues.js
@@ -11,16 +11,47 @@ export function issueType(issue) {
 }
 
 export function issueColumn(issue) {
-  if (issue.state === "closed") return "Done";
+  if (issue.state === "closed") return "Complete";
   const names = (issue.labels || []).map((l) =>
     (l.name || "").toLowerCase()
   );
+  if (names.includes("sign off")) return "Sign Off";
   if (names.includes("in review")) return "In Review";
   if (names.includes("in progress")) return "In Progress";
+  if (names.includes("ready")) return "Ready";
+  if (names.includes("triage")) return "Triage";
   return "Backlog";
 }
 
-export const COLUMNS = ["Backlog", "In Progress", "In Review", "Done"];
+export const COLUMNS = [
+  "Triage",
+  "Backlog",
+  "Ready",
+  "In Progress",
+  "In Review",
+  "Sign Off",
+  "Complete",
+];
+
+// Labels that map 1-to-1 with columns (Complete = closed state, not a label)
+export const COLUMN_LABELS = {
+  Triage: "triage",
+  Backlog: null,
+  Ready: "ready",
+  "In Progress": "in progress",
+  "In Review": "in review",
+  "Sign Off": "sign off",
+  Complete: null,
+};
+
+// All label values used for column tracking — strip these when moving columns
+export const ALL_COLUMN_LABELS = [
+  "triage",
+  "ready",
+  "in progress",
+  "in review",
+  "sign off",
+];
 
 export const TYPES = ["epic", "story", "bug", "task"];
 
@@ -68,14 +99,14 @@ export const useIssueStore = create((set, get) => ({
     set((state) => {
       const issues = state.issues.map((iss) => {
         if (iss.number !== issueNumber) return iss;
-        let labels = (iss.labels || []).map((l) => l.name || l);
-        labels = labels.filter(
-          (l) =>
-            !["in progress", "in review"].includes(l.toLowerCase())
-        );
-        if (targetColumn === "In Progress") labels.push("in progress");
-        if (targetColumn === "In Review") labels.push("in review");
-        const newState = targetColumn === "Done" ? "closed" : "open";
+        // Strip all column-tracking labels
+        let labels = (iss.labels || [])
+          .map((l) => l.name || l)
+          .filter((l) => !ALL_COLUMN_LABELS.includes(l.toLowerCase()));
+        // Add the new column label if one exists for this column
+        const colLabel = COLUMN_LABELS[targetColumn];
+        if (colLabel) labels.push(colLabel);
+        const newState = targetColumn === "Complete" ? "closed" : "open";
         return {
           ...iss,
           state: newState,

--- a/kanban/src/store/issues.js
+++ b/kanban/src/store/issues.js
@@ -1,0 +1,122 @@
+import { create } from "zustand";
+
+export function issueType(issue) {
+  const names = (issue.labels || []).map((l) =>
+    (l.name || "").toLowerCase()
+  );
+  if (names.includes("epic")) return "epic";
+  if (names.includes("story")) return "story";
+  if (names.includes("bug")) return "bug";
+  return "task";
+}
+
+export function issueColumn(issue) {
+  if (issue.state === "closed") return "Done";
+  const names = (issue.labels || []).map((l) =>
+    (l.name || "").toLowerCase()
+  );
+  if (names.includes("in review")) return "In Review";
+  if (names.includes("in progress")) return "In Progress";
+  return "Backlog";
+}
+
+export const COLUMNS = ["Backlog", "In Progress", "In Review", "Done"];
+
+export const TYPES = ["epic", "story", "bug", "task"];
+
+export const useIssueStore = create((set, get) => ({
+  issues: [],
+  loading: false,
+  error: null,
+  selectedIssue: null,
+  activeTypes: new Set(TYPES),
+  columnOrder: {},
+
+  setIssues(issues) {
+    set({ issues });
+  },
+
+  setLoading(loading) {
+    set({ loading });
+  },
+
+  setError(error) {
+    set({ error });
+  },
+
+  selectIssue(issue) {
+    set({ selectedIssue: issue });
+  },
+
+  clearSelectedIssue() {
+    set({ selectedIssue: null });
+  },
+
+  toggleType(type) {
+    set((state) => {
+      const next = new Set(state.activeTypes);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return { activeTypes: next };
+    });
+  },
+
+  moveIssue(issueNumber, targetColumn) {
+    set((state) => {
+      const issues = state.issues.map((iss) => {
+        if (iss.number !== issueNumber) return iss;
+        let labels = (iss.labels || []).map((l) => l.name || l);
+        labels = labels.filter(
+          (l) =>
+            !["in progress", "in review"].includes(l.toLowerCase())
+        );
+        if (targetColumn === "In Progress") labels.push("in progress");
+        if (targetColumn === "In Review") labels.push("in review");
+        const newState = targetColumn === "Done" ? "closed" : "open";
+        return {
+          ...iss,
+          state: newState,
+          labels: labels.map((name) =>
+            typeof name === "string" ? { name } : name
+          ),
+        };
+      });
+      return {
+        issues,
+        columnOrder: {
+          ...state.columnOrder,
+          [issueNumber]: targetColumn,
+        },
+      };
+    });
+  },
+
+  updateIssueInStore(updated) {
+    set((state) => ({
+      issues: state.issues.map((i) =>
+        i.number === updated.number ? updated : i
+      ),
+      selectedIssue:
+        state.selectedIssue?.number === updated.number
+          ? updated
+          : state.selectedIssue,
+    }));
+  },
+
+  addIssueToStore(issue) {
+    set((state) => ({ issues: [issue, ...state.issues] }));
+  },
+
+  getColumn(issue) {
+    const override = get().columnOrder[issue.number];
+    return override ?? issueColumn(issue);
+  },
+
+  filteredIssues() {
+    const { issues, activeTypes } = get();
+    return issues.filter((i) => activeTypes.has(issueType(i)));
+  },
+}));

--- a/kanban/vite.config.js
+++ b/kanban/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/kanban/vite.config.js
+++ b/kanban/vite.config.js
@@ -3,15 +3,4 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      // Proxy GitHub OAuth endpoints to avoid CORS issues in the browser.
-      // Only needed in development — in production you'd handle this server-side.
-      "/github-oauth": {
-        target: "https://github.com",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/github-oauth/, ""),
-      },
-    },
-  },
 });

--- a/kanban/vite.config.js
+++ b/kanban/vite.config.js
@@ -3,4 +3,15 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // Proxy GitHub OAuth endpoints to avoid CORS issues in the browser.
+      // Only needed in development — in production you'd handle this server-side.
+      "/github-oauth": {
+        target: "https://github.com",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/github-oauth/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- Adds a multi-stage `kanban/Dockerfile` (Node 20 build → nginx serve) with SPA routing and a mountable `config.json` for custom deployments
- Adds `kanban/public/config.json` as the runtime config file (GitHub OAuth client ID and callback URL) — loaded before React mounts, no build-time env vars required
- Adds `.github/workflows/kanban-publish.yml`: semantic-release drives versioned GHCR image pushes on merge to main; PRs get a SHA-tagged image
- Adds `kanban/.releaserc.json` with `kanban-v*` tag format, independent of the game release pipeline
- Adds `kanban` service to `infra/n8n/docker-compose.yml` pulling from GHCR, served on port 80 internally for the Cloudflare tunnel (`http://kanban:80`)
- Refactors `auth.js` to accept config as a parameter rather than reading build-time env vars
- Config promise is initiated at module load time in `main.jsx` — React does not mount until config resolves; failure renders a plain error message before React initialises