### PR TITLE
feat(kanban): view switcher scaffold with Board/Backlog tabs

### DIFF
--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -4,6 +4,7 @@ import Sidebar from "./components/Sidebar";
 import Board from "./components/Board";
 import IssueDetail from "./components/IssueDetail";
 import LoginScreen from "./components/LoginScreen";
+import BacklogView from "./components/BacklogView";
 import { checkSession, parseErrorFromHash } from "./api/auth";
 import { useIssueStore } from "./store/issues";
 import { useAuthStore } from "./store/auth";
@@ -40,6 +41,8 @@ export default function App({ config }) {
   const [repo, setRepo] = useState(() => {
     return localStorage.getItem("gh_kanban_repo") || "";
   });
+
+  const [view, setView] = useState("board");
 
   useEffect(() => {
     async function bootstrap() {
@@ -85,10 +88,16 @@ export default function App({ config }) {
 
   return (
     <div style={styles.app}>
-      <Header repo={repo} onRepoChange={handleRepoChange} />
+      <Header repo={repo} onRepoChange={handleRepoChange} view={view} onViewChange={setView} />
       <div style={styles.body}>
-        <Sidebar />
-        <Board repo={repo} />
+        {view === "board" ? (
+          <>
+            <Sidebar />
+            <Board repo={repo} />
+          </>
+        ) : (
+          <BacklogView />
+        )}
       </div>
       {selectedIssue && <IssueDetail repo={repo} />}
     </div>

--- a/kanban/src/components/BacklogView.jsx
+++ b/kanban/src/components/BacklogView.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+
+const MODES = [
+  { key: "flat", label: "Flat List" },
+  { key: "type", label: "Group by Type" },
+  { key: "status", label: "Group by Status" },
+  { key: "priority", label: "Priority Order" },
+  { key: "epic", label: "Epic Tree" },
+];
+
+const s = {
+  container: {
+    flex: 1,
+    overflow: "auto",
+    padding: 20,
+    background: "#0d1117",
+    color: "#e6edf3",
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: 700,
+    marginBottom: 16,
+    color: "#58a6ff",
+  },
+  modeStrip: {
+    display: "flex",
+    gap: 8,
+    marginBottom: 20,
+  },
+  modeBtn: {
+    padding: "6px 14px",
+    borderRadius: 6,
+    border: "1px solid #30363d",
+    background: "#161b22",
+    color: "#8b949e",
+    cursor: "pointer",
+    fontSize: 13,
+    fontWeight: 500,
+    transition: "all 0.15s",
+  },
+  modeBtnActive: {
+    background: "#1f6feb",
+    color: "#fff",
+    borderColor: "#1f6feb",
+  },
+  placeholder: {
+    color: "#8b949e",
+    fontSize: 14,
+    fontStyle: "italic",
+  },
+};
+
+export default function BacklogView() {
+  const [mode, setMode] = useState("flat");
+
+  return (
+    <div style={s.container}>
+      <div style={s.heading}>Backlog</div>
+      <div style={s.modeStrip}>
+        {MODES.map((m) => (
+          <button
+            key={m.key}
+            style={{
+              ...s.modeBtn,
+              ...(mode === m.key ? s.modeBtnActive : {}),
+            }}
+            onClick={() => setMode(m.key)}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+      <div style={s.placeholder}>mode: {mode}</div>
+    </div>
+  );
+}

--- a/kanban/src/components/Header.jsx
+++ b/kanban/src/components/Header.jsx
@@ -56,9 +56,35 @@ const s = {
     marginLeft: "auto",
   },
   userName: { fontSize: 13, color: "#e6edf3" },
+  tabStrip: {
+    display: "flex",
+    gap: 0,
+    marginLeft: 16,
+    borderRadius: 6,
+    overflow: "hidden",
+    border: "1px solid #30363d",
+  },
+  tab: {
+    padding: "5px 14px",
+    fontSize: 13,
+    fontWeight: 500,
+    background: "#0d1117",
+    color: "#8b949e",
+    border: "none",
+    cursor: "pointer",
+    borderRight: "1px solid #30363d",
+    transition: "all 0.15s",
+  },
+  tabActive: {
+    background: "#1f6feb",
+    color: "#fff",
+  },
+  tabLast: {
+    borderRight: "none",
+  },
 };
 
-export default function Header({ repo, onRepoChange }) {
+export default function Header({ repo, onRepoChange, view, onViewChange }) {
   const { setIssues, setLoading, setError, loading, error } = useIssueStore();
   const { user, signOut } = useAuthStore();
 
@@ -123,6 +149,21 @@ export default function Header({ repo, onRepoChange }) {
           <option key={r} value={r}>{r}</option>
         ))}
       </select>
+
+      <div style={s.tabStrip}>
+        <button
+          style={{ ...s.tab, ...(view === "board" ? s.tabActive : {}) }}
+          onClick={() => onViewChange("board")}
+        >
+          Board
+        </button>
+        <button
+          style={{ ...s.tab, ...s.tabLast, ...(view === "backlog" ? s.tabActive : {}) }}
+          onClick={() => onViewChange("backlog")}
+        >
+          Backlog
+        </button>
+      </div>
 
       {reposError && <span style={s.error}>{reposError}</span>}
       {error && <span style={s.error}>{error}</span>}


### PR DESCRIPTION
## Summary

- Adds Board/Backlog tab strip to the header for switching views
- New `BacklogView.jsx` component with five mode toggle buttons (Flat List, Group by Type, Group by Status, Priority Order, Epic Tree)
- Board view shows existing Sidebar + Board; Backlog view shows the stub BacklogView
- Mode content is placeholder only — subsequent stories (#254, #255, #256) implement the actual display modes

Closes #253