### PR TITLE
feat: add carry-based movement and stamina feedback

### DIFF
--- a/STATE_OF_THE_GAME.md
+++ b/STATE_OF_THE_GAME.md
@@ -109,8 +109,20 @@ The journal is your memory. As you test, combine, and re-test, it fills with the
 
 ---
 
+## Weight and Stamina
+
+Carrying materials has consequences now.
+
+The more weight you carry, the slower you move. A single light sphere barely affects your pace, but stash a handful of heavy cubes and you'll feel the difference. The speed curve is smooth — you won't hit a wall, just a steady drag that grows with load.
+
+**Sprinting** (hold **Shift**) gives you a burst of speed, but it costs stamina. Stamina drains faster when you're carrying more weight. Stop sprinting and it regenerates — stand still to catch your breath faster. If your stamina runs out, you can't sprint until it recovers.
+
+All of this is tunable in `assets/config/carry.toml` — sprint speed, base stamina, drain and regen rates are per-profile. Creative mode ignores weight and stamina entirely.
+
+---
+
 ## What Lies Ahead
 
-The carry system now lets you juggle multiple materials, but you can't yet feel their weight. Soon your steps will slow under a heavy load, your stamina will drain faster, and your carry strength will grow with use. The world beyond the doorway is waiting.
+The workshop is functional. You can gather, carry, heat, combine, and record. Your body now responds to what you carry. The world beyond the doorway is waiting.
 
-But for now — ten materials, one burner, one fabricator, a carry container, and a journal full of blank pages. The rest is up to you.
+But for now — ten materials, one burner, one fabricator, a carry container that slows you down, and a journal full of blank pages. The rest is up to you.

--- a/assets/config/input.toml
+++ b/assets/config/input.toml
@@ -6,6 +6,7 @@ sensitivity_y = 0.3
 Move = { up = "W", down = "S", left = "A", right = "D" }
 CaptureCursor = ["MouseLeft"]
 Interact = ["E"]
+Sprint = ["ShiftLeft"]
 Examine = ["Q"]
 Stash = ["T"]
 CycleCarry = ["C"]

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -42,6 +42,7 @@ impl Plugin for CarryPlugin {
             .add_message::<CarryActionRejected>()
             .init_resource::<CarryConfig>()
             .init_resource::<ActiveCarryProfile>()
+            .init_resource::<CarryMovementState>()
             .add_systems(PreStartup, load_carry_config)
             .add_systems(
                 Startup,
@@ -50,6 +51,7 @@ impl Plugin for CarryPlugin {
             .add_systems(
                 Update,
                 (
+                    update_carry_movement_state,
                     emit_stash_intent,
                     emit_cycle_carry_intent,
                     emit_drop_carry_intent,
@@ -105,6 +107,31 @@ pub(crate) enum CarryRejectionReason {
 pub(crate) struct CarryWeightChanged {
     pub current_weight: f32,
     pub effective_capacity: f32,
+}
+
+/// Current movement-facing interpretation of carry consequences.
+///
+/// `CarryState` is the source of truth for inventory mass. This resource is the
+/// source of truth for *how that mass affects locomotion right now*. Keeping the
+/// two separated lets later stories change the feedback model without rewriting
+/// how carry contents are tracked.
+#[derive(Clone, Debug, Resource, PartialEq)]
+pub(crate) struct CarryMovementState {
+    pub speed_modifier: f32,
+    pub stamina_drain_multiplier: f32,
+    pub encumbrance_ratio: f32,
+    pub creative_mode: bool,
+}
+
+impl Default for CarryMovementState {
+    fn default() -> Self {
+        Self {
+            speed_modifier: 1.0,
+            stamina_drain_multiplier: 1.0,
+            encumbrance_ratio: 0.0,
+            creative_mode: false,
+        }
+    }
 }
 
 /// Marks a material entity as being in the player's carry container rather than
@@ -555,6 +582,80 @@ fn attach_carry_state_to_player(
         },
         device_state,
     ));
+}
+
+/// Convert current carry state into movement-facing consequences.
+///
+/// This runs every frame instead of only on `CarryWeightChanged` because Story 4.3
+/// is the first consumer and simplicity matters more than event fan-out here.
+/// Later stories can make this reactive if needed.
+fn update_carry_movement_state(
+    active_profile: Res<ActiveCarryProfile>,
+    mut movement_state: ResMut<CarryMovementState>,
+    player_query: Query<&CarryState, With<Player>>,
+) {
+    let Ok(carry_state) = player_query.single() else {
+        return;
+    };
+
+    if active_profile.profile_name == "creative" {
+        *movement_state = CarryMovementState {
+            speed_modifier: 1.0,
+            stamina_drain_multiplier: 1.0,
+            encumbrance_ratio: 0.0,
+            creative_mode: true,
+        };
+        return;
+    }
+
+    let encumbrance_ratio = if carry_state.effective_capacity <= f32::EPSILON {
+        if carry_state.current_weight > 0.0 {
+            1.0
+        } else {
+            0.0
+        }
+    } else {
+        (carry_state.current_weight / carry_state.effective_capacity).max(0.0)
+    };
+
+    let speed_modifier = evaluate_speed_curve(
+        &active_profile.tuning.speed_curve,
+        encumbrance_ratio,
+        carry_state.hard_limit_enabled,
+    );
+    let stamina_drain_multiplier =
+        1.0 + encumbrance_ratio.max(0.0) * (active_profile.tuning.stamina_cost_multiplier - 1.0);
+
+    *movement_state = CarryMovementState {
+        speed_modifier,
+        stamina_drain_multiplier,
+        encumbrance_ratio,
+        creative_mode: false,
+    };
+}
+
+fn evaluate_speed_curve(
+    curve: &CarryCurveConfig,
+    encumbrance_ratio: f32,
+    hard_limit_enabled: bool,
+) -> f32 {
+    let clamped_ratio = if hard_limit_enabled {
+        encumbrance_ratio.clamp(0.0, 1.0)
+    } else {
+        encumbrance_ratio.max(0.0)
+    };
+
+    let falloff = match curve.kind {
+        CarryCurveKind::Linear => clamped_ratio.powf(curve.exponent.max(0.01)),
+        CarryCurveKind::Exponential => 1.0 - (-clamped_ratio * curve.exponent.max(0.01)).exp(),
+    };
+
+    let base = 1.0 - (1.0 - curve.min_multiplier) * falloff;
+    if hard_limit_enabled {
+        base.max(curve.min_multiplier)
+    } else {
+        base.max(0.1)
+    }
 }
 
 /// Capacity depends on both the configured base capacity and the carry-device rule.
@@ -1012,5 +1113,27 @@ exponent = 1.0
     fn evict_stale_entity_returns_false_for_unknown() {
         let mut state = CarryState::new(5.0, true);
         assert!(!state.evict_stale_entity(Entity::from_bits(999)));
+    }
+
+    #[test]
+    fn linear_speed_curve_clamps_at_min_multiplier_when_hard_limit_is_enabled() {
+        let curve = CarryCurveConfig {
+            kind: CarryCurveKind::Linear,
+            min_multiplier: 0.45,
+            exponent: 1.0,
+        };
+
+        assert!((evaluate_speed_curve(&curve, 3.0, true) - 0.45).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn linear_speed_curve_continues_degrading_when_hard_limit_is_disabled() {
+        let curve = CarryCurveConfig {
+            kind: CarryCurveKind::Linear,
+            min_multiplier: 0.45,
+            exponent: 1.0,
+        };
+
+        assert!(evaluate_speed_curve(&curve, 3.0, false) < 0.45);
     }
 }

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -121,6 +121,14 @@ pub(crate) struct CarryMovementState {
     pub stamina_drain_multiplier: f32,
     pub encumbrance_ratio: f32,
     pub creative_mode: bool,
+    /// Sprint speed multiplier sourced from the active carry profile config.
+    pub sprint_speed_multiplier: f32,
+    /// Maximum stamina from the active carry profile config.
+    pub base_stamina: f32,
+    /// Stamina drain per second (before the weight-based multiplier) from config.
+    pub stamina_drain_per_second: f32,
+    /// Stamina regen per second from config.
+    pub stamina_regen_per_second: f32,
 }
 
 impl Default for CarryMovementState {
@@ -130,6 +138,10 @@ impl Default for CarryMovementState {
             stamina_drain_multiplier: 1.0,
             encumbrance_ratio: 0.0,
             creative_mode: false,
+            sprint_speed_multiplier: default_sprint_speed_multiplier(),
+            base_stamina: default_base_stamina(),
+            stamina_drain_per_second: default_stamina_drain_per_second(),
+            stamina_regen_per_second: default_stamina_regen_per_second(),
         }
     }
 }
@@ -416,6 +428,17 @@ pub(crate) struct CarryProfileConfig {
     pub stamina_cost_multiplier: f32,
     #[serde(default = "default_hard_limit_enabled")]
     pub hard_limit_enabled: bool,
+    /// When true, carry weight has no effect on movement or stamina.
+    #[serde(default)]
+    pub creative_mode: bool,
+    #[serde(default = "default_sprint_speed_multiplier")]
+    pub sprint_speed_multiplier: f32,
+    #[serde(default = "default_base_stamina")]
+    pub base_stamina: f32,
+    #[serde(default = "default_stamina_drain_per_second")]
+    pub stamina_drain_per_second: f32,
+    #[serde(default = "default_stamina_regen_per_second")]
+    pub stamina_regen_per_second: f32,
 }
 
 fn default_profile_config() -> CarryProfileConfig {
@@ -423,6 +446,11 @@ fn default_profile_config() -> CarryProfileConfig {
         speed_curve: CarryCurveConfig::default(),
         stamina_cost_multiplier: default_stamina_cost_multiplier(),
         hard_limit_enabled: default_hard_limit_enabled(),
+        creative_mode: false,
+        sprint_speed_multiplier: default_sprint_speed_multiplier(),
+        base_stamina: default_base_stamina(),
+        stamina_drain_per_second: default_stamina_drain_per_second(),
+        stamina_regen_per_second: default_stamina_regen_per_second(),
     }
 }
 
@@ -435,6 +463,11 @@ fn relaxed_profile_config() -> CarryProfileConfig {
         },
         stamina_cost_multiplier: 1.15,
         hard_limit_enabled: false,
+        creative_mode: false,
+        sprint_speed_multiplier: default_sprint_speed_multiplier(),
+        base_stamina: default_base_stamina(),
+        stamina_drain_per_second: default_stamina_drain_per_second(),
+        stamina_regen_per_second: default_stamina_regen_per_second(),
     }
 }
 
@@ -447,6 +480,11 @@ fn creative_profile_config() -> CarryProfileConfig {
         },
         stamina_cost_multiplier: 1.0,
         hard_limit_enabled: false,
+        creative_mode: true,
+        sprint_speed_multiplier: default_sprint_speed_multiplier(),
+        base_stamina: default_base_stamina(),
+        stamina_drain_per_second: default_stamina_drain_per_second(),
+        stamina_regen_per_second: default_stamina_regen_per_second(),
     }
 }
 
@@ -456,6 +494,18 @@ fn default_stamina_cost_multiplier() -> f32 {
 
 fn default_hard_limit_enabled() -> bool {
     true
+}
+fn default_sprint_speed_multiplier() -> f32 {
+    1.45
+}
+fn default_base_stamina() -> f32 {
+    100.0
+}
+fn default_stamina_drain_per_second() -> f32 {
+    22.0
+}
+fn default_stamina_regen_per_second() -> f32 {
+    14.0
 }
 
 /// Config shape for future speed degradation curves.
@@ -598,12 +648,23 @@ fn update_carry_movement_state(
         return;
     };
 
-    if active_profile.profile_name == "creative" {
+    // Always propagate the stamina tuning knobs from the active profile so
+    // player.rs never needs its own hardcoded copies.
+    let sprint_speed_multiplier = active_profile.tuning.sprint_speed_multiplier;
+    let base_stamina = active_profile.tuning.base_stamina;
+    let stamina_drain_per_second = active_profile.tuning.stamina_drain_per_second;
+    let stamina_regen_per_second = active_profile.tuning.stamina_regen_per_second;
+
+    if active_profile.tuning.creative_mode {
         *movement_state = CarryMovementState {
             speed_modifier: 1.0,
             stamina_drain_multiplier: 1.0,
             encumbrance_ratio: 0.0,
             creative_mode: true,
+            sprint_speed_multiplier,
+            base_stamina,
+            stamina_drain_per_second,
+            stamina_regen_per_second,
         };
         return;
     }
@@ -631,6 +692,10 @@ fn update_carry_movement_state(
         stamina_drain_multiplier,
         encumbrance_ratio,
         creative_mode: false,
+        sprint_speed_multiplier,
+        base_stamina,
+        stamina_drain_per_second,
+        stamina_regen_per_second,
     };
 }
 
@@ -1135,5 +1200,26 @@ exponent = 1.0
         };
 
         assert!(evaluate_speed_curve(&curve, 3.0, false) < 0.45);
+    }
+
+    #[test]
+    fn exponential_speed_curve_degrades_faster_at_high_encumbrance() {
+        let curve = CarryCurveConfig {
+            kind: CarryCurveKind::Exponential,
+            min_multiplier: 0.45,
+            exponent: 2.0,
+        };
+
+        let at_25 = evaluate_speed_curve(&curve, 0.25, true);
+        let at_75 = evaluate_speed_curve(&curve, 0.75, true);
+
+        // Exponential curve should produce meaningful degradation.
+        assert!(at_25 > at_75, "higher encumbrance should be slower");
+        // At 75% load the multiplier should sit between min and the 25% value.
+        assert!(at_75 >= 0.45, "should not drop below min_multiplier");
+        assert!(at_75 < at_25, "75% load slower than 25% load");
+        // At 0% load there should be no penalty.
+        let at_0 = evaluate_speed_curve(&curve, 0.0, true);
+        assert!((at_0 - 1.0).abs() < f32::EPSILON, "zero load = full speed");
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -58,6 +58,7 @@ pub(crate) enum InputAction {
     #[actionlike(DualAxis)]
     Look,
     CaptureCursor,
+    Sprint,
     Interact,
     Examine,
     Stash,
@@ -109,6 +110,8 @@ pub(crate) struct BindingsConfig {
     pub interact: Vec<String>,
     #[serde(default = "default_capture_cursor", rename = "CaptureCursor")]
     pub capture_cursor: Vec<String>,
+    #[serde(default = "default_sprint", rename = "Sprint")]
+    pub sprint: Vec<String>,
     #[serde(default = "default_examine", rename = "Examine")]
     pub examine: Vec<String>,
     #[serde(default = "default_stash", rename = "Stash")]
@@ -133,6 +136,7 @@ impl Default for BindingsConfig {
             movement: MoveBindings::default(),
             interact: default_interact(),
             capture_cursor: default_capture_cursor(),
+            sprint: default_sprint(),
             examine: default_examine(),
             stash: default_stash(),
             cycle_carry: default_cycle_carry(),
@@ -185,6 +189,9 @@ fn default_interact() -> Vec<String> {
 }
 fn default_capture_cursor() -> Vec<String> {
     vec!["MouseLeft".into()]
+}
+fn default_sprint() -> Vec<String> {
+    vec!["ShiftLeft".into()]
 }
 fn default_examine() -> Vec<String> {
     vec!["Q".into()]
@@ -348,6 +355,7 @@ pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
         InputAction::CaptureCursor,
         &bindings.capture_cursor,
     );
+    insert_bindings(&mut input_map, InputAction::Sprint, &bindings.sprint);
     insert_bindings(&mut input_map, InputAction::Examine, &bindings.examine);
     insert_bindings(&mut input_map, InputAction::Stash, &bindings.stash);
     insert_bindings(
@@ -456,6 +464,7 @@ sensitivity_y = 0.4
 Move = { up = "I", down = "K", left = "J", right = "L" }
 Interact = ["F"]
 CaptureCursor = ["MouseRight"]
+Sprint = ["ShiftLeft"]
 Stash = ["T"]
 CycleCarry = ["C"]
 Drop = ["G"]
@@ -464,6 +473,7 @@ Drop = ["G"]
         assert_eq!(config.bindings.movement.up, "I");
         assert_eq!(config.bindings.interact, vec!["F"]);
         assert_eq!(config.bindings.capture_cursor, vec!["MouseRight"]);
+        assert_eq!(config.bindings.sprint, vec!["ShiftLeft"]);
         assert_eq!(config.bindings.stash, vec!["T"]);
         assert_eq!(config.bindings.cycle_carry, vec!["C"]);
         assert_eq!(config.bindings.drop_item, vec!["G"]);
@@ -502,6 +512,7 @@ Drop = ["G"]
         let config_str = r#"
 [bindings]
 CaptureCursor = ["MouseLeft"]
+Sprint = ["ShiftLeft"]
 Interact = ["MouseLeft"]
 Examine = ["MouseRight"]
 Stash = ["T"]
@@ -515,6 +526,10 @@ Drop = ["G"]
                 .get_buttonlike(&InputAction::CaptureCursor)
                 .is_some(),
             "CaptureCursor should accept MouseButton bindings"
+        );
+        assert!(
+            input_map.get_buttonlike(&InputAction::Sprint).is_some(),
+            "Sprint should have bindings"
         );
         assert!(
             input_map.get_buttonlike(&InputAction::Interact).is_some(),

--- a/src/player.rs
+++ b/src/player.rs
@@ -24,10 +24,6 @@ use crate::scene::{PositionXZ, RoomShellCollision, SceneConfig};
 const LOOK_SCALE: f32 = 0.003;
 const PITCH_LIMIT: f32 = std::f32::consts::FRAC_PI_2 * 0.99;
 const PLAYER_COLLISION_RADIUS: f32 = 0.2;
-const SPRINT_SPEED_MULTIPLIER: f32 = 1.45;
-const BASE_STAMINA: f32 = 100.0;
-const BASE_STAMINA_DRAIN_PER_SECOND: f32 = 22.0;
-const BASE_STAMINA_REGEN_PER_SECOND: f32 = 14.0;
 
 /// Minimal stamina framework for Story 4.3.
 ///
@@ -81,7 +77,11 @@ pub(crate) struct PlayerCamera;
 #[derive(Component, Default)]
 struct CameraPitch(f32);
 
-pub(crate) fn spawn_player(mut commands: Commands, scene: Res<SceneConfig>) {
+pub(crate) fn spawn_player(
+    mut commands: Commands,
+    scene: Res<SceneConfig>,
+    carry_movement: Res<CarryMovementState>,
+) {
     commands
         .spawn((
             Player,
@@ -95,8 +95,8 @@ pub(crate) fn spawn_player(mut commands: Commands, scene: Res<SceneConfig>) {
             // The InputMap is attached separately by InputPlugin after spawn.
             ActionState::<InputAction>::default(),
             StaminaState {
-                current: BASE_STAMINA,
-                max: BASE_STAMINA,
+                current: carry_movement.base_stamina,
+                max: carry_movement.base_stamina,
             },
         ))
         .with_children(|parent| {
@@ -190,7 +190,27 @@ fn player_move(
     enforce_eye_height(&mut transform.translation, scene.player.eye_height);
 
     let input = action_state.clamped_axis_pair(&InputAction::Move);
-    if input == Vec2::ZERO {
+
+    // Stamina must update even when stationary so the player can "catch their
+    // breath" by standing still after exhausting sprint.
+    let wants_sprint = action_state.pressed(&InputAction::Sprint);
+    let can_sprint = carry_movement.creative_mode || stamina.current > f32::EPSILON;
+    let is_moving = input != Vec2::ZERO;
+    let is_sprinting = wants_sprint && can_sprint && is_moving;
+
+    if carry_movement.creative_mode {
+        stamina.current = stamina.max;
+    } else if is_sprinting {
+        let drain = carry_movement.stamina_drain_per_second
+            * carry_movement.stamina_drain_multiplier
+            * time.delta_secs();
+        stamina.current = (stamina.current - drain).max(0.0);
+    } else {
+        let regen = carry_movement.stamina_regen_per_second * time.delta_secs();
+        stamina.current = (stamina.current + regen).min(stamina.max);
+    }
+
+    if !is_moving {
         return;
     }
 
@@ -202,12 +222,9 @@ fn player_move(
     let right_xz = Vec3::new(right.x, 0.0, right.z).normalize_or_zero();
 
     let direction = (forward_xz * input.y + right_xz * input.x).normalize_or_zero();
-    let wants_sprint = action_state.pressed(&InputAction::Sprint);
-    let can_sprint = !carry_movement.creative_mode && stamina.current > f32::EPSILON;
-    let is_sprinting = wants_sprint && can_sprint;
 
     let sprint_multiplier = if is_sprinting {
-        SPRINT_SPEED_MULTIPLIER
+        carry_movement.sprint_speed_multiplier
     } else {
         1.0
     };
@@ -229,19 +246,6 @@ fn player_move(
         PLAYER_COLLISION_RADIUS,
     ) {
         transform.translation.z = proposed.z;
-    }
-
-    let is_moving = input != Vec2::ZERO;
-    if carry_movement.creative_mode {
-        stamina.current = stamina.max;
-    } else if is_sprinting && is_moving {
-        let drain = BASE_STAMINA_DRAIN_PER_SECOND
-            * carry_movement.stamina_drain_multiplier
-            * time.delta_secs();
-        stamina.current = (stamina.current - drain).max(0.0);
-    } else {
-        let regen = BASE_STAMINA_REGEN_PER_SECOND * time.delta_secs();
-        stamina.current = (stamina.current + regen).min(stamina.max);
     }
 
     enforce_eye_height(&mut transform.translation, scene.player.eye_height);

--- a/src/player.rs
+++ b/src/player.rs
@@ -14,6 +14,7 @@ use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, CursorOptions};
 use leafwing_input_manager::prelude::*;
 
+use crate::carry::CarryMovementState;
 use crate::input::InputAction;
 use crate::scene::{PositionXZ, RoomShellCollision, SceneConfig};
 
@@ -23,6 +24,26 @@ use crate::scene::{PositionXZ, RoomShellCollision, SceneConfig};
 const LOOK_SCALE: f32 = 0.003;
 const PITCH_LIMIT: f32 = std::f32::consts::FRAC_PI_2 * 0.99;
 const PLAYER_COLLISION_RADIUS: f32 = 0.2;
+const SPRINT_SPEED_MULTIPLIER: f32 = 1.45;
+const BASE_STAMINA: f32 = 100.0;
+const BASE_STAMINA_DRAIN_PER_SECOND: f32 = 22.0;
+const BASE_STAMINA_REGEN_PER_SECOND: f32 = 14.0;
+
+/// Minimal stamina framework for Story 4.3.
+///
+/// The design docs describe richer future stamina, but carry feedback only
+/// needs a small truthful model right now:
+/// - sprinting drains stamina
+/// - not sprinting regenerates stamina
+/// - low stamina prevents sustained sprint
+///
+/// This is intentionally enough to make weight feel physical without pretending
+/// we already have the final progression system.
+#[derive(Component, Clone, Copy, Debug, PartialEq)]
+pub(crate) struct StaminaState {
+    pub current: f32,
+    pub max: f32,
+}
 
 pub(crate) fn cursor_is_captured(grab_mode: CursorGrabMode) -> bool {
     grab_mode != CursorGrabMode::None
@@ -73,6 +94,10 @@ pub(crate) fn spawn_player(mut commands: Commands, scene: Res<SceneConfig>) {
             // leafwing tracks which actions are active on this entity.
             // The InputMap is attached separately by InputPlugin after spawn.
             ActionState::<InputAction>::default(),
+            StaminaState {
+                current: BASE_STAMINA,
+                max: BASE_STAMINA,
+            },
         ))
         .with_children(|parent| {
             parent.spawn((PlayerCamera, CameraPitch::default(), Camera3d::default()));
@@ -148,13 +173,17 @@ fn player_move(
     cursor_options: Single<&CursorOptions>,
     scene: Res<SceneConfig>,
     room_shell: Res<RoomShellCollision>,
-    mut player_query: Query<(&ActionState<InputAction>, &mut Transform), With<Player>>,
+    carry_movement: Res<CarryMovementState>,
+    mut player_query: Query<
+        (&ActionState<InputAction>, &mut Transform, &mut StaminaState),
+        With<Player>,
+    >,
 ) {
     if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
 
-    let Ok((action_state, mut transform)) = player_query.single_mut() else {
+    let Ok((action_state, mut transform, mut stamina)) = player_query.single_mut() else {
         return;
     };
 
@@ -173,7 +202,18 @@ fn player_move(
     let right_xz = Vec3::new(right.x, 0.0, right.z).normalize_or_zero();
 
     let direction = (forward_xz * input.y + right_xz * input.x).normalize_or_zero();
-    let delta = direction * scene.player.move_speed * time.delta_secs();
+    let wants_sprint = action_state.pressed(&InputAction::Sprint);
+    let can_sprint = !carry_movement.creative_mode && stamina.current > f32::EPSILON;
+    let is_sprinting = wants_sprint && can_sprint;
+
+    let sprint_multiplier = if is_sprinting {
+        SPRINT_SPEED_MULTIPLIER
+    } else {
+        1.0
+    };
+    let effective_speed =
+        scene.player.move_speed * carry_movement.speed_modifier * sprint_multiplier;
+    let delta = direction * effective_speed * time.delta_secs();
     let mut proposed = transform.translation;
     proposed.x += delta.x;
     if !room_shell.blocks_circle_xz(
@@ -189,6 +229,19 @@ fn player_move(
         PLAYER_COLLISION_RADIUS,
     ) {
         transform.translation.z = proposed.z;
+    }
+
+    let is_moving = input != Vec2::ZERO;
+    if carry_movement.creative_mode {
+        stamina.current = stamina.max;
+    } else if is_sprinting && is_moving {
+        let drain = BASE_STAMINA_DRAIN_PER_SECOND
+            * carry_movement.stamina_drain_multiplier
+            * time.delta_secs();
+        stamina.current = (stamina.current - drain).max(0.0);
+    } else {
+        let regen = BASE_STAMINA_REGEN_PER_SECOND * time.delta_secs();
+        stamina.current = (stamina.current + regen).min(stamina.max);
     }
 
     enforce_eye_height(&mut transform.translation, scene.player.eye_height);


### PR DESCRIPTION
Closes #36
Depends on #101

## Summary
- add sprint input and a minimal stamina framework to the player controller
- derive carry-based movement and stamina penalties from the active carry profile
- make creative profile ignore carry consequences while preserving the same systems

## Testing
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test