### PR TITLE
feat(kanban): backlog group-by-status and priority-order modes

### DIFF
--- a/kanban/src/components/BacklogView.jsx
+++ b/kanban/src/components/BacklogView.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useIssueStore, issueType, issueColumn, TYPES, TYPE_COLORS, COLUMN_COLORS } from "../store/issues";
+import { useIssueStore, issueType, issueColumn, TYPES, TYPE_COLORS, COLUMNS, COLUMN_COLORS } from "../store/issues";
 
 const MODES = [
   { key: "flat", label: "Flat List" },
@@ -115,6 +115,13 @@ const s = {
     color: "#8b949e",
     transition: "transform 0.15s",
   },
+  priorityRank: {
+    fontSize: 11,
+    color: "#8b949e",
+    fontFamily: "monospace",
+    minWidth: 40,
+    textAlign: "right",
+  },
 };
 
 function IssueRow({ issue, onSelect }) {
@@ -189,6 +196,100 @@ function GroupByType({ issues, onSelect }) {
   });
 }
 
+function GroupByStatus({ issues, onSelect }) {
+  const [collapsed, setCollapsed] = useState(new Set());
+
+  const groups = [];
+  for (const col of COLUMNS) {
+    const items = issues.filter((i) => issueColumn(i) === col);
+    if (items.length === 0) continue;
+    groups.push({ column: col, items: [...items].sort((a, b) => b.number - a.number) });
+  }
+
+  function toggle(col) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(col)) next.delete(col);
+      else next.add(col);
+      return next;
+    });
+  }
+
+  return groups.map(({ column, items }) => {
+    const isCollapsed = collapsed.has(column);
+    const colColor = COLUMN_COLORS[column] || "#8b949e";
+    return (
+      <div key={column}>
+        <div style={s.sectionHeader} onClick={() => toggle(column)}>
+          <span style={{ ...s.chevron, transform: isCollapsed ? "rotate(-90deg)" : "rotate(0deg)" }}>
+            ▼
+          </span>
+          <span style={{ ...s.typeDot, background: colColor }} />
+          <span style={s.sectionTitle}>{column}</span>
+          <span style={s.countBadge}>{items.length}</span>
+        </div>
+        {!isCollapsed && items.map((issue) => (
+          <IssueRow key={issue.number} issue={issue} onSelect={onSelect} />
+        ))}
+      </div>
+    );
+  });
+}
+
+// Parse implementation order from title patterns like "[Epic N] Story N.M ..."
+// or "Story N.M ..." — returns a numeric sort key, or Infinity if unparseable.
+function parseOrder(title) {
+  // Match patterns: [Epic 4] Story 4.1 … or Story 4.1 …
+  const m = title.match(/story\s+(\d+)\.(\d+)/i);
+  if (m) return parseFloat(`${m[1]}.${m[2]}`);
+  // Also match bare "N.M" at start
+  const m2 = title.match(/^(\d+)\.(\d+)/);
+  if (m2) return parseFloat(`${m2[1]}.${m2[2]}`);
+  return Infinity;
+}
+
+function PriorityOrder({ issues, onSelect }) {
+  const sorted = [...issues].sort((a, b) => {
+    const oa = parseOrder(a.title);
+    const ob = parseOrder(b.title);
+    if (oa !== ob) return oa - ob;
+    return a.number - b.number;
+  });
+
+  return sorted.map((issue, idx) => {
+    const order = parseOrder(issue.title);
+    const rank = order === Infinity ? "—" : `#${idx + 1}`;
+    return (
+      <PriorityRow key={issue.number} issue={issue} rank={rank} onSelect={onSelect} />
+    );
+  });
+}
+
+function PriorityRow({ issue, rank, onSelect }) {
+  const [hovered, setHovered] = useState(false);
+  const type = issueType(issue);
+  const column = issueColumn(issue);
+  const typeColor = TYPE_COLORS[type] || "#8b949e";
+  const colColor = COLUMN_COLORS[column] || "#8b949e";
+
+  return (
+    <div
+      style={{ ...s.row, ...(hovered ? s.rowHover : {}) }}
+      onClick={() => onSelect(issue)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <span style={s.priorityRank}>{rank}</span>
+      <span style={s.issueNumber}>#{issue.number}</span>
+      <span style={{ ...s.typeDot, background: typeColor }} title={type} />
+      <span style={s.issueTitle}>{issue.title}</span>
+      <span style={{ ...s.columnBadge, background: colColor + "22", color: colColor, border: `1px solid ${colColor}44` }}>
+        {column}
+      </span>
+    </div>
+  );
+}
+
 export default function BacklogView() {
   const [mode, setMode] = useState("flat");
   const filteredIssues = useIssueStore((s) => s.filteredIssues());
@@ -203,6 +304,10 @@ export default function BacklogView() {
         return <FlatList issues={openIssues} onSelect={selectIssue} />;
       case "type":
         return <GroupByType issues={openIssues} onSelect={selectIssue} />;
+      case "status":
+        return <GroupByStatus issues={openIssues} onSelect={selectIssue} />;
+      case "priority":
+        return <PriorityOrder issues={openIssues} onSelect={selectIssue} />;
       default:
         return <div style={s.placeholder}>mode: {mode}</div>;
     }


### PR DESCRIPTION
## Summary

- **Group by Status**: collapsible sections per column (in COLUMNS order) with column color accent dots and count badges; empty columns hidden
- **Priority Order**: flat list sorted by implementation order parsed from title patterns like `[Epic N] Story N.M` or `Story N.M`; unparseable titles sort to bottom; each row shows a priority rank indicator

Only Epic Tree mode remains as a placeholder.

Closes #255