### PR TITLE
refactor: privatize 25 zero-consumer pub(crate) items across 8 modules

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -66,11 +66,11 @@ impl Plugin for CarryPlugin {
 
 /// Story 4.2 will emit this when the player wants to move the held item into carry.
 #[derive(Message)]
-pub(crate) struct StashIntent;
+struct StashIntent;
 
 /// Story 4.2 will emit this when the player wants to cycle the next carried item to hand.
 #[derive(Message)]
-pub(crate) struct CycleCarryIntent;
+struct CycleCarryIntent;
 
 /// Story 4.2 will emit this when the player wants to drop an item out of carry.
 #[derive(Message)]
@@ -103,7 +103,7 @@ pub(crate) enum CarryRejectionReason {
 /// Later stories will emit this whenever carry weight changes so movement/stamina
 /// systems can respond without polling and guessing.
 #[derive(Message, Clone, Copy, Debug, PartialEq)]
-pub(crate) struct CarryWeightChanged {
+struct CarryWeightChanged {
     pub current_weight: f32,
     pub effective_capacity: f32,
 }
@@ -302,7 +302,7 @@ pub(crate) struct CarryStrength {
 /// the design direction is "carry may come from a real fabricated or acquired
 /// object later," not "carry is always an innate stat."
 #[derive(Component, Clone, Debug, PartialEq, Eq, Default)]
-pub(crate) struct CarryDeviceState {
+struct CarryDeviceState {
     pub required_item_key: Option<String>,
     pub equipped_item_key: Option<String>,
 }
@@ -782,7 +782,7 @@ pub(crate) enum CarryCurveKind {
 /// This gives later systems one stable resource to read without making every
 /// caller re-implement "which profile name did the config select?" logic.
 #[derive(Clone, Debug, Resource, PartialEq)]
-pub(crate) struct ActiveCarryProfile {
+struct ActiveCarryProfile {
     pub profile_name: String,
     pub tuning: CarryProfileConfig,
 }
@@ -1019,7 +1019,7 @@ fn carry_strength_delta(
     }
 }
 
-pub(crate) fn describe_weight_observation(
+fn describe_weight_observation(
     density: f32,
     carry_strength: f32,
     confidence: ConfidenceLevel,

--- a/src/exterior_generation.rs
+++ b/src/exterior_generation.rs
@@ -59,7 +59,7 @@ impl Plugin for ExteriorGenerationPlugin {
 /// - how likely it is relative to sibling deposit definitions
 /// - how large it can appear
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct SurfaceMineralDepositDefinition {
+struct SurfaceMineralDepositDefinition {
     pub key: String,
     pub material_key: String,
     pub selection_weight: f32,
@@ -79,7 +79,7 @@ pub(crate) struct SurfaceMineralDepositDefinition {
 /// threshold here because they are part of "what this exterior object family
 /// looks like in the world" rather than generic world foundation config.
 #[derive(Clone, Debug, PartialEq, Resource, Serialize, Deserialize)]
-pub(crate) struct SurfaceMineralDepositCatalog {
+struct SurfaceMineralDepositCatalog {
     #[serde(default = "default_site_spacing_world_units")]
     pub site_spacing_world_units: f32,
     #[serde(default = "default_site_density_field_scale_world_units")]
@@ -175,7 +175,7 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
 /// untouched chunk-baseline object and should no longer be managed by chunk
 /// loading/unloading rules.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct GeneratedExteriorObject {
+struct GeneratedExteriorObject {
     pub home_chunk: ChunkCoord,
 }
 
@@ -187,7 +187,7 @@ pub(crate) struct GeneratedExteriorObject {
 /// this exterior-specific role instead of pretending they are just anonymous
 /// loose material objects.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct SurfaceMineralDeposit {
+struct SurfaceMineralDeposit {
     pub definition_key: String,
 }
 
@@ -197,7 +197,7 @@ pub(crate) struct SurfaceMineralDeposit {
 /// above them so the world can say "this whole Ferrite patch is one deposit"
 /// instead of pretending the individual loose pieces are unrelated.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Component)]
-pub(crate) struct GeneratedDepositSiteId {
+struct GeneratedDepositSiteId {
     pub planet_seed: u64,
     pub chunk_coord: ChunkCoord,
     pub deposit_kind_key: String,
@@ -207,7 +207,7 @@ pub(crate) struct GeneratedDepositSiteId {
 
 /// Marker connecting a generated child mineral back to its parent deposit site.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct DepositSiteMember {
+struct DepositSiteMember {
     pub site_id: GeneratedDepositSiteId,
     pub local_child_index: u32,
 }
@@ -246,7 +246,7 @@ struct GeneratedSurfaceMineralDepositSite {
 
 /// Active chunk baseline entities currently spawned into the world.
 #[derive(Resource, Default)]
-pub(crate) struct ActiveExteriorChunkSpawns {
+struct ActiveExteriorChunkSpawns {
     pub spawned_entities_by_chunk: HashMap<ChunkCoord, Vec<Entity>>,
 }
 

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -46,7 +46,7 @@ pub(crate) struct ActivateIntent;
 // ── State ───────────────────────────────────────────────────────────────
 
 #[derive(Resource, Default, Debug, PartialEq)]
-pub(crate) enum FabricatorState {
+enum FabricatorState {
     #[default]
     Idle,
     Processing {
@@ -383,11 +383,7 @@ fn blend_color(a: &[f32; 3], b: &[f32; 3], catalytic: bool) -> [f32; 3] {
 
 // ── Main combine function ────────────────────────────────────────────────
 
-pub(crate) fn rule_combine(
-    rules: &CombinationRules,
-    a: &GameMaterial,
-    b: &GameMaterial,
-) -> GameMaterial {
+fn rule_combine(rules: &CombinationRules, a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
     let pair_rules = rules.rules_for(&a.name, &b.name);
 
     let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);

--- a/src/input.rs
+++ b/src/input.rs
@@ -73,7 +73,7 @@ pub(crate) enum InputAction {
 
 /// Top-level structure of `assets/config/input.toml`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Resource)]
-pub(crate) struct InputConfig {
+struct InputConfig {
     #[serde(default)]
     pub mouse: MouseConfig,
     #[serde(default)]
@@ -81,7 +81,7 @@ pub(crate) struct InputConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct MouseConfig {
+struct MouseConfig {
     #[serde(default = "default_sensitivity")]
     pub sensitivity_x: f32,
     #[serde(default = "default_sensitivity")]
@@ -102,7 +102,7 @@ fn default_sensitivity() -> f32 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct BindingsConfig {
+struct BindingsConfig {
     #[serde(default = "MoveBindings::default", rename = "Move")]
     pub movement: MoveBindings,
     #[serde(default = "default_interact", rename = "Interact")]
@@ -146,7 +146,7 @@ impl Default for BindingsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct MoveBindings {
+struct MoveBindings {
     #[serde(default = "default_up")]
     pub up: String,
     #[serde(default = "default_down")]
@@ -308,7 +308,7 @@ fn load_input_config(mut commands: Commands) {
 
 /// Builds a leafwing `InputMap` from the current `InputConfig` and attaches it
 /// to the player entity. Runs once at startup after the player is spawned.
-pub(crate) fn attach_input_map_to_player(
+fn attach_input_map_to_player(
     mut commands: Commands,
     config: Res<InputConfig>,
     player_query: Query<Entity, With<Player>>,
@@ -325,7 +325,7 @@ pub(crate) fn attach_input_map_to_player(
 
 /// Pure function: constructs an `InputMap` from an `InputConfig`.
 /// Separated from the system so it can be called when rebinding too.
-pub(crate) fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
+fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     let bindings = &config.bindings;
     let mut input_map = InputMap::default();
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -84,7 +84,7 @@ pub(crate) struct RecordWeightObservation {
 // ── Player-owned journal data ───────────────────────────────────────────
 
 #[derive(Component, Default)]
-pub(crate) struct Journal {
+struct Journal {
     fabrication_log: Vec<String>,
     entries: BTreeMap<u64, JournalEntry>,
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -52,7 +52,7 @@ impl ConfidenceLevel {
     }
 }
 
-pub(crate) fn describe_thermal_behavior(value: f32) -> &'static str {
+fn describe_thermal_behavior(value: f32) -> &'static str {
     if value < 0.25 {
         "soften quickly under heat"
     } else if value < 0.5 {

--- a/src/player.rs
+++ b/src/player.rs
@@ -36,7 +36,7 @@ const PLAYER_COLLISION_RADIUS: f32 = 0.2;
 /// This is intentionally enough to make weight feel physical without pretending
 /// we already have the final progression system.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
-pub(crate) struct StaminaState {
+struct StaminaState {
     pub current: f32,
     pub max: f32,
 }

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -269,7 +269,7 @@ fn update_active_chunk_neighborhood(
 ///
 /// That last case is why floor matters. Truncation would incorrectly map
 /// slightly-negative positions back to chunk `0`.
-pub(crate) fn world_position_to_chunk_coord(
+fn world_position_to_chunk_coord(
     position_xz: PositionXZ,
     chunk_size_world_units: f32,
 ) -> ChunkCoord {
@@ -304,7 +304,7 @@ pub(crate) fn chunk_origin_xz(chunk_coord: ChunkCoord, chunk_size_world_units: f
 ///
 /// The nested loop order is stable, so any later story that iterates this list
 /// gets the same ordering every run.
-pub(crate) fn active_chunk_neighborhood(center_chunk: ChunkCoord, radius: i32) -> Vec<ChunkCoord> {
+fn active_chunk_neighborhood(center_chunk: ChunkCoord, radius: i32) -> Vec<ChunkCoord> {
     let mut chunks = Vec::new();
 
     for dz in -radius..=radius {


### PR DESCRIPTION
Story 25.1 (#245) — pure visibility refactor, no behavioral changes.

Removed pub(crate) from structs, enums, and functions that have no
cross-module consumers: StaminaState, InputConfig, MouseConfig,
BindingsConfig, MoveBindings, attach_input_map_to_player, build_input_map,
StashIntent, CycleCarryIntent, CarryWeightChanged, CarryDeviceState,
ActiveCarryProfile, describe_weight_observation, describe_thermal_behavior,
FabricatorState, rule_combine, Journal, and 7 exterior_generation types.

PlanetSeed, ChunkGenerationKey, and CarriedItem remain pub(crate) because
they have verified cross-module consumers (exterior_generation, interaction).

Closes #245