### PR TITLE
refactor: decouple interaction from carry internals via message passing

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -40,6 +40,8 @@ impl Plugin for CarryPlugin {
             .add_message::<CycleCarryIntent>()
             .add_message::<CarryWeightChanged>()
             .add_message::<CarryActionRejected>()
+            .add_message::<StashHeldForPickup>()
+            .add_message::<ObserveWeight>()
             .init_resource::<CarryConfig>()
             .init_resource::<ActiveCarryProfile>()
             .init_resource::<CarryMovementState>()
@@ -56,6 +58,8 @@ impl Plugin for CarryPlugin {
                     emit_stash_intent,
                     emit_cycle_carry_intent,
                     process_stash_intent,
+                    process_stash_held_for_pickup,
+                    process_observe_weight,
                     process_cycle_carry_intent.after(process_stash_intent),
                 ),
             );
@@ -98,6 +102,23 @@ pub(crate) enum CarryRejectionReason {
     CarryEmpty,
     /// The next entity in carry order has been despawned (evicted from carry).
     StaleEntity,
+}
+
+/// Interaction emits this when picking up a new material while already holding one.
+/// Carry handles the stash mutation and weight observation for the held item.
+#[derive(Message)]
+pub struct StashHeldForPickup {
+    pub held_entity: Entity,
+    pub held_material: GameMaterial,
+    pub picked_material: GameMaterial,
+}
+
+/// Request carry to record a weight observation for a material the player just
+/// interacted with (pickup, examine, etc.). Carry handles confidence tracking
+/// and journal recording.
+#[derive(Message)]
+pub struct ObserveWeight {
+    pub material: GameMaterial,
 }
 
 /// Later stories will emit this whenever carry weight changes so movement/stamina
@@ -237,6 +258,15 @@ impl CarryState {
             self.current_weight = 0.0;
         }
         Some(removed)
+    }
+
+    /// Check whether there is room to stash one more material given the current
+    /// weight and capacity rules.
+    pub fn can_stash(&self, material: &GameMaterial) -> bool {
+        if !self.hard_limit_enabled {
+            return true;
+        }
+        (self.current_weight + material.density.value) <= (self.effective_capacity + f32::EPSILON)
     }
 
     /// Select which carried entity should be returned next when cycling or dropping.
@@ -1221,6 +1251,72 @@ fn process_stash_intent(
             &mut journal_writer,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
+    }
+}
+
+/// Handle interaction's request to stash the held item so a new pickup can proceed.
+///
+/// This keeps all carry-state mutation inside the carry module. Interaction only
+/// needs to read `CarryState` for the capacity gate and emit this message.
+#[allow(clippy::too_many_arguments)]
+fn process_stash_held_for_pickup(
+    mut commands: Commands,
+    mut reader: MessageReader<StashHeldForPickup>,
+    mut weight_writer: MessageWriter<CarryWeightChanged>,
+    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut tracker: ResMut<ConfidenceTracker>,
+    config: Res<CarryConfig>,
+    mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
+) {
+    for request in reader.read() {
+        let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
+            continue;
+        };
+
+        stash_entity_into_carry(
+            &mut commands,
+            &mut carry_state,
+            request.held_entity,
+            &request.held_material,
+        );
+        record_weight_observation(
+            &request.held_material,
+            carry_strength.current,
+            &config,
+            &mut tracker,
+            &mut journal_writer,
+        );
+        // Also record weight for the newly picked material.
+        record_weight_observation(
+            &request.picked_material,
+            carry_strength.current,
+            &config,
+            &mut tracker,
+            &mut journal_writer,
+        );
+        emit_carry_weight_changed(&mut weight_writer, &carry_state);
+    }
+}
+
+/// Handle standalone weight observation requests from interaction (pickup without stash).
+fn process_observe_weight(
+    mut reader: MessageReader<ObserveWeight>,
+    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut tracker: ResMut<ConfidenceTracker>,
+    config: Res<CarryConfig>,
+    player_query: Query<&CarryStrength, With<Player>>,
+) {
+    for request in reader.read() {
+        let Ok(carry_strength) = player_query.single() else {
+            continue;
+        };
+        record_weight_observation(
+            &request.material,
+            carry_strength.current,
+            &config,
+            &mut tracker,
+            &mut journal_writer,
+        );
     }
 }
 

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -20,10 +20,7 @@
 use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility};
 use bevy::prelude::*;
 
-use crate::carry::{
-    CarryConfig, CarryState, CarryStrength, can_stash_material, record_weight_observation,
-    stash_entity_into_carry,
-};
+use crate::carry::{CarryState, ObserveWeight, StashHeldForPickup};
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
 use crate::journal::{RecordEncounter, RecordWeightObservation};
@@ -305,18 +302,15 @@ fn emit_activate_intent(
 
 // ── Server-side processing ───────────────────────────────────────────────
 
-// This system bridges world interaction with carry state, confidence tracking,
-// and journal updates. The explicit ECS parameters are easier to audit than
-// hiding the touch points behind wrapper structs here.
 #[allow(clippy::too_many_arguments)]
 fn process_pickup(
     mut commands: Commands,
     mut reader: MessageReader<PickupIntent>,
     config: Res<CarryConfig>,
     target: Res<InteractionTarget>,
-    mut tracker: ResMut<ConfidenceTracker>,
-    mut journal_writer: MessageWriter<RecordWeightObservation>,
-    mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
+    mut stash_writer: MessageWriter<StashHeldForPickup>,
+    mut observe_writer: MessageWriter<ObserveWeight>,
+    player_query: Query<&CarryState, With<Player>>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     camera_query: Query<Entity, With<PlayerCamera>>,
@@ -331,40 +325,32 @@ fn process_pickup(
         let Ok(camera_entity) = camera_query.single() else {
             continue;
         };
-        let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
+        let Ok(carry_state) = player_query.single() else {
             continue;
         };
-
-        if let Some((held_entity, held_material)) = held_query.iter().next() {
-            if !can_stash_material(&carry_state, held_material) {
-                continue;
-            }
-            stash_entity_into_carry(&mut commands, &mut carry_state, held_entity, held_material);
-            record_weight_observation(
-                held_material,
-                carry_strength.current,
-                &config,
-                &mut tracker,
-                &mut journal_writer,
-            );
-        }
 
         let Ok(target_material) = material_query.get(target_entity) else {
             continue;
         };
 
-        record_weight_observation(
-            target_material,
-            carry_strength.current,
-            &config,
-            &mut tracker,
-            &mut journal_writer,
-        );
+        if let Some((held_entity, held_material)) = held_query.iter().next() {
+            if !carry_state.can_stash(held_material) {
+                continue;
+            }
+            // Carry module handles stash mutation + weight observations for both items.
+            stash_writer.write(StashHeldForPickup {
+                held_entity,
+                held_material: held_material.clone(),
+                picked_material: target_material.clone(),
+            });
+        } else {
+            // No held item — just observe weight for the pickup target.
+            observe_writer.write(ObserveWeight {
+                material: target_material.clone(),
+            });
+        }
 
         // Fabricator slot state must follow the actual object in the world.
-        // If the player picks a material up off a slot or output pad, clear the
-        // slot's stored entity reference immediately so later fabrication only
-        // consumes what is physically still seated in the machine.
         for mut slot in &mut input_slots {
             clear_input_slot_reference(&mut slot, target_entity);
         }


### PR DESCRIPTION
Replace direct function imports (can_stash_material, stash_entity_into_carry,
record_weight_observation) with CarryState::can_stash query method and two
messages (StashHeldForPickup, ObserveWeight). interaction.rs now only reads
carry state and sends messages; carry.rs owns all mutation logic.

Closes #248