### PR TITLE
refactor: replace all pub(crate) with pub across 14 modules

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -32,7 +32,7 @@ use leafwing_input_manager::prelude::*;
 
 const CONFIG_PATH: &str = "assets/config/carry.toml";
 
-pub(crate) struct CarryPlugin;
+pub struct CarryPlugin;
 
 impl Plugin for CarryPlugin {
     fn build(&self, app: &mut App) {
@@ -115,7 +115,7 @@ struct CarryWeightChanged {
 /// two separated lets later stories change the feedback model without rewriting
 /// how carry contents are tracked.
 #[derive(Clone, Debug, Resource, PartialEq)]
-pub(crate) struct CarryMovementState {
+pub struct CarryMovementState {
     pub speed_modifier: f32,
     pub stamina_drain_multiplier: f32,
     pub encumbrance_ratio: f32,
@@ -157,7 +157,7 @@ impl Default for CarryMovementState {
 /// Making that state explicit keeps later systems from accidentally treating a
 /// stashed item like a world object that can still be raycast, heated, or placed.
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct InCarry;
+pub struct InCarry;
 
 // ── Runtime player state ─────────────────────────────────────────────────
 
@@ -172,12 +172,12 @@ pub(crate) struct InCarry;
 ///
 /// Starting with a struct now avoids rewriting every caller later.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct CarriedItem {
+pub struct CarriedItem {
     pub entity: Entity,
 }
 
 impl CarriedItem {
-    pub(crate) fn new(entity: Entity) -> Self {
+    pub fn new(entity: Entity) -> Self {
         Self { entity }
     }
 }
@@ -189,7 +189,7 @@ impl CarriedItem {
 /// current carry-device rule. Later stories may change that value over time as
 /// devices are equipped or strength accretes.
 #[derive(Component, Clone, Debug, PartialEq)]
-pub(crate) struct CarryState {
+pub struct CarryState {
     pub current_weight: f32,
     pub effective_capacity: f32,
     pub hard_limit_enabled: bool,
@@ -197,7 +197,7 @@ pub(crate) struct CarryState {
 }
 
 impl CarryState {
-    pub(crate) fn new(effective_capacity: f32, hard_limit_enabled: bool) -> Self {
+    pub fn new(effective_capacity: f32, hard_limit_enabled: bool) -> Self {
         Self {
             current_weight: 0.0,
             effective_capacity,
@@ -210,7 +210,7 @@ impl CarryState {
     ///
     /// Story 4.1 does not wire the stash interaction yet, but this method is the
     /// server-side accounting rule that later intent-processing systems will call.
-    pub(crate) fn add_material(&mut self, entity: Entity, material: &GameMaterial) {
+    pub fn add_material(&mut self, entity: Entity, material: &GameMaterial) {
         self.carried_items.push(CarriedItem::new(entity));
         self.current_weight += material.density.value;
     }
@@ -220,7 +220,7 @@ impl CarryState {
     /// We search by entity because runtime carry is presently keyed by the live
     /// world entity. A future persistence story may need a richer identity model,
     /// but runtime in-session carry can safely start here.
-    pub(crate) fn remove_material(
+    pub fn remove_material(
         &mut self,
         entity: Entity,
         material: &GameMaterial,
@@ -245,7 +245,7 @@ impl CarryState {
     /// item first." We return the entity without mutating here so higher-level
     /// systems can decide the order of multi-step operations like "stash current
     /// hand item, then retrieve an older carried item."
-    pub(crate) fn next_carried_entity(&self, cycle_order: CarryCycleOrder) -> Option<Entity> {
+    pub fn next_carried_entity(&self, cycle_order: CarryCycleOrder) -> Option<Entity> {
         match cycle_order {
             CarryCycleOrder::Fifo => self.carried_items.first().map(|item| item.entity),
             CarryCycleOrder::Lifo => self.carried_items.last().map(|item| item.entity),
@@ -291,7 +291,7 @@ impl CarryState {
 /// stories inventing one ad hoc. Growth rate is owned by [`CarryConfig`], not
 /// duplicated here, since it is a tuning constant rather than mutable player state.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
-pub(crate) struct CarryStrength {
+pub struct CarryStrength {
     pub current: f32,
 }
 
@@ -339,7 +339,7 @@ impl CarryDeviceState {
 /// runtime. That is deliberate: this story is the data-model foundation for the
 /// rest of the epic.
 #[derive(Clone, Debug, Serialize, Deserialize, Resource)]
-pub(crate) struct CarryConfig {
+pub struct CarryConfig {
     #[serde(default = "default_active_profile")]
     pub active_profile: String,
     #[serde(default = "default_starting_capacity")]
@@ -399,7 +399,7 @@ fn default_growth_rate() -> f32 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub(crate) struct CarryGrowthCurveConfig {
+pub struct CarryGrowthCurveConfig {
     #[serde(default)]
     pub kind: CarryGrowthCurveKind,
     #[serde(default = "default_growth_curve_cap")]
@@ -421,7 +421,7 @@ fn default_growth_curve_cap() -> f32 {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum CarryGrowthCurveKind {
+pub enum CarryGrowthCurveKind {
     #[default]
     Linear,
     Logarithmic,
@@ -429,7 +429,7 @@ pub(crate) enum CarryGrowthCurveKind {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub(crate) struct WeightDescriptionBand {
+pub struct WeightDescriptionBand {
     pub max_ratio: f32,
     pub text: String,
 }
@@ -469,7 +469,7 @@ fn default_weight_descriptions() -> Vec<WeightDescriptionBand> {
 /// `carry.toml`, because the goal is "weight feels physical through multiple
 /// channels" rather than "camera math and audio live in unrelated systems."
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub(crate) struct CarryCueConfig {
+pub struct CarryCueConfig {
     #[serde(default = "default_footstep_interval_seconds")]
     pub footstep_interval_seconds: f32,
     #[serde(default = "default_footstep_base_volume")]
@@ -622,14 +622,14 @@ fn default_footstep_sprint_cadence() -> f32 {
 /// How carry retrieval should behave once Story 4.2 starts cycling items.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum CarryCycleOrder {
+pub enum CarryCycleOrder {
     #[default]
     Fifo,
     Lifo,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct CarryProfilesConfig {
+pub struct CarryProfilesConfig {
     #[serde(default = "default_profile_config")]
     pub default: CarryProfileConfig,
     #[serde(default = "relaxed_profile_config")]
@@ -650,7 +650,7 @@ impl Default for CarryProfilesConfig {
 
 /// One difficulty/mode profile's carry consequences.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub(crate) struct CarryProfileConfig {
+pub struct CarryProfileConfig {
     #[serde(default)]
     pub speed_curve: CarryCurveConfig,
     #[serde(default = "default_stamina_cost_multiplier")]
@@ -742,7 +742,7 @@ fn default_stamina_regen_per_second() -> f32 {
 /// Story 4.3 will be the first real consumer. Story 4.1 just proves these
 /// values live in config and resolve deterministically into the active profile.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub(crate) struct CarryCurveConfig {
+pub struct CarryCurveConfig {
     #[serde(default)]
     pub kind: CarryCurveKind,
     #[serde(default = "default_min_multiplier")]
@@ -771,7 +771,7 @@ fn default_curve_exponent() -> f32 {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum CarryCurveKind {
+pub enum CarryCurveKind {
     #[default]
     Linear,
     Exponential,
@@ -1100,7 +1100,7 @@ fn emit_cycle_carry_intent(
 /// - remove `MaterialObject` because it should no longer behave like a world prop
 /// - add `InCarry` to make the state explicit for later systems
 /// - hide the entity so it stops rendering
-pub(crate) fn can_stash_material(carry_state: &CarryState, material: &GameMaterial) -> bool {
+pub fn can_stash_material(carry_state: &CarryState, material: &GameMaterial) -> bool {
     if !carry_state.hard_limit_enabled {
         return true;
     }
@@ -1109,7 +1109,7 @@ pub(crate) fn can_stash_material(carry_state: &CarryState, material: &GameMateri
         <= (carry_state.effective_capacity + f32::EPSILON)
 }
 
-pub(crate) fn stash_entity_into_carry(
+pub fn stash_entity_into_carry(
     commands: &mut Commands,
     carry_state: &mut CarryState,
     entity: Entity,
@@ -1125,7 +1125,7 @@ pub(crate) fn stash_entity_into_carry(
         .insert(Visibility::Hidden);
 }
 
-pub(crate) fn record_weight_observation(
+pub fn record_weight_observation(
     material: &GameMaterial,
     carry_strength: f32,
     config: &CarryConfig,

--- a/src/carry_feedback.rs
+++ b/src/carry_feedback.rs
@@ -29,7 +29,7 @@ use crate::carry::{CarryConfig, CarryCueConfig, CarryMovementState};
 use crate::input::InputAction;
 use crate::player::{Player, PlayerCamera, cursor_is_captured, spawn_player};
 
-pub(crate) struct CarryFeedbackPlugin;
+pub struct CarryFeedbackPlugin;
 
 impl Plugin for CarryFeedbackPlugin {
     fn build(&self, app: &mut App) {

--- a/src/combination.rs
+++ b/src/combination.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pub(crate) struct CombinationPlugin;
+pub struct CombinationPlugin;
 
 impl Plugin for CombinationPlugin {
     fn build(&self, app: &mut App) {
@@ -30,7 +30,7 @@ impl Plugin for CombinationPlugin {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
-pub(crate) enum PropertyRule {
+pub enum PropertyRule {
     Blend { weight_a: f32, weight_b: f32 },
     Max,
     Min,
@@ -39,7 +39,7 @@ pub(crate) enum PropertyRule {
 }
 
 impl PropertyRule {
-    pub(crate) fn apply(&self, a: f32, b: f32) -> f32 {
+    pub fn apply(&self, a: f32, b: f32) -> f32 {
         match self {
             PropertyRule::Blend { weight_a, weight_b } => {
                 let total = weight_a + weight_b;
@@ -68,7 +68,7 @@ impl Default for PropertyRule {
 // ── Rule set for a material pair ────────────────────────────────────────
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct PairRuleSet {
+pub struct PairRuleSet {
     pub density: PropertyRule,
     pub thermal_resistance: PropertyRule,
     pub reactivity: PropertyRule,
@@ -79,7 +79,7 @@ pub(crate) struct PairRuleSet {
 impl PairRuleSet {
     /// Used in tests and by future waste-detection visuals (e.g. grey-out output).
     #[allow(dead_code)]
-    pub(crate) fn all_inert() -> Self {
+    pub fn all_inert() -> Self {
         Self {
             density: PropertyRule::Inert,
             thermal_resistance: PropertyRule::Inert,
@@ -91,7 +91,7 @@ impl PairRuleSet {
 
     /// Used in tests and by future waste-detection visuals.
     #[allow(dead_code)]
-    pub(crate) fn is_inert(&self) -> bool {
+    pub fn is_inert(&self) -> bool {
         self.density == PropertyRule::Inert
             && self.thermal_resistance == PropertyRule::Inert
             && self.reactivity == PropertyRule::Inert
@@ -139,14 +139,14 @@ fn pair_key(a: &str, b: &str) -> (String, String) {
 
 /// Loaded combination rules, keyed by sorted material name pairs.
 #[derive(Resource, Debug, Default)]
-pub(crate) struct CombinationRules {
+pub struct CombinationRules {
     pub default_rule: PropertyRule,
     pub pair_rules: HashMap<(String, String), PairRuleSet>,
 }
 
 impl CombinationRules {
     /// Look up the rule set for a pair, falling back to the default for each property.
-    pub(crate) fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
+    pub fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
         let key = pair_key(name_a, name_b);
         if let Some(rules) = self.pair_rules.get(&key) {
             rules.clone()

--- a/src/exterior_generation.rs
+++ b/src/exterior_generation.rs
@@ -34,7 +34,7 @@ use crate::world_generation::{
 const DEPOSIT_CONFIG_PATH: &str = "assets/exterior/surface_mineral_deposits.toml";
 const SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION: u32 = 1;
 
-pub(crate) struct ExteriorGenerationPlugin;
+pub struct ExteriorGenerationPlugin;
 
 impl Plugin for ExteriorGenerationPlugin {
     fn build(&self, app: &mut App) {

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -20,7 +20,7 @@ use crate::materials::{
 };
 use crate::scene::{SceneConfig, Workbench};
 
-pub(crate) struct FabricatorPlugin;
+pub struct FabricatorPlugin;
 
 impl Plugin for FabricatorPlugin {
     fn build(&self, app: &mut App) {
@@ -41,7 +41,7 @@ impl Plugin for FabricatorPlugin {
 // ── Messages ────────────────────────────────────────────────────────────
 
 #[derive(Message)]
-pub(crate) struct ActivateIntent;
+pub struct ActivateIntent;
 
 // ── State ───────────────────────────────────────────────────────────────
 
@@ -59,7 +59,7 @@ enum FabricatorState {
 /// Marks a fabricator input receptacle. `index` distinguishes slot 0 from slot 1.
 /// `material` holds the entity of the material currently seated in this slot.
 #[derive(Component, Debug)]
-pub(crate) struct InputSlot {
+pub struct InputSlot {
     // Used in debug logging and future UI to identify which slot is which.
     #[allow(dead_code)]
     pub index: usize,
@@ -69,7 +69,7 @@ pub(crate) struct InputSlot {
 
 /// Marks the fabricator output receptacle where the combined material appears.
 #[derive(Component, Debug)]
-pub(crate) struct OutputSlot {
+pub struct OutputSlot {
     pub material: Option<Entity>,
     pub top_y: f32,
 }

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -21,7 +21,7 @@ use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::ConfidenceTracker;
 use crate::scene::{SceneConfig, Workbench};
 
-pub(crate) struct HeatPlugin;
+pub struct HeatPlugin;
 
 impl Plugin for HeatPlugin {
     fn build(&self, app: &mut App) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,7 +26,7 @@ use crate::player::Player;
 
 // ── Plugin ──────────────────────────────────────────────────────────────
 
-pub(crate) struct InputPlugin;
+pub struct InputPlugin;
 
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
@@ -50,7 +50,7 @@ impl Plugin for InputPlugin {
 /// keys are still individually configurable via the TOML config. This deviation
 /// is documented on issue #6.
 #[derive(Actionlike, PartialEq, Eq, Hash, Clone, Copy, Debug, Reflect)]
-pub(crate) enum InputAction {
+pub enum InputAction {
     /// WASD / left stick — produces a Vec2 direction.
     #[actionlike(DualAxis)]
     Move,

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -35,9 +35,9 @@ use crate::scene::Surface;
 use leafwing_input_manager::prelude::*;
 
 const INTERACTION_RANGE: f32 = 3.0;
-pub(crate) const HOLD_OFFSET: Vec3 = Vec3::new(0.2, -0.15, -0.5);
+pub const HOLD_OFFSET: Vec3 = Vec3::new(0.2, -0.15, -0.5);
 
-pub(crate) struct InteractionPlugin;
+pub struct InteractionPlugin;
 
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
@@ -99,7 +99,7 @@ struct SlotTarget {
 
 /// Marks a material entity as currently held by the player.
 #[derive(Component)]
-pub(crate) struct HeldItem;
+pub struct HeldItem;
 
 /// Whether the examine overlay is currently visible.
 #[derive(Resource, Default)]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -16,7 +16,7 @@ use crate::materials::GameMaterial;
 use crate::observation::{ConfidenceLevel, describe_thermal_observation};
 use crate::player::{Player, cursor_is_captured, spawn_player};
 
-pub(crate) struct JournalPlugin;
+pub struct JournalPlugin;
 
 impl Plugin for JournalPlugin {
     fn build(&self, app: &mut App) {
@@ -55,19 +55,19 @@ impl Plugin for JournalPlugin {
 // ── Messages ────────────────────────────────────────────────────────────
 
 #[derive(Message, Clone)]
-pub(crate) struct RecordEncounter {
+pub struct RecordEncounter {
     pub material: GameMaterial,
 }
 
 #[derive(Message, Clone)]
-pub(crate) struct RecordFabrication {
+pub struct RecordFabrication {
     pub output_material: GameMaterial,
     pub input_a: String,
     pub input_b: String,
 }
 
 #[derive(Message, Clone)]
-pub(crate) struct RecordThermalObservation {
+pub struct RecordThermalObservation {
     pub seed: u64,
     pub name: String,
     pub thermal_resistance: f32,
@@ -75,7 +75,7 @@ pub(crate) struct RecordThermalObservation {
 }
 
 #[derive(Message, Clone)]
-pub(crate) struct RecordWeightObservation {
+pub struct RecordWeightObservation {
     pub seed: u64,
     pub name: String,
     pub description: String,

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -22,9 +22,9 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::scene::Shelf;
-pub(crate) struct MaterialPlugin;
+pub struct MaterialPlugin;
 
-pub(crate) const MATERIAL_SURFACE_GAP: f32 = 0.01;
+pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
 
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
@@ -41,7 +41,7 @@ impl Plugin for MaterialPlugin {
 /// weight). `Hidden` properties require environmental testing to discover.
 /// `Revealed` is set at runtime once the player has uncovered a hidden property.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Reflect)]
-pub(crate) enum PropertyVisibility {
+pub enum PropertyVisibility {
     Observable,
     Hidden,
     Revealed,
@@ -53,7 +53,7 @@ pub(crate) enum PropertyVisibility {
 ///
 /// Values are clamped to \[0.0, 1.0\] for uniform combination math (Story 3.2).
 #[derive(Clone, Debug, Serialize, Deserialize, Reflect)]
-pub(crate) struct MaterialProperty {
+pub struct MaterialProperty {
     pub value: f32,
     pub visibility: PropertyVisibility,
 }
@@ -70,7 +70,7 @@ pub(crate) struct MaterialProperty {
 /// Base materials define seed explicitly; derived materials compute it from
 /// input seeds.
 #[derive(Component, Clone, Debug, Serialize, Deserialize, Reflect)]
-pub(crate) struct GameMaterial {
+pub struct GameMaterial {
     pub name: String,
     pub seed: u64,
     /// Display colour as \[R, G, B\] in sRGB 0.0–1.0.
@@ -84,13 +84,13 @@ pub(crate) struct GameMaterial {
 
 impl GameMaterial {
     /// Converts the stored colour triple to a Bevy [`Color`].
-    pub(crate) fn bevy_color(&self) -> Color {
+    pub fn bevy_color(&self) -> Color {
         Color::srgb(self.color[0], self.color[1], self.color[2])
     }
 
     /// Chooses a mesh shape based on material density.
     /// Light materials → sphere, heavy → cube, medium → capsule.
-    pub(crate) fn mesh_for_density(&self, meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
+    pub fn mesh_for_density(&self, meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
         let density = self.density.value;
         if density < 0.3 {
             meshes.add(Sphere::new(0.12).mesh().build())
@@ -102,7 +102,7 @@ impl GameMaterial {
     }
 
     /// Height from the support surface to the entity origin for the selected mesh.
-    pub(crate) fn support_height(&self) -> f32 {
+    pub fn support_height(&self) -> f32 {
         let density = self.density.value;
         if density < 0.3 {
             0.12
@@ -113,11 +113,11 @@ impl GameMaterial {
         }
     }
 
-    pub(crate) fn resting_center_y(&self, surface_y: f32) -> f32 {
+    pub fn resting_center_y(&self, surface_y: f32) -> f32 {
         surface_y + self.support_height() + MATERIAL_SURFACE_GAP
     }
 
-    pub(crate) fn footprint_radius(&self) -> f32 {
+    pub fn footprint_radius(&self) -> f32 {
         let density = self.density.value;
         if density < 0.3 {
             0.12
@@ -136,7 +136,7 @@ impl GameMaterial {
 /// Later stories use this to spawn material entities and to look up base
 /// definitions during fabrication.
 #[derive(Resource, Debug, Default)]
-pub(crate) struct MaterialCatalog {
+pub struct MaterialCatalog {
     pub materials: HashMap<String, GameMaterial>,
 }
 
@@ -145,7 +145,7 @@ pub(crate) struct MaterialCatalog {
 /// Marks an entity as a material object that exists physically in the world.
 /// The material's data is on the same entity as a [`GameMaterial`] component.
 #[derive(Component, Debug)]
-pub(crate) struct MaterialObject;
+pub struct MaterialObject;
 
 // ── Spawning ─────────────────────────────────────────────────────────────
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use bevy::prelude::*;
 
-pub(crate) struct ObservationPlugin;
+pub struct ObservationPlugin;
 
 impl Plugin for ObservationPlugin {
     fn build(&self, app: &mut App) {
@@ -31,7 +31,7 @@ impl Plugin for ObservationPlugin {
 /// Used by the examine panel in the next PR to select descriptor language.
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ConfidenceLevel {
+pub enum ConfidenceLevel {
     /// One observation — tentative language.
     Tentative,
     /// 2–3 observations — factual but unqualified.
@@ -42,7 +42,7 @@ pub(crate) enum ConfidenceLevel {
 
 impl ConfidenceLevel {
     #[allow(dead_code)]
-    pub(crate) fn from_count(count: u32) -> Self {
+    pub fn from_count(count: u32) -> Self {
         match count {
             0 => ConfidenceLevel::Tentative,
             1 => ConfidenceLevel::Tentative,
@@ -64,7 +64,7 @@ fn describe_thermal_behavior(value: f32) -> &'static str {
     }
 }
 
-pub(crate) fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
+pub fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
     let behavior = describe_thermal_behavior(value);
     match confidence {
         ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
@@ -89,7 +89,7 @@ type ObsKey = (u64, String);
 /// Fields read by the examine panel and heat systems in the next PRs.
 #[allow(dead_code)]
 #[derive(Resource, Debug, Default)]
-pub(crate) struct ConfidenceTracker {
+pub struct ConfidenceTracker {
     counts: HashMap<ObsKey, u32>,
 }
 
@@ -97,7 +97,7 @@ impl ConfidenceTracker {
     /// Record one observation. Returns the new count.
     /// Called by the heat revelation system in the next PR.
     #[allow(dead_code)]
-    pub(crate) fn record(&mut self, seed: u64, property: &str) -> u32 {
+    pub fn record(&mut self, seed: u64, property: &str) -> u32 {
         let key = (seed, property.to_string());
         let count = self.counts.entry(key).or_insert(0);
         *count += 1;
@@ -107,7 +107,7 @@ impl ConfidenceTracker {
     /// Current observation count (0 if never observed).
     /// Used by the examine panel in the next PR.
     #[allow(dead_code)]
-    pub(crate) fn count(&self, seed: u64, property: &str) -> u32 {
+    pub fn count(&self, seed: u64, property: &str) -> u32 {
         self.counts
             .get(&(seed, property.to_string()))
             .copied()
@@ -117,7 +117,7 @@ impl ConfidenceTracker {
     /// Confidence level for a specific (material, property) pair.
     /// Used by the examine panel in the next PR.
     #[allow(dead_code)]
-    pub(crate) fn level(&self, seed: u64, property: &str) -> ConfidenceLevel {
+    pub fn level(&self, seed: u64, property: &str) -> ConfidenceLevel {
         ConfidenceLevel::from_count(self.count(seed, property))
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -41,7 +41,7 @@ struct StaminaState {
     pub max: f32,
 }
 
-pub(crate) fn cursor_is_captured(grab_mode: CursorGrabMode) -> bool {
+pub fn cursor_is_captured(grab_mode: CursorGrabMode) -> bool {
     grab_mode != CursorGrabMode::None
 }
 
@@ -49,7 +49,7 @@ fn enforce_eye_height(translation: &mut Vec3, eye_height: f32) {
     translation.y = eye_height;
 }
 
-pub(crate) struct PlayerPlugin;
+pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
@@ -66,18 +66,18 @@ impl Plugin for PlayerPlugin {
 
 /// Marker component for the player's root entity (the "body").
 #[derive(Component)]
-pub(crate) struct Player;
+pub struct Player;
 
 /// Marker component for the player's camera (the "eyes").
 #[derive(Component)]
-pub(crate) struct PlayerCamera;
+pub struct PlayerCamera;
 
 /// Accumulated pitch angle stored alongside the camera so clamping is precise
 /// without needing to extract Euler angles from a quaternion each frame.
 #[derive(Component, Default)]
 struct CameraPitch(f32);
 
-pub(crate) fn spawn_player(
+pub fn spawn_player(
     mut commands: Commands,
     scene: Res<SceneConfig>,
     carry_movement: Res<CarryMovementState>,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pub(crate) struct ScenePlugin;
+pub struct ScenePlugin;
 
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
@@ -25,13 +25,13 @@ impl Plugin for ScenePlugin {
 
 /// Marks the central workbench mesh — future fabricator anchor (Epic 3).
 #[derive(Component)]
-pub(crate) struct Workbench;
+pub struct Workbench;
 
 /// A placement plane: the actual top of a piece of furniture where objects
 /// can be set down. Spawned as its own entity at the true surface Y so
 /// the placement system never needs offset math.
 #[derive(Component)]
-pub(crate) struct Surface {
+pub struct Surface {
     pub half_extent_x: f32,
     pub half_extent_z: f32,
 }
@@ -39,27 +39,27 @@ pub(crate) struct Surface {
 /// Distinguishes storage shelves from the experiment workbench so initial
 /// material spawning only targets shelves.
 #[derive(Component)]
-pub(crate) struct Shelf;
+pub struct Shelf;
 
 /// Ground-plane position using world X/Z coordinates.
 ///
 /// Bevy uses Y as vertical, so any "flat" room-shell collision math happens on
 /// the X/Z plane instead of the X/Y plane familiar from CAD or 3D printing.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct PositionXZ {
+pub struct PositionXZ {
     pub x: f32,
     pub z: f32,
 }
 
 impl PositionXZ {
-    pub(crate) fn new(x: f32, z: f32) -> Self {
+    pub fn new(x: f32, z: f32) -> Self {
         Self { x, z }
     }
 }
 
 /// Axis-aligned rectangle on the world X/Z plane.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct RectXZ {
+pub struct RectXZ {
     pub min_x: f32,
     pub max_x: f32,
     pub min_z: f32,
@@ -67,7 +67,7 @@ pub(crate) struct RectXZ {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct WallCollider {
+pub struct WallCollider {
     pub footprint_xz: RectXZ,
 }
 
@@ -94,12 +94,12 @@ impl WallCollider {
 }
 
 #[derive(Resource, Clone, Debug, Default)]
-pub(crate) struct RoomShellCollision {
+pub struct RoomShellCollision {
     pub wall_colliders: Vec<WallCollider>,
 }
 
 impl RoomShellCollision {
-    pub(crate) fn blocks_circle_xz(&self, position_xz: PositionXZ, radius: f32) -> bool {
+    pub fn blocks_circle_xz(&self, position_xz: PositionXZ, radius: f32) -> bool {
         self.wall_colliders
             .iter()
             .any(|collider| collider.blocks_circle_xz(position_xz, radius))
@@ -114,7 +114,7 @@ impl RoomShellCollision {
 /// playable exterior surface?" instead of hardcoding scene dimensions a second
 /// time in a different module.
 #[derive(Resource, Clone, Debug)]
-pub(crate) struct ExteriorGroundPatch {
+pub struct ExteriorGroundPatch {
     pub bounds_xz: RectXZ,
     pub surface_y: f32,
 }
@@ -125,7 +125,7 @@ const CONFIG_PATH: &str = "assets/config/scene.toml";
 
 /// Top-level structure of `assets/config/scene.toml`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Resource)]
-pub(crate) struct SceneConfig {
+pub struct SceneConfig {
     #[serde(default)]
     pub room: RoomConfig,
     #[serde(default)]
@@ -141,7 +141,7 @@ pub(crate) struct SceneConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct RoomConfig {
+pub struct RoomConfig {
     #[serde(default = "default_half_extent_x")]
     pub half_extent_x: f32,
     #[serde(default = "default_half_extent_z")]
@@ -183,7 +183,7 @@ impl Default for RoomConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct PlayerSceneConfig {
+pub struct PlayerSceneConfig {
     #[serde(default = "default_eye_height")]
     pub eye_height: f32,
     #[serde(default)]
@@ -216,7 +216,7 @@ impl Default for PlayerSceneConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LightingConfig {
+pub struct LightingConfig {
     #[serde(default = "default_ambient_brightness")]
     pub ambient_brightness: f32,
     #[serde(default = "default_directional_illuminance")]
@@ -282,7 +282,7 @@ impl Default for LightingConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct FurnitureConfig {
+pub struct FurnitureConfig {
     #[serde(default = "default_workbench_width")]
     pub workbench_width: f32,
     #[serde(default = "default_workbench_height")]
@@ -359,7 +359,7 @@ impl Default for FurnitureConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct ShelfConfig {
+pub struct ShelfConfig {
     pub x: f32,
     pub z: f32,
     pub y: f32,
@@ -368,7 +368,7 @@ pub(crate) struct ShelfConfig {
 // ── Fabricator config ────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct FabricatorSceneConfig {
+pub struct FabricatorSceneConfig {
     #[serde(default = "default_fab_slot_offset_x")]
     pub slot_offset_x: f32,
     #[serde(default = "default_fab_slot_spacing_z")]
@@ -436,7 +436,7 @@ impl Default for FabricatorSceneConfig {
 // ── Heat source config ──────────────────────────────────────────────────
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct HeatSourceConfig {
+pub struct HeatSourceConfig {
     #[serde(default = "default_hs_offset_x")]
     pub offset_x: f32,
     #[serde(default = "default_hs_offset_z")]
@@ -539,7 +539,7 @@ fn north_wall_center_z(room_half_depth: f32, wall_thickness: f32) -> f32 {
     room_half_depth + wall_thickness * 0.5
 }
 
-pub(crate) fn build_room_shell_collision(
+pub fn build_room_shell_collision(
     room_half_width: f32,
     room_half_depth: f32,
     wall_thickness: f32,

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -29,7 +29,7 @@ const PLACEMENT_DENSITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0001;
 const PLACEMENT_VARIATION_CHANNEL: u64 = 0xD3E5_17A1_0000_0002;
 const OBJECT_IDENTITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0003;
 
-pub(crate) struct WorldGenerationPlugin;
+pub struct WorldGenerationPlugin;
 
 impl Plugin for WorldGenerationPlugin {
     fn build(&self, app: &mut App) {
@@ -48,7 +48,7 @@ impl Plugin for WorldGenerationPlugin {
 /// determinism obvious and testable. A config-backed seed means anyone can read
 /// the world seed, rerun the game, and get the same foundational world state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct PlanetSeed(pub u64);
+pub struct PlanetSeed(pub u64);
 
 /// Signed chunk coordinate on the exterior X/Z ground plane.
 ///
@@ -58,13 +58,13 @@ pub(crate) struct PlanetSeed(pub u64);
 /// "infinite signed grid on X/Z" rather than "special-case only positive
 /// chunks near the room."
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct ChunkCoord {
+pub struct ChunkCoord {
     pub x: i32,
     pub z: i32,
 }
 
 impl ChunkCoord {
-    pub(crate) const fn new(x: i32, z: i32) -> Self {
+    pub const fn new(x: i32, z: i32) -> Self {
         Self { x, z }
     }
 }
@@ -77,7 +77,7 @@ impl ChunkCoord {
 /// - `active_chunk_radius`: how many chunks around the player's chunk are
 ///   considered logically active
 #[derive(Clone, Debug, Resource, PartialEq, Serialize, Deserialize)]
-pub(crate) struct WorldGenerationConfig {
+pub struct WorldGenerationConfig {
     #[serde(default = "default_planet_seed")]
     pub planet_seed: u64,
     #[serde(default = "default_chunk_size_world_units")]
@@ -126,7 +126,7 @@ fn default_active_chunk_radius() -> i32 {
 /// "which seed should I use for this purpose?" from the raw planet seed. We
 /// derive explicit sub-seeds up front and document what each one is for.
 #[derive(Clone, Debug, Resource, PartialEq, Serialize, Deserialize)]
-pub(crate) struct WorldProfile {
+pub struct WorldProfile {
     pub planet_seed: PlanetSeed,
     pub chunk_size_world_units: f32,
     pub active_chunk_radius: i32,
@@ -142,7 +142,7 @@ impl Default for WorldProfile {
 }
 
 impl WorldProfile {
-    pub(crate) fn from_config(config: &WorldGenerationConfig) -> Self {
+    pub fn from_config(config: &WorldGenerationConfig) -> Self {
         let planet_seed = PlanetSeed(config.planet_seed);
 
         Self {
@@ -163,7 +163,7 @@ impl WorldProfile {
 /// placement, object identity, and persistence all agree on what chunk they are
 /// talking about.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ChunkGenerationKey {
+pub struct ChunkGenerationKey {
     pub chunk_coord: ChunkCoord,
     pub placement_density_key: u64,
     pub placement_variation_key: u64,
@@ -177,7 +177,7 @@ pub(crate) struct ChunkGenerationKey {
 /// saved removal record can literally say which planet, which chunk, which
 /// object kind, and which deterministic local candidate it refers to.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Component)]
-pub(crate) struct GeneratedObjectId {
+pub struct GeneratedObjectId {
     pub planet_seed: PlanetSeed,
     pub chunk_coord: ChunkCoord,
     pub object_kind_key: String,
@@ -192,7 +192,7 @@ pub(crate) struct GeneratedObjectId {
 /// loading/unloading stories to build on without having to rediscover the
 /// neighborhood math or re-derive it ad hoc in multiple systems.
 #[derive(Clone, Debug, Default, Resource, PartialEq)]
-pub(crate) struct ActiveChunkNeighborhood {
+pub struct ActiveChunkNeighborhood {
     pub center_chunk: Option<ChunkCoord>,
     pub center_chunk_origin_xz: Option<PositionXZ>,
     pub center_chunk_generation_key: Option<ChunkGenerationKey>,
@@ -287,7 +287,7 @@ fn world_position_to_chunk_coord(
 ///
 /// "Origin" here means the minimum X/minimum Z corner of the chunk on the
 /// ground plane, not the center of the chunk.
-pub(crate) fn chunk_origin_xz(chunk_coord: ChunkCoord, chunk_size_world_units: f32) -> PositionXZ {
+pub fn chunk_origin_xz(chunk_coord: ChunkCoord, chunk_size_world_units: f32) -> PositionXZ {
     PositionXZ::new(
         chunk_coord.x as f32 * chunk_size_world_units,
         chunk_coord.z as f32 * chunk_size_world_units,
@@ -322,7 +322,7 @@ fn active_chunk_neighborhood(center_chunk: ChunkCoord, radius: i32) -> Vec<Chunk
 /// - the same planet + same chunk always gets the same keys
 /// - different chunks on the same planet get different keys
 /// - later systems can tell which key is meant for which job
-pub(crate) fn derive_chunk_generation_key(
+pub fn derive_chunk_generation_key(
     profile: &WorldProfile,
     chunk_coord: ChunkCoord,
 ) -> ChunkGenerationKey {
@@ -363,7 +363,7 @@ fn mix_chunk_coord(planet_seed: PlanetSeed, chunk_coord: ChunkCoord) -> u64 {
     mix_seed(planet_seed.0, packed)
 }
 
-pub(crate) fn derive_generated_object_id(
+pub fn derive_generated_object_id(
     profile: &WorldProfile,
     chunk_coord: ChunkCoord,
     object_kind_key: impl Into<String>,


### PR DESCRIPTION
Binary crate has no downstream consumers, so pub and pub(crate) are
functionally identical. Bevy convention is pub for all plugin API types
(Components, Resources, Events, configs, helper functions). This
eliminates all 107 remaining pub(crate) occurrences, satisfying core
principle #7.

Closes #246