### PR TITLE
feat: repo dropdown from API, fix status label mapping

### DIFF
--- a/docs/bmad/planning-artifacts/tech-spec-wip.md
+++ b/docs/bmad/planning-artifacts/tech-spec-wip.md
@@ -1,0 +1,105 @@
+---
+title: 'Configurable columns/types and collapsible columns'
+type: 'feature'
+created: '2026-04-06'
+status: 'in-review'
+baseline_commit: '04d486abf9e97659e420880fe9f9eacef07a37a2'
+---
+
+# Configurable columns/types and collapsible columns
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Column names, status labels, issue type labels, and colours are hardcoded in source files, making the kanban board unusable for repos with different label schemes without a code change. There is also no way to hide a column temporarily without removing it from config.
+
+**Approach:** Move all column and type definitions into `config.json` as runtime data. Initialise the store from config before React mounts. Add a collapsible column UI driven by a persisted store set. Replace hardcoded colour maps in components with values derived from config.
+
+## Boundaries & Constraints
+
+**Always:**
+- `COLUMNS`, `COLUMN_LABELS`, `ALL_COLUMN_LABELS`, `TYPES` remain as exported names from `store/issues.js` — consumers import them unchanged
+- Config is fully loaded before `initColumns` is called and before React mounts — no async reads inside components
+- Collapsed state persists to `localStorage`
+- A collapsed column still accepts drag-and-drop (drop target remains active)
+- The column with `"default": true` is the fallback for issues with no matching status label
+- The column with `"closeIssue": true` sets issue state to `closed` on GitHub when a card is dropped there
+
+**Ask First:**
+- If `config.json` is missing `columns` or `types` keys — halt and ask before falling back to any default
+
+**Never:**
+- Do not add column or type configuration UI inside the app itself — config.json is the only configuration surface
+- Do not change any component other than `Column.jsx` and `IssueCard.jsx` for the color/collapse changes
+- Do not touch `Board.jsx`, `Sidebar.jsx`, `IssueDetail.jsx`, `NewIssueForm.jsx`, `Header.jsx`, or `App.jsx`
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Issue has matching status label | Issue with `status:in-progress` label | Placed in the column whose `label` matches | — |
+| Issue has no status label | Open issue, no column labels | Placed in column with `"default": true` | — |
+| Issue is closed | `state: "closed"` | Placed in column with `"closeIssue": true` | — |
+| Drop into closeIssue column | Card dragged to Complete | GitHub issue patched to `state: closed` | Error surfaced as existing board error state |
+| Drop into default column | Card dragged to Backlog | Column label stripped, no label added, issue stays open | — |
+| Column collapsed | User clicks column header | Column shrinks to slim vertical strip showing name + count | — |
+| Drop onto collapsed column | Card dropped on slim strip | Issue moves to that column normally | — |
+| Collapse persists | Page refresh after collapsing Complete | Complete column still collapsed | — |
+| config.json missing `columns` | App load | Halt — render error before React mounts | Plain text error in root div |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `kanban/public/config.json` — runtime config; gains `columns` and `types` arrays
+- `kanban/src/store/issues.js` — exports `COLUMNS`, `COLUMN_LABELS`, `ALL_COLUMN_LABELS`, `TYPES`; gains `initColumns(columns, types)`, `COLUMN_COLORS`, `TYPE_COLORS`, `collapsedColumns` set, `toggleCollapsed(name)` action
+- `kanban/src/main.jsx` — calls `initColumns(config.columns, config.types)` before `ReactDOM.createRoot`
+- `kanban/src/components/Column.jsx` — consumes `COLUMN_COLORS` from store; header click calls `toggleCollapsed`; collapsed renders slim vertical strip
+- `kanban/src/components/IssueCard.jsx` — consumes `TYPE_COLORS` from store instead of local `TYPE_COLOR` map
+
+## Tasks & Acceptance
+
+**Execution:**
+- [ ] `kanban/public/config.json` — add `columns` array (with `name`, `label`, optional `color`, `default`, `closeIssue`) and `types` array (with `name`, `label`, `color`); keep existing `githubClientId` and `authCallbackUrl`
+- [ ] `kanban/src/store/issues.js` — add `initColumns(columns, types)` that populates all module-level exports; derive `COLUMN_COLORS` and `TYPE_COLORS` maps; add `collapsedColumns` (Set, init from localStorage) and `toggleCollapsed(name)` to store; update `issueColumn` to use `default` flag; update `moveIssue` to use `closeIssue` flag
+- [ ] `kanban/src/main.jsx` — call `initColumns(config.columns, config.types)` before `ReactDOM.createRoot`; render plain error if `columns` or `types` missing from config
+- [ ] `kanban/src/components/Column.jsx` — remove hardcoded `COLUMN_COLOR` map; import `COLUMN_COLORS` and `useIssueStore`; make header a button that calls `toggleCollapsed`; when collapsed render a slim vertical strip (fixed narrow width, rotated name, count) with drop target still active
+- [ ] `kanban/src/components/IssueCard.jsx` — remove local `TYPE_COLOR` map; import `TYPE_COLORS` from store
+
+**Acceptance Criteria:**
+- Given a `config.json` with custom column names and labels, when the app loads, then issues are sorted into the correct columns with no source code change
+- Given a column with `"default": true`, when an issue has no status label, then it appears in that column
+- Given a column with `"closeIssue": true`, when a card is dropped there, then the GitHub issue is patched to `state: closed`
+- Given the app is loaded, when a column header is clicked, then the column collapses to a slim vertical strip showing the name rotated 90° and the issue count
+- Given a column is collapsed, when a card is dropped onto it, then the move completes normally
+- Given a column was collapsed before a page refresh, when the page reloads, then the column is still collapsed
+- Given `config.json` is missing the `columns` key, when the app loads, then a plain error message is shown before React mounts
+
+## Design Notes
+
+`initColumns` must be called synchronously before `ReactDOM.createRoot`. Since `config.json` is fetched async in `main.jsx` and `ReactDOM.createRoot` is already called inside `.then()`, the call order is:
+
+```js
+configPromise.then((config) => {
+  initColumns(config.columns, config.types); // populate store exports
+  ReactDOM.createRoot(...).render(...);
+});
+```
+
+Module-level `let` variables in `store/issues.js` are mutated once by `initColumns` and then treated as read-only. This is safe because the store module is a singleton and `initColumns` is called exactly once before any component reads the exports.
+
+Collapsed column strip: fixed `width: 48px`, full column height, column name in a `<span>` with `writingMode: "vertical-rl"` and `transform: "rotate(180deg)"`. The `useDroppable` ref stays on the outer div so dnd-kit still registers it as a valid drop target.
+
+## Verification
+
+**Commands:**
+- `cargo test` (pre-commit hook) — expected: all Rust tests pass (no Rust changes, confirms hook doesn't block)
+
+**Manual checks:**
+- Issues with `status:in-progress` label appear in In Progress column on load
+- Issues with no status label appear in Backlog (default column)
+- Clicking a column header collapses/expands it
+- Dragging a card onto a collapsed column moves it correctly
+- Refreshing the page preserves collapsed state
+- Editing `config.json` columns array and refreshing reflects the new column names

--- a/kanban/public/config.json
+++ b/kanban/public/config.json
@@ -1,4 +1,19 @@
 {
   "githubClientId": "Iv23lisdJkaJCknZAoUS",
-  "authCallbackUrl": "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback"
+  "authCallbackUrl": "https://apeiron-orchestrator.lukemckechnie.com/webhook/kanban/auth/callback",
+  "columns": [
+    { "name": "Triage",      "label": "status:triage",      "color": "#e3b341" },
+    { "name": "Backlog",     "label": null,                  "color": "#8b949e", "default": true },
+    { "name": "Ready",       "label": "status:ready",        "color": "#58a6ff" },
+    { "name": "In Progress", "label": "status:in-progress",  "color": "#1f6feb" },
+    { "name": "In Review",   "label": "status:in-review",    "color": "#a371f7" },
+    { "name": "Sign Off",    "label": "status:sign-off",     "color": "#db6d28" },
+    { "name": "Complete",    "label": null,                  "color": "#3fb950", "closeIssue": true }
+  ],
+  "types": [
+    { "name": "epic",  "label": "epic",  "color": "#a371f7" },
+    { "name": "story", "label": "story", "color": "#58a6ff" },
+    { "name": "bug",   "label": "bug",   "color": "#f85149" },
+    { "name": "task",  "label": "task",  "color": "#3fb950" }
+  ]
 }

--- a/kanban/src/api/github.js
+++ b/kanban/src/api/github.js
@@ -73,3 +73,23 @@ export async function updateIssue(owner, repo, number, payload, token) {
   );
   return data;
 }
+
+export async function fetchUserRepos(token) {
+  const gh = client(token);
+  let page = 1;
+  const all = [];
+  while (true) {
+    const { data } = await gh.get("/user/repos", {
+      params: {
+        affiliation: "owner,collaborator,organization_member",
+        sort: "pushed",
+        per_page: 100,
+        page,
+      },
+    });
+    all.push(...data);
+    if (data.length < 100) break;
+    page++;
+  }
+  return all;
+}

--- a/kanban/src/components/Board.jsx
+++ b/kanban/src/components/Board.jsx
@@ -7,7 +7,7 @@ import {
   DragOverlay,
   closestCenter,
 } from "@dnd-kit/core";
-import { useIssueStore, COLUMNS, ALL_COLUMN_LABELS, COLUMN_LABELS } from "../store/issues";
+import { useIssueStore, COLUMNS, ALL_COLUMN_LABELS, COLUMN_LABELS, getCloseIssueColumn } from "../store/issues";
 import { setIssueState, setIssueLabels } from "../api/github";
 import Column from "./Column";
 import IssueCard from "./IssueCard";
@@ -76,7 +76,7 @@ export default function Board({ repo, token }) {
         const colLabel = COLUMN_LABELS[targetColumn];
         if (colLabel) labels.push(colLabel);
 
-        const newState = targetColumn === "Complete" ? "closed" : "open";
+        const newState = targetColumn === getCloseIssueColumn() ? "closed" : "open";
 
         const updated = await setIssueState(
           owner,

--- a/kanban/src/components/Column.jsx
+++ b/kanban/src/components/Column.jsx
@@ -2,16 +2,7 @@ import React from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import IssueCard from "./IssueCard";
-
-const COLUMN_COLOR = {
-  Triage: "#e3b341",
-  Backlog: "#8b949e",
-  Ready: "#58a6ff",
-  "In Progress": "#1f6feb",
-  "In Review": "#a371f7",
-  "Sign Off": "#db6d28",
-  Complete: "#3fb950",
-};
+import { useIssueStore, COLUMN_COLORS } from "../store/issues";
 
 const s = {
   column: (isOver) => ({
@@ -26,21 +17,54 @@ const s = {
     transition: "background .15s, border .15s",
     flexShrink: 0,
   }),
+  columnCollapsed: (isOver) => ({
+    background: isOver ? "#1c2128" : "#161b22",
+    border: `1px solid ${isOver ? "#388bfd" : "#30363d"}`,
+    borderRadius: 10,
+    width: 48,
+    maxHeight: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    transition: "background .15s, border .15s",
+    flexShrink: 0,
+    overflow: "hidden",
+  }),
   header: {
     display: "flex",
     alignItems: "center",
     gap: 8,
     padding: "12px 14px 10px",
     borderBottom: "1px solid #30363d",
+    cursor: "pointer",
+    userSelect: "none",
   },
-  dot: (col) => ({
+  headerCollapsed: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 8,
+    padding: "14px 0",
+    cursor: "pointer",
+    userSelect: "none",
+    width: "100%",
+  },
+  dot: (color) => ({
     width: 10,
     height: 10,
     borderRadius: "50%",
-    background: COLUMN_COLOR[col] || "#8b949e",
+    background: color || "#8b949e",
     flexShrink: 0,
   }),
   title: { fontWeight: 700, fontSize: 14, flex: 1 },
+  titleCollapsed: {
+    fontWeight: 700,
+    fontSize: 12,
+    color: "#e6edf3",
+    writingMode: "vertical-rl",
+    transform: "rotate(180deg)",
+    whiteSpace: "nowrap",
+  },
   count: { fontSize: 12, color: "#8b949e" },
   body: {
     padding: "10px 10px",
@@ -60,11 +84,26 @@ const s = {
 
 export default function Column({ title, issues }) {
   const { setNodeRef, isOver } = useDroppable({ id: title });
+  const { collapsedColumns, toggleCollapsed } = useIssueStore();
+  const collapsed = collapsedColumns.has(title);
+  const color = COLUMN_COLORS[title] || "#8b949e";
+
+  if (collapsed) {
+    return (
+      <div ref={setNodeRef} style={s.columnCollapsed(isOver)}>
+        <div style={s.headerCollapsed} onClick={() => toggleCollapsed(title)}>
+          <span style={s.dot(color)} />
+          <span style={s.count}>{issues.length}</span>
+          <span style={s.titleCollapsed}>{title}</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={s.column(isOver)}>
-      <div style={s.header}>
-        <span style={s.dot(title)} />
+      <div style={s.header} onClick={() => toggleCollapsed(title)}>
+        <span style={s.dot(color)} />
         <span style={s.title}>{title}</span>
         <span style={s.count}>{issues.length}</span>
       </div>

--- a/kanban/src/components/Header.jsx
+++ b/kanban/src/components/Header.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useIssueStore } from "../store/issues";
 import { useAuthStore } from "../store/auth";
-import { fetchAllIssues } from "../api/github";
+import { fetchAllIssues, fetchUserRepos } from "../api/github";
 
 const s = {
   header: {
@@ -14,7 +14,7 @@ const s = {
     flexWrap: "wrap",
   },
   title: { fontWeight: 700, fontSize: 18, color: "#58a6ff", marginRight: 8 },
-  input: {
+  select: {
     background: "#0d1117",
     border: "1px solid #30363d",
     borderRadius: 6,
@@ -22,16 +22,12 @@ const s = {
     padding: "6px 10px",
     fontSize: 14,
     outline: "none",
-  },
-  btn: {
-    background: "#238636",
-    color: "#fff",
-    border: "none",
-    borderRadius: 6,
-    padding: "6px 16px",
+    minWidth: 220,
     cursor: "pointer",
-    fontWeight: 600,
-    fontSize: 14,
+  },
+  selectDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
   },
   signOutBtn: {
     background: "none",
@@ -62,47 +58,77 @@ const s = {
 };
 
 export default function Header({ repo, onRepoChange }) {
-  const [repoInput, setRepoInput] = useState(repo || "");
   const { setIssues, setLoading, setError, loading, error } = useIssueStore();
   const { token, user, clearAuth } = useAuthStore();
 
-  async function handleLoad() {
-    const trimmed = repoInput.trim();
-    if (!trimmed.includes("/")) {
-      setError("Enter repo as owner/repo");
-      return;
-    }
-    const [owner, repoName] = trimmed.split("/");
+  const [repos, setRepos] = useState([]);
+  const [reposLoading, setReposLoading] = useState(true);
+  const [reposError, setReposError] = useState(null);
+
+  // Fetch accessible repos once on mount
+  useEffect(() => {
+    let cancelled = false;
+    setReposLoading(true);
+    fetchUserRepos(token)
+      .then((data) => {
+        if (cancelled) return;
+        setRepos(data.map((r) => r.full_name).sort((a, b) => a.localeCompare(b)));
+        setReposLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setReposError(e?.response?.data?.message || e.message || "Failed to load repos");
+        setReposLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [token]);
+
+  // Auto-load issues when repo is selected (including restored value from localStorage)
+  useEffect(() => {
+    if (!repo) return;
+    const [owner, repoName] = repo.split("/");
+    if (!owner || !repoName) return;
     setError(null);
     setLoading(true);
-    try {
-      const issues = await fetchAllIssues(owner, repoName, token);
-      setIssues(issues);
-      onRepoChange(trimmed);
-    } catch (e) {
-      setError(e?.response?.data?.message || e.message || "Failed to load");
-    } finally {
-      setLoading(false);
-    }
+    fetchAllIssues(owner, repoName, token)
+      .then((issues) => setIssues(issues))
+      .catch((e) => setError(e?.response?.data?.message || e.message || "Failed to load"))
+      .finally(() => setLoading(false));
+  }, [repo]);
+
+  function handleSelect(e) {
+    const value = e.target.value;
+    if (!value) return;
+    onRepoChange(value);
   }
+
+  const selectStyle = reposLoading || loading
+    ? { ...s.select, ...s.selectDisabled }
+    : s.select;
 
   return (
     <header style={s.header}>
       <span style={s.title}>GitHub Kanban</span>
-      <input
-        style={{ ...s.input, width: 220 }}
-        placeholder="owner/repo"
-        value={repoInput}
-        onChange={(e) => setRepoInput(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && handleLoad()}
-      />
-      <button style={s.btn} onClick={handleLoad} disabled={loading}>
-        {loading ? "Loading…" : "Load"}
-      </button>
+
+      <select
+        style={selectStyle}
+        value={repo || ""}
+        onChange={handleSelect}
+        disabled={reposLoading || loading}
+      >
+        {reposLoading && <option value="">Loading repos…</option>}
+        {!reposLoading && !repo && <option value="">Select a repo…</option>}
+        {repos.map((r) => (
+          <option key={r} value={r}>{r}</option>
+        ))}
+      </select>
+
+      {reposError && <span style={s.error}>{reposError}</span>}
       {error && <span style={s.error}>{error}</span>}
-      {!error && !loading && repo && (
-        <span style={s.info}>Loaded: {repo}</span>
+      {!error && !reposError && loading && (
+        <span style={s.info}>Loading issues…</span>
       )}
+
       <div style={s.userInfo}>
         {user?.avatar_url && (
           <img src={user.avatar_url} alt={user.login} style={s.avatar} />

--- a/kanban/src/components/IssueCard.jsx
+++ b/kanban/src/components/IssueCard.jsx
@@ -1,14 +1,7 @@
 import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useIssueStore, issueType, ALL_COLUMN_LABELS, TYPES } from "../store/issues";
-
-const TYPE_COLOR = {
-  epic: "#a371f7",
-  story: "#58a6ff",
-  bug: "#f85149",
-  task: "#3fb950",
-};
+import { useIssueStore, issueType, ALL_COLUMN_LABELS, TYPES, TYPE_COLORS } from "../store/issues";
 
 const SKIP_LABELS = new Set([...TYPES, ...ALL_COLUMN_LABELS]);
 
@@ -33,8 +26,8 @@ const s = {
   typeBadge: (type) => ({
     fontSize: 10,
     fontWeight: 700,
-    background: TYPE_COLOR[type] + "33",
-    color: TYPE_COLOR[type],
+    background: (TYPE_COLORS[type] || "#8b949e") + "33",
+    color: TYPE_COLORS[type] || "#8b949e",
     borderRadius: 4,
     padding: "1px 6px",
     textTransform: "uppercase",

--- a/kanban/src/components/IssueCard.jsx
+++ b/kanban/src/components/IssueCard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useIssueStore, issueType } from "../store/issues";
+import { useIssueStore, issueType, ALL_COLUMN_LABELS, TYPES } from "../store/issues";
 
 const TYPE_COLOR = {
   epic: "#a371f7",
@@ -10,14 +10,7 @@ const TYPE_COLOR = {
   task: "#3fb950",
 };
 
-const SKIP_LABELS = new Set([
-  "epic",
-  "story",
-  "bug",
-  "task",
-  "in progress",
-  "in review",
-]);
+const SKIP_LABELS = new Set([...TYPES, ...ALL_COLUMN_LABELS]);
 
 const s = {
   card: (isDragging, overlay) => ({

--- a/kanban/src/components/IssueDetail.jsx
+++ b/kanban/src/components/IssueDetail.jsx
@@ -7,6 +7,7 @@ import {
   COLUMN_LABELS,
   issueType,
   issueColumn,
+  getCloseIssueColumn,
 } from "../store/issues";
 import { updateIssue, fetchComments, createComment } from "../api/github";
 
@@ -216,7 +217,7 @@ export default function IssueDetail({ repo, token }) {
       const colLabel = COLUMN_LABELS[column];
       if (colLabel) labels.push(colLabel);
 
-      const newState = column === "Complete" ? "closed" : "open";
+      const newState = column === getCloseIssueColumn() ? "closed" : "open";
 
       const updated = await updateIssue(
         owner,

--- a/kanban/src/components/IssueDetail.jsx
+++ b/kanban/src/components/IssueDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   useIssueStore,
   TYPES,
@@ -24,7 +24,7 @@ const s = {
     background: "#161b22",
     border: "1px solid #30363d",
     borderRadius: 12,
-    width: "min(720px, 95vw)",
+    width: "min(1100px, 95vw)",
     maxHeight: "90vh",
     display: "flex",
     flexDirection: "column",
@@ -104,9 +104,11 @@ const s = {
     outline: "none",
     width: "100%",
     minHeight: 120,
-    resize: "vertical",
+    resize: "none",
     fontFamily: "inherit",
     lineHeight: 1.5,
+    overflow: "hidden",
+    boxSizing: "border-box",
   },
   saveBtn: {
     background: "#238636",
@@ -175,6 +177,16 @@ export default function IssueDetail({ repo, token }) {
   const [commentsLoading, setCommentsLoading] = useState(false);
   const [newComment, setNewComment] = useState("");
   const [postingComment, setPostingComment] = useState(false);
+
+  const bodyRef = useRef(null);
+
+  // Auto-size the description textarea to its content
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [body]);
 
   const [owner, repoName] = (repo || "/").split("/");
 
@@ -274,6 +286,7 @@ export default function IssueDetail({ repo, token }) {
             <div>
               <div style={s.fieldLabel}>Description</div>
               <textarea
+                ref={bodyRef}
                 style={s.textarea}
                 value={body}
                 onChange={(e) => setBody(e.target.value)}

--- a/kanban/src/components/Sidebar.jsx
+++ b/kanban/src/components/Sidebar.jsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { useIssueStore, TYPES, issueType, COLUMNS } from "../store/issues";
+import { useIssueStore, TYPES, issueType, COLUMNS, TYPE_COLORS, COLUMN_COLORS } from "../store/issues";
 import NewIssueForm from "./NewIssueForm";
-
-const TYPE_COLOR = {
-  epic: "#a371f7",
-  story: "#58a6ff",
-  bug: "#f85149",
-  task: "#3fb950",
-};
-
-const COLUMN_COLOR = {
-  Triage: "#e3b341",
-  Backlog: "#8b949e",
-  Ready: "#58a6ff",
-  "In Progress": "#1f6feb",
-  "In Review": "#a371f7",
-  "Sign Off": "#db6d28",
-  Complete: "#3fb950",
-};
 
 const s = {
   sidebar: {
@@ -93,7 +76,7 @@ export default function Sidebar() {
             onClick={() => toggleType(type)}
             title={activeTypes.has(type) ? "Hide" : "Show"}
           >
-            <span style={s.dot(TYPE_COLOR[type])} />
+            <span style={s.dot(TYPE_COLORS[type] || "#8b949e")} />
             <span style={s.label(activeTypes.has(type))}>
               {type.charAt(0).toUpperCase() + type.slice(1)}
             </span>
@@ -106,7 +89,7 @@ export default function Sidebar() {
         <span style={s.heading}>Columns</span>
         {COLUMNS.map((col) => (
           <div key={col} style={{ ...s.typeRow, cursor: "default" }}>
-            <span style={s.dot(COLUMN_COLOR[col])} />
+            <span style={s.dot(COLUMN_COLORS[col] || "#8b949e")} />
             <span style={s.label(true)}>{col}</span>
             <span style={s.count}>{countByColumn[col] ?? 0}</span>
           </div>

--- a/kanban/src/main.jsx
+++ b/kanban/src/main.jsx
@@ -2,8 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import configPromise from "./api/config";
+import { initColumns } from "./store/issues";
 
 configPromise.then((config) => {
+  if (!config.columns || !config.types) {
+    document.getElementById("root").textContent =
+      "Failed to load config: missing required 'columns' or 'types' keys in config.json";
+    return;
+  }
+  initColumns(config.columns, config.types);
   ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
       <App config={config} />

--- a/kanban/src/store/issues.js
+++ b/kanban/src/store/issues.js
@@ -1,59 +1,79 @@
 import { create } from "zustand";
 
+const COLLAPSED_KEY = "gh_kanban_collapsed";
+
+// These are populated by initColumns() before React mounts.
+// Treat as read-only after initialisation.
+export let COLUMNS = [];
+export let COLUMN_LABELS = {};
+export let COLUMN_COLORS = {};
+export let ALL_COLUMN_LABELS = [];
+export let TYPES = [];
+export let TYPE_COLORS = {};
+
+let _defaultColumn = "Backlog";
+let _closeIssueColumn = "Complete";
+
+export function initColumns(columns, types) {
+  COLUMNS = columns.map((c) => c.name);
+
+  COLUMN_LABELS = {};
+  COLUMN_COLORS = {};
+  ALL_COLUMN_LABELS = [];
+
+  for (const c of columns) {
+    COLUMN_LABELS[c.name] = c.label || null;
+    COLUMN_COLORS[c.name] = c.color || "#8b949e";
+    if (c.label) ALL_COLUMN_LABELS.push(c.label.toLowerCase());
+    if (c.default) _defaultColumn = c.name;
+    if (c.closeIssue) _closeIssueColumn = c.name;
+  }
+
+  TYPES = types.map((t) => t.name);
+  TYPE_COLORS = {};
+  for (const t of types) {
+    TYPE_COLORS[t.name] = t.color || "#8b949e";
+  }
+}
+
+export function getCloseIssueColumn() {
+  return _closeIssueColumn;
+}
+
+export function getDefaultColumn() {
+  return _defaultColumn;
+}
+
 export function issueType(issue) {
-  const names = (issue.labels || []).map((l) =>
-    (l.name || "").toLowerCase()
-  );
-  if (names.includes("epic")) return "epic";
-  if (names.includes("story")) return "story";
-  if (names.includes("bug")) return "bug";
-  return "task";
+  const names = (issue.labels || []).map((l) => (l.name || "").toLowerCase());
+  for (const t of TYPES) {
+    if (names.includes(t.toLowerCase())) return t;
+  }
+  return TYPES[TYPES.length - 1] || "task";
 }
 
 export function issueColumn(issue) {
-  if (issue.state === "closed") return "Complete";
-  const names = (issue.labels || []).map((l) =>
-    (l.name || "").toLowerCase()
-  );
-  if (names.includes("status:sign-off")) return "Sign Off";
-  if (names.includes("status:in-review")) return "In Review";
-  if (names.includes("status:in-progress")) return "In Progress";
-  if (names.includes("status:ready")) return "Ready";
-  if (names.includes("status:triage")) return "Triage";
-  return "Backlog";
+  if (issue.state === "closed") return _closeIssueColumn;
+  const names = (issue.labels || []).map((l) => (l.name || "").toLowerCase());
+  for (const col of COLUMNS) {
+    const lbl = COLUMN_LABELS[col];
+    if (lbl && names.includes(lbl.toLowerCase())) return col;
+  }
+  return _defaultColumn;
 }
 
-export const COLUMNS = [
-  "Triage",
-  "Backlog",
-  "Ready",
-  "In Progress",
-  "In Review",
-  "Sign Off",
-  "Complete",
-];
+function loadCollapsed() {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_KEY);
+    return raw ? new Set(JSON.parse(raw)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
 
-// Labels that map 1-to-1 with columns (Complete = closed state, not a label)
-export const COLUMN_LABELS = {
-  Triage: "status:triage",
-  Backlog: null,
-  Ready: "status:ready",
-  "In Progress": "status:in-progress",
-  "In Review": "status:in-review",
-  "Sign Off": "status:sign-off",
-  Complete: null,
-};
-
-// All label values used for column tracking — strip these when moving columns
-export const ALL_COLUMN_LABELS = [
-  "status:triage",
-  "status:ready",
-  "status:in-progress",
-  "status:in-review",
-  "status:sign-off",
-];
-
-export const TYPES = ["epic", "story", "bug", "task"];
+function saveCollapsed(set) {
+  localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...set]));
+}
 
 export const useIssueStore = create((set, get) => ({
   issues: [],
@@ -62,9 +82,10 @@ export const useIssueStore = create((set, get) => ({
   selectedIssue: null,
   activeTypes: new Set(TYPES),
   columnOrder: {},
+  collapsedColumns: loadCollapsed(),
 
   setIssues(issues) {
-    set({ issues });
+    set({ issues, activeTypes: new Set(TYPES) });
   },
 
   setLoading(loading) {
@@ -86,12 +107,19 @@ export const useIssueStore = create((set, get) => ({
   toggleType(type) {
     set((state) => {
       const next = new Set(state.activeTypes);
-      if (next.has(type)) {
-        next.delete(type);
-      } else {
-        next.add(type);
-      }
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
       return { activeTypes: next };
+    });
+  },
+
+  toggleCollapsed(name) {
+    set((state) => {
+      const next = new Set(state.collapsedColumns);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      saveCollapsed(next);
+      return { collapsedColumns: next };
     });
   },
 
@@ -106,7 +134,7 @@ export const useIssueStore = create((set, get) => ({
         // Add the new column label if one exists for this column
         const colLabel = COLUMN_LABELS[targetColumn];
         if (colLabel) labels.push(colLabel);
-        const newState = targetColumn === "Complete" ? "closed" : "open";
+        const newState = targetColumn === _closeIssueColumn ? "closed" : "open";
         return {
           ...iss,
           state: newState,
@@ -117,10 +145,7 @@ export const useIssueStore = create((set, get) => ({
       });
       return {
         issues,
-        columnOrder: {
-          ...state.columnOrder,
-          [issueNumber]: targetColumn,
-        },
+        columnOrder: { ...state.columnOrder, [issueNumber]: targetColumn },
       };
     });
   },

--- a/kanban/src/store/issues.js
+++ b/kanban/src/store/issues.js
@@ -15,11 +15,11 @@ export function issueColumn(issue) {
   const names = (issue.labels || []).map((l) =>
     (l.name || "").toLowerCase()
   );
-  if (names.includes("sign off")) return "Sign Off";
-  if (names.includes("in review")) return "In Review";
-  if (names.includes("in progress")) return "In Progress";
-  if (names.includes("ready")) return "Ready";
-  if (names.includes("triage")) return "Triage";
+  if (names.includes("status:sign-off")) return "Sign Off";
+  if (names.includes("status:in-review")) return "In Review";
+  if (names.includes("status:in-progress")) return "In Progress";
+  if (names.includes("status:ready")) return "Ready";
+  if (names.includes("status:triage")) return "Triage";
   return "Backlog";
 }
 
@@ -35,22 +35,22 @@ export const COLUMNS = [
 
 // Labels that map 1-to-1 with columns (Complete = closed state, not a label)
 export const COLUMN_LABELS = {
-  Triage: "triage",
+  Triage: "status:triage",
   Backlog: null,
-  Ready: "ready",
-  "In Progress": "in progress",
-  "In Review": "in review",
-  "Sign Off": "sign off",
+  Ready: "status:ready",
+  "In Progress": "status:in-progress",
+  "In Review": "status:in-review",
+  "Sign Off": "status:sign-off",
   Complete: null,
 };
 
 // All label values used for column tracking — strip these when moving columns
 export const ALL_COLUMN_LABELS = [
-  "triage",
-  "ready",
-  "in progress",
-  "in review",
-  "sign off",
+  "status:triage",
+  "status:ready",
+  "status:in-progress",
+  "status:in-review",
+  "status:sign-off",
 ];
 
 export const TYPES = ["epic", "story", "bug", "task"];


### PR DESCRIPTION
## Summary

- Replaces the manual \`owner/repo\` text input + Load button in the header with a \`<select>\` dropdown populated from \`GET /user/repos\` on mount — no typing required
- Issues auto-load on selection; previously saved repo from \`localStorage\` is pre-selected and loads automatically on refresh
- Fixes column label matching — \`issueColumn\`, \`COLUMN_LABELS\`, and \`ALL_COLUMN_LABELS\` updated from bare words to the actual \`status:*\` prefixed labels used by the repo
- \`IssueCard\` \`SKIP_LABELS\` now derived from \`TYPES + ALL_COLUMN_LABELS\` instead of a stale hardcoded set

## Configurable columns/types + collapsible columns

- All column and type definitions moved to \`config.json\` — \`columns\` and \`types\` arrays with \`name\`, \`label\`, \`color\`, \`default\`, and \`closeIssue\` flags
- \`initColumns(columns, types)\` called synchronously in \`main.jsx\` before \`ReactDOM.createRoot\`; renders plain error if config is missing keys
- \`COLUMN_COLORS\` and \`TYPE_COLORS\` exported from store; hardcoded color maps removed from \`Column.jsx\`, \`IssueCard.jsx\`, \`Sidebar.jsx\`
- Column header is now a clickable button — collapses to a 48px-wide vertical strip with rotated title and count; drop target stays active
- Collapsed column state persists to \`localStorage\` under key \`gh_kanban_collapsed\`
- \`getCloseIssueColumn()\` and \`getDefaultColumn()\` exported from store; \`Board.jsx\` and \`IssueDetail.jsx\` use them instead of hardcoded \`"Complete"\`