### PR TITLE
refactor: merge exterior_generation into world_generation module tree

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use bevy::prelude::*;
 mod carry;
 mod carry_feedback;
 mod combination;
-mod exterior_generation;
 mod fabricator;
 mod heat;
 mod input;
@@ -49,7 +48,7 @@ fn main() {
         // Materials: data-driven material definitions with observable/hidden properties.
         .add_plugins(materials::MaterialPlugin)
         // Exterior generation: deterministic baseline surface mineral deposits per active chunk.
-        .add_plugins(exterior_generation::ExteriorGenerationPlugin)
+        .add_plugins(world_generation::exterior::ExteriorGenerationPlugin)
         // Interaction: raycast, pickup/place, crosshair UI.
         .add_plugins(interaction::InteractionPlugin)
         // Heat: burner on workbench, thermal exposure → property revelation.

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -15,6 +15,8 @@
 //! kind of system that can feel "obvious" when you just wrote it and opaque a
 //! week later when you are trying to prove that nothing is secretly random.
 
+pub mod exterior;
+
 use std::fs;
 use std::path::Path;
 

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -22,14 +22,14 @@ use std::path::Path;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use super::{
+    ActiveChunkNeighborhood, ChunkCoord, GeneratedObjectId, WorldProfile, chunk_origin_xz,
+    derive_chunk_generation_key, derive_generated_object_id,
+};
 use crate::carry::InCarry;
 use crate::interaction::HeldItem;
 use crate::materials::{MaterialCatalog, MaterialObject};
 use crate::scene::{ExteriorGroundPatch, PositionXZ, RectXZ};
-use crate::world_generation::{
-    ActiveChunkNeighborhood, ChunkCoord, GeneratedObjectId, WorldProfile, chunk_origin_xz,
-    derive_chunk_generation_key, derive_generated_object_id,
-};
 
 const DEPOSIT_CONFIG_PATH: &str = "assets/exterior/surface_mineral_deposits.toml";
 const SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION: u32 = 1;


### PR DESCRIPTION
Move exterior_generation.rs into world_generation/exterior.rs as a
submodule. The exterior module was the sole external consumer of 8 of
world_generation's exports — they belong in the same module tree.

main.rs now registers ExteriorGenerationPlugin via
world_generation::exterior::ExteriorGenerationPlugin. No behavioral
changes.

Closes #247