### PR TITLE
refactor: split SceneConfig into per-feature plugin resources

### DIFF
--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -18,7 +18,7 @@ use crate::journal::RecordFabrication;
 use crate::materials::{
     GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, MaterialProperty, PropertyVisibility,
 };
-use crate::scene::{SceneConfig, Workbench};
+use crate::scene::{FabricatorSceneConfig, FurnitureConfig, Workbench};
 
 pub struct FabricatorPlugin;
 
@@ -80,7 +80,8 @@ fn spawn_fabricator_slots(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cfg: Res<SceneConfig>,
+    fab: Res<FabricatorSceneConfig>,
+    fur: Res<FurnitureConfig>,
     workbench_query: Query<&Transform, With<Workbench>>,
 ) {
     let Ok(wb_tf) = workbench_query.single() else {
@@ -88,8 +89,6 @@ fn spawn_fabricator_slots(
         return;
     };
 
-    let fab = &cfg.fabricator;
-    let fur = &cfg.furniture;
     let wb_top_y = fur.workbench_height;
     let wb_center = wb_tf.translation;
 
@@ -182,7 +181,7 @@ fn process_activation(
 fn tick_processing(
     mut commands: Commands,
     time: Res<Time>,
-    cfg: Res<SceneConfig>,
+    cfg: Res<FabricatorSceneConfig>,
     rules: Res<CombinationRules>,
     mut journal_writer: MessageWriter<RecordFabrication>,
     mut state: ResMut<FabricatorState>,
@@ -198,7 +197,7 @@ fn tick_processing(
 
     *elapsed += time.delta_secs();
 
-    if *elapsed < cfg.fabricator.process_seconds {
+    if *elapsed < cfg.process_seconds {
         return;
     }
 
@@ -268,13 +267,13 @@ fn tick_processing(
 
 fn apply_processing_visuals(
     state: Res<FabricatorState>,
-    cfg: Res<SceneConfig>,
+    cfg: Res<FabricatorSceneConfig>,
     slot_query: Query<&MeshMaterial3d<StandardMaterial>, With<InputSlot>>,
     mut std_materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let glow = match *state {
         FabricatorState::Processing { elapsed } => {
-            let frac = (elapsed / cfg.fabricator.process_seconds).clamp(0.0, 1.0);
+            let frac = (elapsed / cfg.process_seconds).clamp(0.0, 1.0);
             let pulse = (frac * std::f32::consts::TAU * 3.0).sin().abs();
             LinearRgba::new(pulse * 60.0, pulse * 40.0, pulse * 80.0, 1.0)
         }

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -19,7 +19,7 @@ use bevy::prelude::*;
 use crate::journal::RecordThermalObservation;
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::ConfidenceTracker;
-use crate::scene::{SceneConfig, Workbench};
+use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
 
 pub struct HeatPlugin;
 
@@ -101,16 +101,14 @@ fn spawn_heat_source(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cfg: Res<SceneConfig>,
+    hs: Res<HeatSourceConfig>,
+    fur: Res<FurnitureConfig>,
     workbench_query: Query<&Transform, With<Workbench>>,
 ) {
     let Ok(wb_tf) = workbench_query.single() else {
         warn!("No workbench found — heat source will not be spawned");
         return;
     };
-
-    let hs = &cfg.heat_source;
-    let fur = &cfg.furniture;
 
     let pos = Vec3::new(
         wb_tf.translation.x + hs.offset_x,
@@ -151,7 +149,7 @@ fn spawn_heat_source(
 fn track_heat_exposure(
     mut commands: Commands,
     time: Res<Time>,
-    cfg: Res<SceneConfig>,
+    hs_cfg: Res<HeatSourceConfig>,
     heat_query: Query<&GlobalTransform, With<HeatSource>>,
     mut material_query: Query<
         (
@@ -167,7 +165,7 @@ fn track_heat_exposure(
         return;
     };
     let heat_pos = heat_gtf.translation();
-    let zone_r_sq = cfg.heat_source.zone_radius * cfg.heat_source.zone_radius;
+    let zone_r_sq = hs_cfg.zone_radius * hs_cfg.zone_radius;
     let dt = time.delta_secs();
 
     for (entity, mat_gtf, mat, exposure) in &mut material_query {
@@ -219,7 +217,7 @@ fn reaction_scale(intensity: f32, thermal_resistance: f32) -> Vec3 {
 // for the mutable transform. Collapsing would require unsafe world access.
 #[allow(clippy::type_complexity)]
 fn apply_thermal_reaction(
-    cfg: Res<SceneConfig>,
+    hs_cfg: Res<HeatSourceConfig>,
     exposure_query: Query<
         (
             &HeatExposure,
@@ -234,7 +232,7 @@ fn apply_thermal_reaction(
         With<MaterialObject>,
     >,
 ) {
-    let reaction_secs = cfg.heat_source.reaction_seconds;
+    let reaction_secs = hs_cfg.reaction_seconds;
 
     for (exp, mat, mat_handle) in &exposure_query {
         let frac = (exp.elapsed / reaction_secs).clamp(0.0, 1.0);
@@ -264,7 +262,7 @@ fn apply_thermal_reaction(
 
 fn reveal_thermal_property(
     mut commands: Commands,
-    cfg: Res<SceneConfig>,
+    hs_cfg: Res<HeatSourceConfig>,
     mut tracker: ResMut<ConfidenceTracker>,
     mut journal_writer: MessageWriter<RecordThermalObservation>,
     mut material_query: Query<
@@ -277,7 +275,7 @@ fn reveal_thermal_property(
         With<MaterialObject>,
     >,
 ) {
-    let reveal_secs = cfg.heat_source.reveal_seconds;
+    let reveal_secs = hs_cfg.reveal_seconds;
     let mut revealed_seeds = Vec::new();
 
     for (entity, exp, mut mat, recorded) in &mut material_query {
@@ -454,7 +452,7 @@ mod tests {
     fn thermal_observation_repeats_after_cooling_cycle() {
         let mut app = App::new();
         app.add_message::<RecordThermalObservation>();
-        app.insert_resource(SceneConfig::default());
+        app.insert_resource(HeatSourceConfig::default());
         app.insert_resource(ConfidenceTracker::default());
         app.add_systems(Update, reveal_thermal_property);
 
@@ -504,7 +502,7 @@ mod tests {
     fn revealing_one_entity_propagates_visibility_to_same_seed() {
         let mut app = App::new();
         app.add_message::<RecordThermalObservation>();
-        app.insert_resource(SceneConfig::default());
+        app.insert_resource(HeatSourceConfig::default());
         app.insert_resource(ConfidenceTracker::default());
         app.add_systems(Update, reveal_thermal_property);
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -16,7 +16,7 @@ use leafwing_input_manager::prelude::*;
 
 use crate::carry::CarryMovementState;
 use crate::input::InputAction;
-use crate::scene::{PositionXZ, RoomShellCollision, SceneConfig};
+use crate::scene::{PlayerSceneConfig, PositionXZ, RoomShellCollision};
 
 /// Converts the leafwing axis_pair output (pixels * config sensitivity) to radians.
 /// Tune by adjusting `sensitivity_x` / `sensitivity_y` in input.toml rather than
@@ -79,17 +79,13 @@ struct CameraPitch(f32);
 
 pub fn spawn_player(
     mut commands: Commands,
-    scene: Res<SceneConfig>,
+    scene: Res<PlayerSceneConfig>,
     carry_movement: Res<CarryMovementState>,
 ) {
     commands
         .spawn((
             Player,
-            Transform::from_xyz(
-                scene.player.spawn_x,
-                scene.player.eye_height,
-                scene.player.spawn_z,
-            ),
+            Transform::from_xyz(scene.spawn_x, scene.eye_height, scene.spawn_z),
             Visibility::default(),
             // leafwing tracks which actions are active on this entity.
             // The InputMap is attached separately by InputPlugin after spawn.
@@ -171,7 +167,7 @@ fn player_look(
 fn player_move(
     time: Res<Time>,
     cursor_options: Single<&CursorOptions>,
-    scene: Res<SceneConfig>,
+    scene: Res<PlayerSceneConfig>,
     room_shell: Res<RoomShellCollision>,
     carry_movement: Res<CarryMovementState>,
     mut player_query: Query<
@@ -187,7 +183,7 @@ fn player_move(
         return;
     };
 
-    enforce_eye_height(&mut transform.translation, scene.player.eye_height);
+    enforce_eye_height(&mut transform.translation, scene.eye_height);
 
     let input = action_state.clamped_axis_pair(&InputAction::Move);
 
@@ -228,8 +224,7 @@ fn player_move(
     } else {
         1.0
     };
-    let effective_speed =
-        scene.player.move_speed * carry_movement.speed_modifier * sprint_multiplier;
+    let effective_speed = scene.move_speed * carry_movement.speed_modifier * sprint_multiplier;
     let delta = direction * effective_speed * time.delta_secs();
     let mut proposed = transform.translation;
     proposed.x += delta.x;
@@ -248,7 +243,7 @@ fn player_move(
         transform.translation.z = proposed.z;
     }
 
-    enforce_eye_height(&mut transform.translation, scene.player.eye_height);
+    enforce_eye_height(&mut transform.translation, scene.eye_height);
 }
 
 #[cfg(test)]

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -140,7 +140,7 @@ pub struct SceneConfig {
     pub heat_source: HeatSourceConfig,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct RoomConfig {
     #[serde(default = "default_half_extent_x")]
     pub half_extent_x: f32,
@@ -182,7 +182,7 @@ impl Default for RoomConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct PlayerSceneConfig {
     #[serde(default = "default_eye_height")]
     pub eye_height: f32,
@@ -215,7 +215,7 @@ impl Default for PlayerSceneConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct LightingConfig {
     #[serde(default = "default_ambient_brightness")]
     pub ambient_brightness: f32,
@@ -281,7 +281,7 @@ impl Default for LightingConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct FurnitureConfig {
     #[serde(default = "default_workbench_width")]
     pub workbench_width: f32,
@@ -367,7 +367,7 @@ pub struct ShelfConfig {
 
 // ── Fabricator config ────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct FabricatorSceneConfig {
     #[serde(default = "default_fab_slot_offset_x")]
     pub slot_offset_x: f32,
@@ -435,7 +435,7 @@ impl Default for FabricatorSceneConfig {
 
 // ── Heat source config ──────────────────────────────────────────────────
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Resource)]
 pub struct HeatSourceConfig {
     #[serde(default = "default_hs_offset_x")]
     pub offset_x: f32,
@@ -515,6 +515,12 @@ fn load_scene_config(mut commands: Commands) {
         warn!("{CONFIG_PATH} not found, using defaults");
         SceneConfig::default()
     };
+    commands.insert_resource(config.room.clone());
+    commands.insert_resource(config.player.clone());
+    commands.insert_resource(config.lighting.clone());
+    commands.insert_resource(config.furniture.clone());
+    commands.insert_resource(config.fabricator.clone());
+    commands.insert_resource(config.heat_source.clone());
     commands.insert_resource(config);
 }
 
@@ -603,12 +609,14 @@ fn setup_scene(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cfg: Res<SceneConfig>,
+    room: Res<RoomConfig>,
+    lighting: Res<LightingConfig>,
+    fur: Res<FurnitureConfig>,
 ) {
-    let hx = cfg.room.half_extent_x;
-    let hz = cfg.room.half_extent_z;
-    let h = cfg.room.wall_height;
-    let t = cfg.room.wall_thickness;
+    let hx = room.half_extent_x;
+    let hz = room.half_extent_z;
+    let h = room.wall_height;
+    let t = room.wall_thickness;
 
     // Room shell materials — darker than furniture so interactive materials read clearly.
     let floor_mat = materials.add(StandardMaterial {
@@ -732,7 +740,6 @@ fn setup_scene(
     ));
 
     // Workbench — lighter, lower roughness than walls (future fabricator site).
-    let fur = &cfg.furniture;
     let wb_half_y = fur.workbench_height * 0.5;
     let workbench_mat = materials.add(StandardMaterial {
         base_color: Color::srgb(0.52, 0.48, 0.42),
@@ -790,29 +797,29 @@ fn setup_scene(
     // Directional fill — angled so forms read; lower than the open-plane setup.
     commands.spawn((
         DirectionalLight {
-            illuminance: cfg.lighting.directional_illuminance,
-            shadows_enabled: cfg.lighting.directional_shadows,
+            illuminance: lighting.directional_illuminance,
+            shadows_enabled: lighting.directional_shadows,
             ..default()
         },
         Transform::from_xyz(6.0, 9.0, 4.0).looking_at(Vec3::new(0.0, 0.6, 0.0), Vec3::Y),
     ));
 
     commands.spawn(AmbientLight {
-        brightness: cfg.lighting.ambient_brightness,
+        brightness: lighting.ambient_brightness,
         ..default()
     });
 
     // Focused spot over the workbench — contrast for future material placement.
-    let spot_y = cfg.lighting.spot_height;
-    let target_y = cfg.lighting.spot_target_y;
+    let spot_y = lighting.spot_height;
+    let target_y = lighting.spot_target_y;
     commands.spawn((
         SpotLight {
             color: Color::srgb(1.0, 0.97, 0.92),
-            intensity: cfg.lighting.spot_intensity,
-            range: cfg.lighting.spot_range,
+            intensity: lighting.spot_intensity,
+            range: lighting.spot_range,
             shadows_enabled: true,
-            inner_angle: cfg.lighting.spot_inner_angle,
-            outer_angle: cfg.lighting.spot_outer_angle,
+            inner_angle: lighting.spot_inner_angle,
+            outer_angle: lighting.spot_outer_angle,
             ..default()
         },
         Transform::from_xyz(fur.workbench_x, spot_y, fur.workbench_z).looking_at(


### PR DESCRIPTION
Each sub-config (PlayerSceneConfig, FurnitureConfig, FabricatorSceneConfig,
HeatSourceConfig, RoomConfig, LightingConfig) is now a Resource inserted
individually by load_scene_config. Consumer plugins import only the configs
they need instead of depending on the monolithic SceneConfig.

player.rs no longer imports SceneConfig (uses PlayerSceneConfig).
fabricator.rs no longer imports SceneConfig (uses FabricatorSceneConfig + FurnitureConfig).
heat.rs no longer imports SceneConfig (uses HeatSourceConfig + FurnitureConfig).

Closes #249