### PR TITLE
fix: pre-commit Cargo detection and orchestrator test portability

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,8 +7,8 @@ echo "Running pre-commit checks..."
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 
 # --- Rust / Game code ---
-if echo "$STAGED" | grep -qE '\.rs$'; then
-  echo "  Rust files staged — running cargo checks."
+if echo "$STAGED" | grep -qE '(\.rs$|^Cargo\.(toml|lock)$)'; then
+  echo "  Rust/Cargo files staged — running cargo checks."
   echo "  cargo fmt --check"
   cargo fmt --check
   echo "  cargo clippy -- -D warnings"

--- a/infra/orchestrator/cmd/server/main_integration_test.go
+++ b/infra/orchestrator/cmd/server/main_integration_test.go
@@ -69,7 +69,7 @@ func TestServerBinary_WebhookPersistsExpectedFields(t *testing.T) {
 
 	binaryPath := filepath.Join(t.TempDir(), "orchestrator-server")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = "/Users/lmckechn/projects/opensky/infra/orchestrator/cmd/server"
+	buildCmd.Dir = resolveTestFileDir(t)
 	buildOut, err := buildCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("building server binary: %v\n%s", err, string(buildOut))
@@ -196,7 +196,7 @@ func TestServerBinary_InvalidSignatureDoesNotPersistEvent(t *testing.T) {
 
 	binaryPath := filepath.Join(t.TempDir(), "orchestrator-server")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = "/Users/lmckechn/projects/opensky/infra/orchestrator/cmd/server"
+	buildCmd.Dir = resolveTestFileDir(t)
 	buildOut, err := buildCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("building server binary: %v\n%s", err, string(buildOut))
@@ -307,7 +307,7 @@ func TestServerBinary_FixtureWebhookWithEnvSecretPersistsEvent(t *testing.T) {
 
 	binaryPath := filepath.Join(t.TempDir(), "orchestrator-server")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
-	buildCmd.Dir = "/Users/lmckechn/projects/opensky/infra/orchestrator/cmd/server"
+	buildCmd.Dir = resolveTestFileDir(t)
 	buildOut, err := buildCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("building server binary: %v\n%s", err, string(buildOut))
@@ -569,4 +569,15 @@ func jsonBodiesEqual(got, want []byte) bool {
 	}
 
 	return strings.EqualFold(string(gotJSON), string(wantJSON))
+}
+
+// resolveTestFileDir returns the directory containing this test file,
+// used so `go build` targets the correct package without hardcoded paths.
+func resolveTestFileDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to resolve test file location")
+	}
+	return filepath.Dir(thisFile)
 }

--- a/infra/orchestrator/testdata/pr_needs_review.json
+++ b/infra/orchestrator/testdata/pr_needs_review.json
@@ -1,0 +1,44 @@
+[
+  {
+    "headers": {
+      "x-github-delivery": "test-delivery-001",
+      "x-github-event": "pull_request"
+    },
+    "body": {
+      "action": "labeled",
+      "number": 1,
+      "label": {
+        "id": 100,
+        "name": "status:needs-review",
+        "color": "0e8a16"
+      },
+      "pull_request": {
+        "number": 1,
+        "title": "feat: test PR for fixture",
+        "state": "open",
+        "html_url": "https://github.com/galamdring/apeiron-cipher/pull/1",
+        "user": {
+          "login": "test-user",
+          "id": 12345
+        },
+        "head": {
+          "ref": "feat/test-branch",
+          "sha": "abc123def456"
+        },
+        "base": {
+          "ref": "main",
+          "sha": "789abc012def"
+        }
+      },
+      "repository": {
+        "id": 1,
+        "full_name": "galamdring/apeiron-cipher",
+        "html_url": "https://github.com/galamdring/apeiron-cipher"
+      },
+      "sender": {
+        "login": "test-user",
+        "id": 12345
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- **Pre-commit hook**: Now triggers `make check` when `Cargo.toml` or `Cargo.lock` are staged, not just `.rs` files. Previously, changing dependencies without touching Rust source would skip cargo checks.
- **Orchestrator test fixture**: Added missing `infra/orchestrator/testdata/pr_needs_review.json` that `TestServerBinary_FixtureWebhookWithEnvSecretPersistsEvent` requires.
- **Hardcoded paths removed**: Replaced 3 instances of `/Users/lmckechn/projects/opensky/infra/orchestrator/cmd/server` in integration tests with `runtime.Caller`-based resolution, making the tests portable across machines and worktrees.

## Verification

- `make check` — 262/262 tests pass
- `make kb-check` — passes
- `make o-check` — passes (was failing before due to missing fixture)