### PR TITLE
feat: 5a.4 - region-specific material palettes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [build]
 # Shared build cache across all worktrees of this repo.
 # Keeps compiled Bevy deps from being rebuilt from scratch every time you
-# switch worktrees. The path lives outside any worktree so it is never
-# accidentally staged or committed.
-target-dir = "/Users/lmckechn/projects/opensky-target"
+# switch worktrees. For local development with multiple worktrees, set the
+# CARGO_TARGET_DIR environment variable to point to a shared target directory:
+#
+#   export CARGO_TARGET_DIR="$HOME/projects/opensky-target"
+#
+# In CI and without the environment variable, this defaults to ./target

--- a/assets/config/biomes.toml
+++ b/assets/config/biomes.toml
@@ -43,6 +43,31 @@ ferrite  = 3.0
 silite   = 0.8
 prismate = 0.2
 
+# Material palette — hot, metallic, and reactive materials dominate.
+[[biomes.material_palette]]
+material_seed = 1001  # Ferrite — iron-rich, at home in baked desert
+selection_weight = 3.0
+
+[[biomes.material_palette]]
+material_seed = 1003  # Sulfurite — volcanic/sulfurous affinity
+selection_weight = 2.5
+
+[[biomes.material_palette]]
+material_seed = 1006  # Osmium — dense metal exposed by erosion
+selection_weight = 2.0
+
+[[biomes.material_palette]]
+material_seed = 1007  # Volatite — reactive, heat-associated
+selection_weight = 1.5
+
+[[biomes.material_palette]]
+material_seed = 1002  # Calcium — trace presence
+selection_weight = 0.5
+
+[[biomes.material_palette]]
+material_seed = 1009  # Silite — rare in hot regions
+selection_weight = 0.3
+
 [[biomes]]
 key = "mineral_steppe"
 temperature_min = 0.3
@@ -56,6 +81,35 @@ density_modifier = 1.0
 
 [biomes.deposit_weight_modifiers]
 # All weights at 1.0 (identity) — the steppe uses global catalog weights.
+
+# Material palette — balanced mix, the generalist biome.
+[[biomes.material_palette]]
+material_seed = 1002  # Calcium — common mineral deposit
+selection_weight = 2.0
+
+[[biomes.material_palette]]
+material_seed = 1005  # Verdant — organic/plant-adjacent, thrives in temperate
+selection_weight = 2.5
+
+[[biomes.material_palette]]
+material_seed = 1008  # Cobaltine — moderate metal ore
+selection_weight = 2.0
+
+[[biomes.material_palette]]
+material_seed = 1009  # Silite — silicate, well-represented here
+selection_weight = 1.5
+
+[[biomes.material_palette]]
+material_seed = 1001  # Ferrite — present but not dominant
+selection_weight = 1.0
+
+[[biomes.material_palette]]
+material_seed = 1003  # Sulfurite — trace amounts
+selection_weight = 0.5
+
+[[biomes.material_palette]]
+material_seed = 1010  # Phosphite — occasional find
+selection_weight = 0.8
 
 [[biomes]]
 key = "frost_shelf"
@@ -72,3 +126,28 @@ density_modifier = 0.7
 ferrite  = 0.2
 silite   = 1.0
 prismate = 3.0
+
+# Material palette — crystalline, cold-affinity materials dominate.
+[[biomes.material_palette]]
+material_seed = 1004  # Prismate — crystalline, thrives in cold
+selection_weight = 3.0
+
+[[biomes.material_palette]]
+material_seed = 1009  # Silite — silicate, ice-embedded
+selection_weight = 2.0
+
+[[biomes.material_palette]]
+material_seed = 1010  # Phosphite — phosphorescent, cold-stable
+selection_weight = 2.5
+
+[[biomes.material_palette]]
+material_seed = 1008  # Cobaltine — metallic veins in ice
+selection_weight = 1.0
+
+[[biomes.material_palette]]
+material_seed = 1005  # Verdant — frozen organic traces
+selection_weight = 0.3
+
+[[biomes.material_palette]]
+material_seed = 1006  # Osmium — rare deep-ice pockets
+selection_weight = 0.5

--- a/assets/exterior/surface_mineral_deposits.toml
+++ b/assets/exterior/surface_mineral_deposits.toml
@@ -24,7 +24,7 @@ site_jitter_fraction = 0.28
 site_min_gap_world_units = 1.5
 
 [[deposits]]
-key = "ferrite_surface_deposit"
+key = "dense_cluster_deposit"
 selection_weight = 1.0
 scale_min = 0.9
 scale_max = 1.2
@@ -35,7 +35,7 @@ child_count_max = 11
 cluster_compactness = 0.75
 
 [[deposits]]
-key = "silite_surface_deposit"
+key = "scattered_cluster_deposit"
 selection_weight = 0.8
 scale_min = 0.85
 scale_max = 1.15
@@ -46,7 +46,7 @@ child_count_max = 9
 cluster_compactness = 0.68
 
 [[deposits]]
-key = "prismate_surface_deposit"
+key = "compact_cluster_deposit"
 selection_weight = 0.45
 scale_min = 0.8
 scale_max = 1.05

--- a/assets/exterior/surface_mineral_deposits.toml
+++ b/assets/exterior/surface_mineral_deposits.toml
@@ -25,7 +25,6 @@ site_min_gap_world_units = 1.5
 
 [[deposits]]
 key = "ferrite_surface_deposit"
-material_key = "Ferrite"
 selection_weight = 1.0
 scale_min = 0.9
 scale_max = 1.2
@@ -37,7 +36,6 @@ cluster_compactness = 0.75
 
 [[deposits]]
 key = "silite_surface_deposit"
-material_key = "Silite"
 selection_weight = 0.8
 scale_min = 0.85
 scale_max = 1.15
@@ -49,7 +47,6 @@ cluster_compactness = 0.68
 
 [[deposits]]
 key = "prismate_surface_deposit"
-material_key = "Prismate"
 selection_weight = 0.45
 scale_min = 0.8
 scale_max = 1.05

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -329,22 +329,11 @@ fn apply_rule_with_perturbation(
 }
 
 // ── Procedural naming ────────────────────────────────────────────────────
+// Vocabulary tables and the `procedural_name` function live in
+// `crate::naming` so both the fabricator and the seed-derived material
+// pipeline can share them without cross-module coupling.
 
-pub const PREFIXES: &[&str] = &[
-    "Neo", "Aur", "Vex", "Cor", "Nyx", "Zel", "Pyr", "Lux", "Thal", "Kyn", "Ven", "Dra", "Sol",
-    "Mor", "Cyn", "Vir",
-];
-
-pub const SUFFIXES: &[&str] = &[
-    "ite", "ium", "ite", "ane", "ene", "oid", "ate", "ide", "yne", "ase", "ose", "ine", "ile",
-    "ore", "ux", "al",
-];
-
-pub fn procedural_name(seed: u64) -> String {
-    let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
-    let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
-    format!("{}{}", PREFIXES[prefix_idx], SUFFIXES[suffix_idx])
-}
+pub use crate::naming::procedural_name;
 
 // ── Color blending ───────────────────────────────────────────────────────
 

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -843,4 +843,78 @@ mod tests {
             "catalog must not contain duplicate names"
         );
     }
+
+    /// Verify that fabricator `combined_seed` values never collide with biome
+    /// palette seeds.
+    ///
+    /// Biome palettes use well-known seeds in the range 1001–1010. The
+    /// fabricator computes `a.seed.wrapping_mul(31).wrapping_add(b.seed)`.
+    /// Because `wrapping_mul(31)` on any seed ≥ 1 produces a value ≥ 31,
+    /// the minimum fabricator output for palette-range inputs is
+    /// `1001 * 31 + 1001 = 32_032`, which is well above the palette range.
+    ///
+    /// This test exhaustively checks all pairwise combinations of the
+    /// well-known palette seeds and confirms no output lands in that range.
+    /// It also checks multi-generation chains (fabricated seeds fed back in).
+    #[test]
+    fn combined_seed_does_not_collide_with_biome_palette_seeds() {
+        // Well-known biome palette seeds from `assets/config/biomes.toml`.
+        let palette_seeds: Vec<u64> = (1001..=1010).collect();
+        let palette_set: std::collections::HashSet<u64> = palette_seeds.iter().copied().collect();
+
+        // ── Single-step fabrication ──────────────────────────────────────
+        let mut first_gen_seeds: Vec<u64> = Vec::new();
+        for &a in &palette_seeds {
+            for &b in &palette_seeds {
+                let combined = a.wrapping_mul(31).wrapping_add(b);
+                assert!(
+                    !palette_set.contains(&combined),
+                    "single-step fabrication of seeds ({a}, {b}) produced {combined} which collides with a palette seed"
+                );
+                first_gen_seeds.push(combined);
+            }
+        }
+
+        // ── Second-step fabrication (fabricated × palette, palette × fabricated) ─
+        for &fab in &first_gen_seeds {
+            for &p in &palette_seeds {
+                let combined_fp = fab.wrapping_mul(31).wrapping_add(p);
+                assert!(
+                    !palette_set.contains(&combined_fp),
+                    "second-step fabrication (fab={fab}, palette={p}) produced {combined_fp} which collides with a palette seed"
+                );
+                let combined_pf = p.wrapping_mul(31).wrapping_add(fab);
+                assert!(
+                    !palette_set.contains(&combined_pf),
+                    "second-step fabrication (palette={p}, fab={fab}) produced {combined_pf} which collides with a palette seed"
+                );
+            }
+        }
+
+        // ── Structural argument ─────────────────────────────────────────
+        // The minimum single-step output is 1001 * 31 + 1001 = 32_032.
+        // All palette seeds are ≤ 1010. The gap is 31× the input floor.
+        let min_output = palette_seeds
+            .iter()
+            .copied()
+            .min()
+            .expect("palette_seeds is non-empty")
+            .wrapping_mul(31)
+            .wrapping_add(
+                palette_seeds
+                    .iter()
+                    .copied()
+                    .min()
+                    .expect("palette_seeds is non-empty"),
+            );
+        let max_palette = palette_seeds
+            .iter()
+            .copied()
+            .max()
+            .expect("palette_seeds is non-empty");
+        assert!(
+            min_output > max_palette,
+            "minimum fabricator output ({min_output}) must exceed maximum palette seed ({max_palette})"
+        );
+    }
 }

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -822,7 +822,7 @@ mod tests {
         }
 
         // All registered entries must have unique names (catalog invariant).
-        let names: Vec<&String> = catalog.materials.keys().collect();
+        let names: Vec<&String> = catalog.names().collect();
         let unique_count = names.iter().collect::<std::collections::HashSet<_>>().len();
         assert_eq!(
             names.len(),

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -330,17 +330,17 @@ fn apply_rule_with_perturbation(
 
 // ── Procedural naming ────────────────────────────────────────────────────
 
-const PREFIXES: &[&str] = &[
+pub const PREFIXES: &[&str] = &[
     "Neo", "Aur", "Vex", "Cor", "Nyx", "Zel", "Pyr", "Lux", "Thal", "Kyn", "Ven", "Dra", "Sol",
     "Mor", "Cyn", "Vir",
 ];
 
-const SUFFIXES: &[&str] = &[
+pub const SUFFIXES: &[&str] = &[
     "ite", "ium", "ite", "ane", "ene", "oid", "ate", "ide", "yne", "ase", "ose", "ine", "ile",
     "ore", "ux", "al",
 ];
 
-fn procedural_name(seed: u64) -> String {
+pub fn procedural_name(seed: u64) -> String {
     let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
     let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
     format!("{}{}", PREFIXES[prefix_idx], SUFFIXES[suffix_idx])

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -988,4 +988,77 @@ mod tests {
             "second fabricated material must be retrievable by name"
         );
     }
+
+    /// Fabricated material names must not shadow seed-derived material names.
+    ///
+    /// Both `derive_and_register` (biome palette path) and `register_fabricated`
+    /// (fabricator path) call `procedural_name` on their respective seeds.  If a
+    /// fabricated combined-seed happens to produce the same base name as an
+    /// already-registered biome seed, the `disambiguated_name` logic must kick in
+    /// so that every catalog entry remains independently retrievable by name.
+    ///
+    /// This test registers all well-known biome palette seeds first, then
+    /// fabricates every pairwise combination and registers the results.  After
+    /// all registrations the catalog must contain exactly
+    /// `palette_count + fabrication_count` entries with fully unique names.
+    #[test]
+    fn fabricated_material_name_does_not_collide_with_seed_derived_names() {
+        use crate::materials::MaterialCatalog;
+        use std::collections::HashSet;
+
+        let palette_seeds: Vec<u64> = (1001..=1010).collect();
+        let rules = default_rules();
+
+        let mut catalog = MaterialCatalog::default();
+
+        // ── Phase 1: register all biome palette materials (seed-derived) ─────
+        for &seed in &palette_seeds {
+            catalog.derive_and_register(seed);
+        }
+        assert_eq!(catalog.len(), palette_seeds.len());
+
+        // ── Phase 2: fabricate every pairwise combo and register ─────────────
+        let mut fabricated_seeds: Vec<u64> = Vec::new();
+        for &a_seed in &palette_seeds {
+            for &b_seed in &palette_seeds {
+                let a = test_material("A", a_seed, 0.5);
+                let b = test_material("B", b_seed, 0.5);
+                let output = rule_combine(&rules, &a, &b);
+                let fab_seed = output.seed;
+                fabricated_seeds.push(fab_seed);
+                catalog.register_fabricated(output);
+            }
+        }
+
+        // Deduplicate fabricated seeds (some combos could theoretically collide
+        // at the seed level, though in practice they don't for this range).
+        let unique_fab_seeds: HashSet<u64> = fabricated_seeds.iter().copied().collect();
+        let expected_count = palette_seeds.len() + unique_fab_seeds.len();
+
+        assert_eq!(
+            catalog.len(),
+            expected_count,
+            "catalog must contain every palette material and every unique fabricated material"
+        );
+
+        // ── Phase 3: verify all names are unique ────────────────────────────
+        let names: Vec<String> = catalog.names().cloned().collect();
+        let unique_names: HashSet<&String> = names.iter().collect();
+        assert_eq!(
+            names.len(),
+            unique_names.len(),
+            "every material in the catalog must have a unique name; found {} names for {} entries",
+            unique_names.len(),
+            names.len()
+        );
+
+        // ── Phase 4: every entry retrievable by its own name ────────────────
+        for name in &names {
+            assert!(
+                catalog.get_by_name(name).is_some(),
+                "material '{}' must be retrievable by name",
+                name
+            );
+        }
+    }
 }

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -917,4 +917,75 @@ mod tests {
             "minimum fabricator output ({min_output}) must exceed maximum palette seed ({max_palette})"
         );
     }
+
+    /// Fabricate two distinct materials from different input pairs and verify
+    /// both outputs are independently retrievable from the catalog by seed.
+    #[test]
+    fn fabricate_two_materials_both_appear_in_catalog() {
+        use crate::materials::MaterialCatalog;
+
+        let rules = default_rules();
+        let mut catalog = MaterialCatalog::default();
+
+        // First fabrication: seeds 1001 + 1002
+        let a1 = test_material("InputA1", 1001, 0.4);
+        let b1 = test_material("InputB1", 1002, 0.6);
+        let output1 = rule_combine(&rules, &a1, &b1);
+        let seed1 = output1.seed;
+        let name1 = output1.name.clone();
+        let density1 = output1.density.value;
+        catalog.register_fabricated(output1);
+
+        // Second fabrication: seeds 1003 + 1004
+        let a2 = test_material("InputA2", 1003, 0.3);
+        let b2 = test_material("InputB2", 1004, 0.7);
+        let output2 = rule_combine(&rules, &a2, &b2);
+        let seed2 = output2.seed;
+        let name2 = output2.name.clone();
+        let density2 = output2.density.value;
+        catalog.register_fabricated(output2);
+
+        // Both seeds must differ (fabrication produces distinct combined seeds).
+        assert_ne!(
+            seed1, seed2,
+            "two fabrications from different inputs must produce different seeds"
+        );
+
+        // Catalog must contain exactly 2 entries.
+        assert_eq!(
+            catalog.len(),
+            2,
+            "catalog must contain both fabricated materials"
+        );
+
+        // First material retrievable by seed with preserved blended properties.
+        let entry1 = catalog
+            .get_by_seed(seed1)
+            .expect("first fabricated material must be in catalog");
+        assert_eq!(entry1.name, name1);
+        assert!(
+            (entry1.density.value - density1).abs() < f32::EPSILON,
+            "catalog must preserve blended density for first material"
+        );
+
+        // Second material retrievable by seed with preserved blended properties.
+        let entry2 = catalog
+            .get_by_seed(seed2)
+            .expect("second fabricated material must be in catalog");
+        assert_eq!(entry2.name, name2);
+        assert!(
+            (entry2.density.value - density2).abs() < f32::EPSILON,
+            "catalog must preserve blended density for second material"
+        );
+
+        // Both materials also retrievable by name.
+        assert!(
+            catalog.get_by_name(&name1).is_some(),
+            "first fabricated material must be retrievable by name"
+        );
+        assert!(
+            catalog.get_by_name(&name2).is_some(),
+            "second fabricated material must be retrievable by name"
+        );
+    }
 }

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -757,4 +757,77 @@ mod tests {
             "expected conductivity to move upward for a thermally conductive result"
         );
     }
+
+    /// Fabricated materials must produce valid procedural names that register
+    /// cleanly in the `MaterialCatalog` — even after the migration from
+    /// static TOML materials to seed-derived generation.
+    #[test]
+    fn fabricated_materials_register_valid_names_in_catalog() {
+        use crate::materials::MaterialCatalog;
+
+        let rules = default_rules();
+
+        // Simulate a range of fabrication outputs from different seed pairs.
+        let seed_pairs: &[(u64, u64)] = &[
+            (100, 200),
+            (1, 2),
+            (0xDEAD_BEEF, 0xCAFE_BABE),
+            (u64::MAX, 1),
+            (0, 0),
+            (7, 7),
+            (0xFE00_0000_0000_0001, 0xFE00_0000_0000_0002),
+        ];
+
+        let mut catalog = MaterialCatalog::default();
+
+        for &(seed_a, seed_b) in seed_pairs {
+            let a = test_material("InputA", seed_a, 0.5);
+            let b = test_material("InputB", seed_b, 0.5);
+            let output = rule_combine(&rules, &a, &b);
+
+            // Name must be non-empty and follow the three-part procedural pattern
+            // (no dashes — disambiguation only happens at catalog registration).
+            assert!(
+                !output.name.is_empty(),
+                "fabricated name must not be empty for seeds ({seed_a}, {seed_b})"
+            );
+            assert!(
+                output.name.len() >= 6,
+                "procedural names have at least 6 chars (prefix+root+suffix): got '{}' for seeds ({seed_a}, {seed_b})",
+                output.name
+            );
+            assert!(
+                output.name.chars().all(|c| c.is_alphanumeric()),
+                "base procedural name must be alphanumeric: got '{}' for seeds ({seed_a}, {seed_b})",
+                output.name
+            );
+
+            // Name must match what `procedural_name` returns for the combined seed.
+            let expected_name = procedural_name(output.seed);
+            assert_eq!(
+                output.name, expected_name,
+                "fabricated name must equal procedural_name(combined_seed) for seeds ({seed_a}, {seed_b})"
+            );
+
+            // Registration into the catalog must succeed without panic.
+            let registered = catalog.derive_and_register(output.seed);
+            assert_eq!(
+                registered.seed, output.seed,
+                "catalog entry seed must match fabricated seed for seeds ({seed_a}, {seed_b})"
+            );
+            assert!(
+                !registered.name.is_empty(),
+                "registered name must not be empty for seeds ({seed_a}, {seed_b})"
+            );
+        }
+
+        // All registered entries must have unique names (catalog invariant).
+        let names: Vec<&String> = catalog.materials.keys().collect();
+        let unique_count = names.iter().collect::<std::collections::HashSet<_>>().len();
+        assert_eq!(
+            names.len(),
+            unique_count,
+            "catalog must not contain duplicate names"
+        );
+    }
 }

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -16,7 +16,8 @@ use bevy::prelude::*;
 use crate::combination::CombinationRules;
 use crate::journal::RecordFabrication;
 use crate::materials::{
-    GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, MaterialProperty, PropertyVisibility,
+    GameMaterial, MATERIAL_SURFACE_GAP, MaterialCatalog, MaterialObject, MaterialProperty,
+    PropertyVisibility,
 };
 use crate::scene::{FabricatorSceneConfig, FurnitureConfig, Workbench};
 
@@ -185,6 +186,7 @@ fn tick_processing(
     rules: Res<CombinationRules>,
     _journal_writer: MessageWriter<RecordFabrication>,
     mut state: ResMut<FabricatorState>,
+    mut catalog: ResMut<MaterialCatalog>,
     mut slots: Query<&mut InputSlot>,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     mut output_slot: Query<(&GlobalTransform, &mut OutputSlot)>,
@@ -222,6 +224,10 @@ fn tick_processing(
 
     // Rule-driven combination.
     let output_mat = rule_combine(&rules, &input_mats[0], &input_mats[1]);
+
+    // Register the fabricated material in the catalog so it is discoverable
+    // by seed/name lookups (e.g. journal, future recipes).
+    let _ = catalog.register_fabricated(output_mat.clone());
 
     // Spawn the output material on the output slot.
     let Ok((output_gtf, mut out_slot)) = output_slot.single_mut() else {
@@ -809,15 +815,22 @@ mod tests {
                 "fabricated name must equal procedural_name(combined_seed) for seeds ({seed_a}, {seed_b})"
             );
 
-            // Registration into the catalog must succeed without panic.
-            let registered = catalog.derive_and_register(output.seed);
+            // Registration via `register_fabricated` must preserve blended properties.
+            let blended_density = output.density.value;
+            let registered = catalog.register_fabricated(output);
             assert_eq!(
-                registered.seed, output.seed,
+                registered.seed,
+                a.seed.wrapping_mul(31).wrapping_add(b.seed),
                 "catalog entry seed must match fabricated seed for seeds ({seed_a}, {seed_b})"
             );
             assert!(
                 !registered.name.is_empty(),
                 "registered name must not be empty for seeds ({seed_a}, {seed_b})"
+            );
+            // The catalog must store the actual blended properties, not re-derived ones.
+            assert!(
+                (registered.density.value - blended_density).abs() < f32::EPSILON,
+                "catalog must preserve fabricated (blended) properties, not re-derive from seed for seeds ({seed_a}, {seed_b})"
             );
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod input;
 mod interaction;
 mod journal;
 mod materials;
+mod naming;
 mod observation;
 mod player;
 mod scene;

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -60,6 +60,30 @@ pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
 #[allow(dead_code)]
 pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
 
+// ── Well-known material seeds ────────────────────────────────────────────
+//
+// Migration table: maps the 10 original hand-authored material names to their
+// canonical seed values (from the `seed` field in each `assets/materials/*.toml`
+// file). These seeds are referenced by biome palettes so the legacy materials
+// appear naturally through exploration. The seed values must never change —
+// doing so would break saved worlds and biome palette references.
+
+/// Well-known material seeds: `(name, seed)` pairs for the 10 original
+/// materials that shipped in the static TOML catalog.
+#[allow(dead_code)] // Consumed by biome palette integration in Story 5a.4 Phase 7+.
+pub const WELL_KNOWN_MATERIAL_SEEDS: &[(&str, u64)] = &[
+    ("Ferrite", 1001),
+    ("Calcium", 1002),
+    ("Sulfurite", 1003),
+    ("Prismate", 1004),
+    ("Verdant", 1005),
+    ("Osmium", 1006),
+    ("Volatite", 1007),
+    ("Cobaltine", 1008),
+    ("Silite", 1009),
+    ("Phosphite", 1010),
+];
+
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreStartup, load_material_catalog)

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -242,6 +242,66 @@ pub struct MaterialCatalog {
     pub materials: HashMap<String, GameMaterial>,
 }
 
+impl MaterialCatalog {
+    /// Derive a material from a seed and register it in the catalog, returning a
+    /// reference to the (possibly already-present) entry.
+    ///
+    /// If a material with the same **seed** already exists, returns the existing
+    /// entry unchanged.  If the procedurally generated name collides with a
+    /// *different* seed's material, a deterministic disambiguator derived from
+    /// the seed is appended (e.g. `"Vexorite-a3f1"`) until the name is unique.
+    #[allow(dead_code)] // Public API for Story 5a.4 Phase 3+ (biome palette integration).
+    pub fn derive_and_register(&mut self, seed: u64) -> &GameMaterial {
+        // Fast path: already registered (lookup by name of this seed's base material).
+        // We check all entries for a matching seed to avoid re-deriving.
+        if let Some(name) = self.materials.values().find_map(|m| {
+            if m.seed == seed {
+                Some(m.name.clone())
+            } else {
+                None
+            }
+        }) {
+            return &self.materials[&name];
+        }
+
+        let mut mat = derive_material_from_seed(seed);
+        mat.name = Self::disambiguated_name(&mat.name, seed, &self.materials);
+        let key = mat.name.clone();
+        self.materials.insert(key.clone(), mat);
+        &self.materials[&key]
+    }
+
+    /// Return `base_name` if it is not already taken in `existing`, otherwise
+    /// append a short hex suffix derived deterministically from `seed`.
+    ///
+    /// The suffix is produced by taking successive 16-bit windows of the seed
+    /// (formatted as lowercase hex).  In the astronomically unlikely case that
+    /// *all* eight 16-bit windows also collide, we fall back to the full 16-hex
+    /// seed representation which is unique by definition (different seeds).
+    #[allow(dead_code)] // Used by `derive_and_register`; called indirectly in tests.
+    fn disambiguated_name(
+        base_name: &str,
+        seed: u64,
+        existing: &HashMap<String, GameMaterial>,
+    ) -> String {
+        if !existing.contains_key(base_name) {
+            return base_name.to_owned();
+        }
+
+        // Try successive 16-bit windows of the seed as a 4-hex-char suffix.
+        for shift in (0..64).step_by(16) {
+            let fragment = (seed >> shift) as u16;
+            let candidate = format!("{base_name}-{fragment:04x}");
+            if !existing.contains_key(&candidate) {
+                return candidate;
+            }
+        }
+
+        // Ultimate fallback: full seed hex (guaranteed unique for distinct seeds).
+        format!("{base_name}-{seed:016x}")
+    }
+}
+
 // ── World-object marker ──────────────────────────────────────────────────
 
 /// Marks an entity as a material object that exists physically in the world.
@@ -733,5 +793,71 @@ visibility = "Hidden"
         assert!((unit_interval_01(u64::MAX) - 1.0).abs() < f32::EPSILON);
         let mid = unit_interval_01(u64::MAX / 2);
         assert!((0.0..=1.0).contains(&mid));
+    }
+
+    // ── Collision-avoidance tests ────────────────────────────────────────
+
+    #[test]
+    fn derive_and_register_returns_same_entry_for_same_seed() {
+        let mut catalog = MaterialCatalog::default();
+        let name1 = catalog.derive_and_register(42).name.clone();
+        let name2 = catalog.derive_and_register(42).name.clone();
+        assert_eq!(name1, name2);
+        assert_eq!(catalog.materials.len(), 1);
+    }
+
+    #[test]
+    fn derive_and_register_disambiguates_name_collision() {
+        // Force a collision by pre-inserting a material whose name matches
+        // what seed 999 would generate, but with a different seed.
+        let mut catalog = MaterialCatalog::default();
+        let base_name = crate::naming::procedural_name(999);
+
+        let mut imposter = derive_material_from_seed(0xBEEF);
+        imposter.name = base_name.clone();
+        imposter.seed = 0xBEEF; // different seed, same name
+        catalog.materials.insert(base_name.clone(), imposter);
+
+        let registered = catalog.derive_and_register(999);
+        // Name must differ from the pre-existing entry.
+        assert_ne!(registered.name, base_name);
+        // Must contain the base name as a prefix with a hex suffix.
+        assert!(
+            registered.name.starts_with(&base_name),
+            "disambiguated name '{}' should start with base '{}'",
+            registered.name,
+            base_name
+        );
+        assert!(
+            registered.name.contains('-'),
+            "disambiguated name should contain a '-' separator"
+        );
+        // Catalog now has both entries.
+        assert_eq!(catalog.materials.len(), 2);
+    }
+
+    #[test]
+    fn disambiguated_name_no_collision_returns_base() {
+        let existing = HashMap::new();
+        let result = MaterialCatalog::disambiguated_name("Vexorite", 42, &existing);
+        assert_eq!(result, "Vexorite");
+    }
+
+    #[test]
+    fn disambiguated_name_with_collision_appends_suffix() {
+        let mut existing = HashMap::new();
+        existing.insert("Vexorite".to_string(), derive_material_from_seed(0xAAAA));
+        let result =
+            MaterialCatalog::disambiguated_name("Vexorite", 0x1234_5678_9ABC_DEF0, &existing);
+        assert_eq!(result, "Vexorite-def0");
+    }
+
+    #[test]
+    fn disambiguated_name_deterministic() {
+        let mut existing = HashMap::new();
+        existing.insert("Coranite".to_string(), derive_material_from_seed(0xBBBB));
+        let a = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
+        let b = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
+        assert_eq!(a, b);
     }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -5,18 +5,19 @@
 //! visibility states that control what the player can observe directly versus
 //! what must be discovered through experimentation.
 //!
-//! Material definitions live in TOML files under `assets/materials/`. They are
-//! loaded at startup via `std::fs` (not `AssetServer` — material definitions are
-//! startup configuration, not hot-reloadable game assets). Each file defines one
-//! material with its seed, color, and property values.
+//! Materials are seed-derived: each material is deterministically generated from
+//! a `u64` seed via [`derive_material_from_seed`]. The [`MaterialCatalog`]
+//! starts empty at startup and grows as the player explores — biome palettes
+//! define which seeds appear in each region, and materials are registered on
+//! first encounter.
 //!
-//! The [`MaterialCatalog`] resource holds every loaded definition, keyed by name.
+//! Legacy TOML files under `assets/materials/` are retained as reference
+//! documentation but are no longer loaded at startup.
+//!
 //! The `spawn_material_objects` system creates 3D entities from the catalog and
 //! distributes them across [`Surface`](crate::scene::Surface) shelves.
 
 use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -374,51 +375,15 @@ fn spawn_material_objects(
 
 // ── Loading ──────────────────────────────────────────────────────────────
 
-const MATERIALS_DIR: &str = "assets/materials";
-
+/// Initializes an empty [`MaterialCatalog`].
+///
+/// Materials are no longer loaded from TOML files at startup. Instead, the
+/// catalog starts empty and grows as the player explores — biome palettes
+/// define which material seeds appear in each region, and
+/// [`MaterialCatalog::derive_and_register`] inserts them on first encounter.
 fn load_material_catalog(mut commands: Commands) {
-    let mut catalog = MaterialCatalog::default();
-    let dir = Path::new(MATERIALS_DIR);
-
-    if !dir.exists() || !dir.is_dir() {
-        warn!("{MATERIALS_DIR} directory not found — starting with an empty material catalog");
-        commands.insert_resource(catalog);
-        return;
-    }
-
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(err) => {
-            warn!("Could not read {MATERIALS_DIR}: {err}");
-            commands.insert_resource(catalog);
-            return;
-        }
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "toml") {
-            match fs::read_to_string(&path) {
-                Ok(contents) => match toml::from_str::<GameMaterial>(&contents) {
-                    Ok(mat) => {
-                        info!("Loaded material '{}' from {}", mat.name, path.display());
-                        catalog.materials.insert(mat.name.clone(), mat);
-                    }
-                    Err(e) => {
-                        warn!("Skipping malformed material file {}: {e}", path.display());
-                    }
-                },
-                Err(e) => {
-                    warn!("Could not read {}: {e}", path.display());
-                }
-            }
-        }
-    }
-
-    info!(
-        "Material catalog loaded: {} materials",
-        catalog.materials.len()
-    );
+    let catalog = MaterialCatalog::default();
+    info!("Material catalog initialized (empty — materials are seed-derived on demand)");
     commands.insert_resource(catalog);
 }
 

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -36,28 +36,20 @@ pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
 // every seed-derived material in every saved world.
 
 /// Channel for deriving material density from a seed.
-#[allow(dead_code)] // Used by derive_material_from_seed; callers arrive in Story 5a.4 Phase 2+.
 pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
 /// Channel for deriving material thermal resistance from a seed.
-#[allow(dead_code)]
 pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
 /// Channel for deriving material reactivity from a seed.
-#[allow(dead_code)]
 pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
 /// Channel for deriving material conductivity from a seed.
-#[allow(dead_code)]
 pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
 /// Channel for deriving material toxicity from a seed.
-#[allow(dead_code)]
 pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
 /// Channel for deriving the red component of material color from a seed.
-#[allow(dead_code)]
 pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
 /// Channel for deriving the green component of material color from a seed.
-#[allow(dead_code)]
 pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
 /// Channel for deriving the blue component of material color from a seed.
-#[allow(dead_code)]
 pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
 
 // ── Well-known material seeds ────────────────────────────────────────────
@@ -70,7 +62,6 @@ pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
 
 /// Well-known material seeds: `(name, seed)` pairs for the 10 original
 /// materials that shipped in the static TOML catalog.
-#[allow(dead_code)] // Consumed by biome palette integration in Story 5a.4 Phase 7+.
 pub const WELL_KNOWN_MATERIAL_SEEDS: &[(&str, u64)] = &[
     ("Ferrite", 1001),
     ("Calcium", 1002),
@@ -194,7 +185,6 @@ impl GameMaterial {
 /// SplitMix64-style bit mixer — cheap, deterministic, no external crate.
 /// Identical to the mixer in `world_generation`; duplicated here so the
 /// material module has no coupling to world-gen internals.
-#[allow(dead_code)] // Called by derive_material_from_seed; callers arrive in later phases.
 fn mix_seed(base: u64, channel: u64) -> u64 {
     let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
@@ -203,7 +193,6 @@ fn mix_seed(base: u64, channel: u64) -> u64 {
 }
 
 /// Map a `u64` into the closed unit interval \[0.0, 1.0\].
-#[allow(dead_code)]
 fn unit_interval_01(value: u64) -> f32 {
     (value as f64 / u64::MAX as f64) as f32
 }
@@ -219,7 +208,6 @@ fn unit_interval_01(value: u64) -> f32 {
 /// observation/journal system reveals them through gameplay.
 ///
 /// **Determinism guarantee:** same seed always produces the same material.
-#[allow(dead_code)] // Public API for Story 5a.4 Phase 2+ (biome palette integration).
 pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
     let name = crate::naming::procedural_name(seed);
 

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -596,49 +596,6 @@ visibility = "Hidden"
         assert!(catalog.is_empty());
     }
 
-    #[test]
-    fn material_file_parsing_matches_expected_format() {
-        let file_content = include_str!("../assets/materials/ferrite.toml");
-        let mat: GameMaterial = toml::from_str(file_content).expect("parse ferrite.toml");
-        assert_eq!(mat.name, "Ferrite");
-        assert_eq!(mat.seed, 1001);
-        assert_eq!(mat.density.visibility, PropertyVisibility::Observable);
-        assert_eq!(
-            mat.thermal_resistance.visibility,
-            PropertyVisibility::Hidden
-        );
-    }
-
-    #[test]
-    fn all_material_files_parse_successfully() {
-        let files = [
-            include_str!("../assets/materials/ferrite.toml"),
-            include_str!("../assets/materials/calcium.toml"),
-            include_str!("../assets/materials/sulfurite.toml"),
-            include_str!("../assets/materials/prismate.toml"),
-            include_str!("../assets/materials/verdant.toml"),
-            include_str!("../assets/materials/osmium.toml"),
-            include_str!("../assets/materials/volatite.toml"),
-            include_str!("../assets/materials/cobaltine.toml"),
-            include_str!("../assets/materials/silite.toml"),
-            include_str!("../assets/materials/phosphite.toml"),
-        ];
-        let mut names = std::collections::HashSet::new();
-        let mut seeds = std::collections::HashSet::new();
-        for (i, src) in files.iter().enumerate() {
-            let mat: GameMaterial =
-                toml::from_str(src).unwrap_or_else(|e| panic!("file {i} failed: {e}"));
-            assert!(!mat.name.is_empty(), "material {i} has an empty name");
-            assert!(
-                names.insert(mat.name.clone()),
-                "duplicate name: {}",
-                mat.name
-            );
-            assert!(seeds.insert(mat.seed), "duplicate seed: {}", mat.seed);
-        }
-        assert_eq!(names.len(), 10, "expected 10 unique materials");
-    }
-
     // ── derive_material_from_seed tests ──────────────────────────────────
 
     #[test]

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -240,7 +240,10 @@ pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
 /// definitions during fabrication.
 #[derive(Resource, Debug, Default)]
 pub struct MaterialCatalog {
-    pub materials: HashMap<String, GameMaterial>,
+    /// Primary index: seed → material.
+    by_seed: HashMap<u64, GameMaterial>,
+    /// Secondary index: name → seed (for name-based lookups).
+    by_name: HashMap<String, u64>,
 }
 
 impl MaterialCatalog {
@@ -252,27 +255,62 @@ impl MaterialCatalog {
     /// *different* seed's material, a deterministic disambiguator derived from
     /// the seed is appended (e.g. `"Vexorite-a3f1"`) until the name is unique.
     pub fn derive_and_register(&mut self, seed: u64) -> &GameMaterial {
-        // Fast path: already registered (lookup by name of this seed's base material).
-        // We check all entries for a matching seed to avoid re-deriving.
-        if let Some(name) = self.materials.values().find_map(|m| {
-            if m.seed == seed {
-                Some(m.name.clone())
-            } else {
-                None
-            }
-        }) {
-            return &self.materials[&name];
+        // Fast path: already registered by seed — O(1) lookup.
+        if self.by_seed.contains_key(&seed) {
+            return &self.by_seed[&seed];
         }
 
         let mut mat = derive_material_from_seed(seed);
-        mat.name = Self::disambiguated_name(&mat.name, seed, &self.materials);
-        let key = mat.name.clone();
-        self.materials.insert(key.clone(), mat);
-        &self.materials[&key]
+        mat.name = Self::disambiguated_name(&mat.name, seed, &self.by_name);
+        self.by_name.insert(mat.name.clone(), seed);
+        self.by_seed.insert(seed, mat);
+        &self.by_seed[&seed]
     }
 
-    /// Return `base_name` if it is not already taken in `existing`, otherwise
-    /// append a short hex suffix derived deterministically from `seed`.
+    /// Look up a material by its seed, returning `None` if not yet registered.
+    #[allow(dead_code)]
+    pub fn get_by_seed(&self, seed: u64) -> Option<&GameMaterial> {
+        self.by_seed.get(&seed)
+    }
+
+    /// Look up a material by its display name, returning `None` if not found.
+    pub fn get_by_name(&self, name: &str) -> Option<&GameMaterial> {
+        self.by_name
+            .get(name)
+            .and_then(|seed| self.by_seed.get(seed))
+    }
+
+    /// Returns the number of materials in the catalog.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.by_seed.len()
+    }
+
+    /// Returns `true` if the catalog contains no materials.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.by_seed.is_empty()
+    }
+
+    /// Iterate over all materials in the catalog.
+    #[allow(dead_code)]
+    pub fn values(&self) -> impl Iterator<Item = &GameMaterial> {
+        self.by_seed.values()
+    }
+
+    /// Iterate over all material names in the catalog.
+    pub fn names(&self) -> impl Iterator<Item = &String> {
+        self.by_name.keys()
+    }
+
+    /// Iterate over all seeds in the catalog.
+    #[allow(dead_code)]
+    pub fn seeds(&self) -> impl Iterator<Item = &u64> {
+        self.by_seed.keys()
+    }
+
+    /// Return `base_name` if it is not already taken, otherwise append a short
+    /// hex suffix derived deterministically from `seed`.
     ///
     /// The suffix is produced by taking successive 16-bit windows of the seed
     /// (formatted as lowercase hex).  In the astronomically unlikely case that
@@ -281,9 +319,9 @@ impl MaterialCatalog {
     fn disambiguated_name(
         base_name: &str,
         seed: u64,
-        existing: &HashMap<String, GameMaterial>,
+        existing_names: &HashMap<String, u64>,
     ) -> String {
-        if !existing.contains_key(base_name) {
+        if !existing_names.contains_key(base_name) {
             return base_name.to_owned();
         }
 
@@ -291,7 +329,7 @@ impl MaterialCatalog {
         for shift in (0..64).step_by(16) {
             let fragment = (seed >> shift) as u16;
             let candidate = format!("{base_name}-{fragment:04x}");
-            if !existing.contains_key(&candidate) {
+            if !existing_names.contains_key(&candidate) {
                 return candidate;
             }
         }
@@ -328,11 +366,13 @@ fn spawn_material_objects(
         return;
     }
 
-    let mut sorted_names: Vec<&String> = catalog.materials.keys().collect();
+    let mut sorted_names: Vec<&String> = catalog.names().collect();
     sorted_names.sort();
 
     for (i, name) in sorted_names.iter().enumerate() {
-        let mat = &catalog.materials[*name];
+        let mat = catalog
+            .get_by_name(name)
+            .expect("name index references a valid material");
         let surface_tf = shelf_transforms[i % shelf_transforms.len()];
 
         let items_on_this_surface = sorted_names
@@ -511,7 +551,7 @@ visibility = "Hidden"
     #[test]
     fn catalog_default_is_empty() {
         let catalog = MaterialCatalog::default();
-        assert!(catalog.materials.is_empty());
+        assert!(catalog.is_empty());
     }
 
     #[test]
@@ -766,7 +806,7 @@ visibility = "Hidden"
         let name1 = catalog.derive_and_register(42).name.clone();
         let name2 = catalog.derive_and_register(42).name.clone();
         assert_eq!(name1, name2);
-        assert_eq!(catalog.materials.len(), 1);
+        assert_eq!(catalog.len(), 1);
     }
 
     #[test]
@@ -779,7 +819,8 @@ visibility = "Hidden"
         let mut imposter = derive_material_from_seed(0xBEEF);
         imposter.name = base_name.clone();
         imposter.seed = 0xBEEF; // different seed, same name
-        catalog.materials.insert(base_name.clone(), imposter);
+        catalog.by_name.insert(base_name.clone(), 0xBEEF);
+        catalog.by_seed.insert(0xBEEF, imposter);
 
         let registered = catalog.derive_and_register(999);
         // Name must differ from the pre-existing entry.
@@ -796,7 +837,7 @@ visibility = "Hidden"
             "disambiguated name should contain a '-' separator"
         );
         // Catalog now has both entries.
-        assert_eq!(catalog.materials.len(), 2);
+        assert_eq!(catalog.len(), 2);
     }
 
     #[test]
@@ -808,8 +849,8 @@ visibility = "Hidden"
 
     #[test]
     fn disambiguated_name_with_collision_appends_suffix() {
-        let mut existing = HashMap::new();
-        existing.insert("Vexorite".to_string(), derive_material_from_seed(0xAAAA));
+        let mut existing: HashMap<String, u64> = HashMap::new();
+        existing.insert("Vexorite".to_string(), 0xAAAA);
         let result =
             MaterialCatalog::disambiguated_name("Vexorite", 0x1234_5678_9ABC_DEF0, &existing);
         assert_eq!(result, "Vexorite-def0");
@@ -831,16 +872,16 @@ visibility = "Hidden"
             catalog.derive_and_register(seed);
         }
 
-        // Every entry in the catalog must have a unique name (HashMap keys
-        // guarantee this structurally, but verify the count matches).
+        // Every entry in the catalog must have a unique name (dual-index
+        // guarantees this structurally, but verify the count matches).
         assert_eq!(
-            catalog.materials.len(),
+            catalog.len(),
             1000,
             "catalog should contain exactly 1000 materials after 1000 unique seeds"
         );
 
         // Double-check: collect all names into a HashSet and confirm no loss.
-        let unique_names: std::collections::HashSet<&String> = catalog.materials.keys().collect();
+        let unique_names: std::collections::HashSet<&String> = catalog.names().collect();
         assert_eq!(
             unique_names.len(),
             1000,
@@ -850,8 +891,8 @@ visibility = "Hidden"
 
     #[test]
     fn disambiguated_name_deterministic() {
-        let mut existing = HashMap::new();
-        existing.insert("Coranite".to_string(), derive_material_from_seed(0xBBBB));
+        let mut existing: HashMap<String, u64> = HashMap::new();
+        existing.insert("Coranite".to_string(), 0xBBBB);
         let a = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
         let b = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
         assert_eq!(a, b);

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -35,20 +35,28 @@ pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
 // every seed-derived material in every saved world.
 
 /// Channel for deriving material density from a seed.
+#[allow(dead_code)] // Used by derive_material_from_seed; callers arrive in Story 5a.4 Phase 2+.
 pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
 /// Channel for deriving material thermal resistance from a seed.
+#[allow(dead_code)]
 pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
 /// Channel for deriving material reactivity from a seed.
+#[allow(dead_code)]
 pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
 /// Channel for deriving material conductivity from a seed.
+#[allow(dead_code)]
 pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
 /// Channel for deriving material toxicity from a seed.
+#[allow(dead_code)]
 pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
 /// Channel for deriving the red component of material color from a seed.
+#[allow(dead_code)]
 pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
 /// Channel for deriving the green component of material color from a seed.
+#[allow(dead_code)]
 pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
 /// Channel for deriving the blue component of material color from a seed.
+#[allow(dead_code)]
 pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
 
 impl Plugin for MaterialPlugin {
@@ -151,6 +159,75 @@ impl GameMaterial {
         } else {
             0.13
         }
+    }
+}
+
+// ── Seed-derived helpers ─────────────────────────────────────────────────
+
+/// Deterministically mix a base seed and a channel into a new 64-bit value.
+///
+/// SplitMix64-style bit mixer — cheap, deterministic, no external crate.
+/// Identical to the mixer in `world_generation`; duplicated here so the
+/// material module has no coupling to world-gen internals.
+#[allow(dead_code)] // Called by derive_material_from_seed; callers arrive in later phases.
+fn mix_seed(base: u64, channel: u64) -> u64 {
+    let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Map a `u64` into the closed unit interval \[0.0, 1.0\].
+#[allow(dead_code)]
+fn unit_interval_01(value: u64) -> f32 {
+    (value as f64 / u64::MAX as f64) as f32
+}
+
+/// Derive a complete [`GameMaterial`] deterministically from a seed.
+///
+/// Every property is produced by mixing the seed with a fixed channel constant
+/// and mapping the result to \[0.0, 1.0\]. Color channels (R, G, B) use three
+/// additional channels. The name is generated procedurally via
+/// [`crate::fabricator::procedural_name`].
+///
+/// All property visibilities start as [`PropertyVisibility::Hidden`] — the
+/// observation/journal system reveals them through gameplay.
+///
+/// **Determinism guarantee:** same seed always produces the same material.
+#[allow(dead_code)] // Public API for Story 5a.4 Phase 2+ (biome palette integration).
+pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
+    let name = crate::fabricator::procedural_name(seed);
+
+    let color = [
+        unit_interval_01(mix_seed(seed, MAT_COLOR_R_CHANNEL)),
+        unit_interval_01(mix_seed(seed, MAT_COLOR_G_CHANNEL)),
+        unit_interval_01(mix_seed(seed, MAT_COLOR_B_CHANNEL)),
+    ];
+
+    GameMaterial {
+        name,
+        seed,
+        color,
+        density: MaterialProperty {
+            value: unit_interval_01(mix_seed(seed, MAT_DENSITY_CHANNEL)),
+            visibility: PropertyVisibility::Hidden,
+        },
+        thermal_resistance: MaterialProperty {
+            value: unit_interval_01(mix_seed(seed, MAT_THERMAL_RESISTANCE_CHANNEL)),
+            visibility: PropertyVisibility::Hidden,
+        },
+        reactivity: MaterialProperty {
+            value: unit_interval_01(mix_seed(seed, MAT_REACTIVITY_CHANNEL)),
+            visibility: PropertyVisibility::Hidden,
+        },
+        conductivity: MaterialProperty {
+            value: unit_interval_01(mix_seed(seed, MAT_CONDUCTIVITY_CHANNEL)),
+            visibility: PropertyVisibility::Hidden,
+        },
+        toxicity: MaterialProperty {
+            value: unit_interval_01(mix_seed(seed, MAT_TOXICITY_CHANNEL)),
+            visibility: PropertyVisibility::Hidden,
+        },
     }
 }
 
@@ -455,5 +532,106 @@ visibility = "Hidden"
             assert!(seeds.insert(mat.seed), "duplicate seed: {}", mat.seed);
         }
         assert_eq!(names.len(), 10, "expected 10 unique materials");
+    }
+
+    // ── derive_material_from_seed tests ──────────────────────────────────
+
+    #[test]
+    fn derive_material_deterministic() {
+        let a = derive_material_from_seed(0xDEAD_BEEF);
+        let b = derive_material_from_seed(0xDEAD_BEEF);
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.seed, b.seed);
+        assert!((a.density.value - b.density.value).abs() < f32::EPSILON);
+        assert!((a.thermal_resistance.value - b.thermal_resistance.value).abs() < f32::EPSILON);
+        assert!((a.reactivity.value - b.reactivity.value).abs() < f32::EPSILON);
+        assert!((a.conductivity.value - b.conductivity.value).abs() < f32::EPSILON);
+        assert!((a.toxicity.value - b.toxicity.value).abs() < f32::EPSILON);
+        assert_eq!(a.color, b.color);
+    }
+
+    #[test]
+    fn derive_material_different_seeds_differ() {
+        let a = derive_material_from_seed(1);
+        let b = derive_material_from_seed(2);
+        // With good mixing, at least one property should differ.
+        let same_density = (a.density.value - b.density.value).abs() < f32::EPSILON;
+        let same_reactivity = (a.reactivity.value - b.reactivity.value).abs() < f32::EPSILON;
+        let same_conductivity = (a.conductivity.value - b.conductivity.value).abs() < f32::EPSILON;
+        assert!(
+            !(same_density && same_reactivity && same_conductivity),
+            "different seeds should produce different materials"
+        );
+    }
+
+    #[test]
+    fn derive_material_all_hidden() {
+        let mat = derive_material_from_seed(42);
+        assert_eq!(mat.density.visibility, PropertyVisibility::Hidden);
+        assert_eq!(
+            mat.thermal_resistance.visibility,
+            PropertyVisibility::Hidden
+        );
+        assert_eq!(mat.reactivity.visibility, PropertyVisibility::Hidden);
+        assert_eq!(mat.conductivity.visibility, PropertyVisibility::Hidden);
+        assert_eq!(mat.toxicity.visibility, PropertyVisibility::Hidden);
+    }
+
+    #[test]
+    fn derive_material_values_in_unit_range() {
+        // Test across a spread of seeds to ensure all properties stay in [0, 1].
+        for seed in [0, 1, u64::MAX, 0xCAFE_BABE, 0x1234_5678_9ABC_DEF0] {
+            let mat = derive_material_from_seed(seed);
+            for (label, val) in [
+                ("density", mat.density.value),
+                ("thermal_resistance", mat.thermal_resistance.value),
+                ("reactivity", mat.reactivity.value),
+                ("conductivity", mat.conductivity.value),
+                ("toxicity", mat.toxicity.value),
+                ("color_r", mat.color[0]),
+                ("color_g", mat.color[1]),
+                ("color_b", mat.color[2]),
+            ] {
+                assert!(
+                    (0.0..=1.0).contains(&val),
+                    "seed {seed:#X}: {label} = {val} out of [0,1]"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn derive_material_name_not_empty() {
+        let mat = derive_material_from_seed(999);
+        assert!(!mat.name.is_empty());
+    }
+
+    #[test]
+    fn derive_material_preserves_seed() {
+        let seed = 0xFE00_0000_0000_0001;
+        let mat = derive_material_from_seed(seed);
+        assert_eq!(mat.seed, seed);
+    }
+
+    #[test]
+    fn mix_seed_deterministic() {
+        let a = mix_seed(100, 200);
+        let b = mix_seed(100, 200);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn mix_seed_different_channels_differ() {
+        let a = mix_seed(100, 1);
+        let b = mix_seed(100, 2);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn unit_interval_01_bounds() {
+        assert!((unit_interval_01(0) - 0.0).abs() < f32::EPSILON);
+        assert!((unit_interval_01(u64::MAX) - 1.0).abs() < f32::EPSILON);
+        let mid = unit_interval_01(u64::MAX / 2);
+        assert!((0.0..=1.0).contains(&mid));
     }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -853,6 +853,39 @@ visibility = "Hidden"
     }
 
     #[test]
+    fn derive_and_register_1000_seeds_no_duplicate_names() {
+        // With only 4 096 possible base names (16³), 1 000 seeds are expected
+        // to produce raw collisions.  `derive_and_register` must disambiguate
+        // every collision so the catalog never contains duplicate names.
+        let mut catalog = MaterialCatalog::default();
+
+        // Use a deterministic spread across the u64 range.
+        let seeds: Vec<u64> = (0u64..1000)
+            .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1))
+            .collect();
+
+        for &seed in &seeds {
+            catalog.derive_and_register(seed);
+        }
+
+        // Every entry in the catalog must have a unique name (HashMap keys
+        // guarantee this structurally, but verify the count matches).
+        assert_eq!(
+            catalog.materials.len(),
+            1000,
+            "catalog should contain exactly 1000 materials after 1000 unique seeds"
+        );
+
+        // Double-check: collect all names into a HashSet and confirm no loss.
+        let unique_names: std::collections::HashSet<&String> = catalog.materials.keys().collect();
+        assert_eq!(
+            unique_names.len(),
+            1000,
+            "all 1000 registered material names must be unique"
+        );
+    }
+
+    #[test]
     fn disambiguated_name_deterministic() {
         let mut existing = HashMap::new();
         existing.insert("Coranite".to_string(), derive_material_from_seed(0xBBBB));

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -614,6 +614,106 @@ visibility = "Hidden"
     }
 
     #[test]
+    fn derive_material_non_degenerate_across_100_seeds() {
+        use std::collections::HashSet;
+
+        let count: usize = 128;
+        // Use seeds spread across the u64 range so every bit window in the
+        // mixer and naming function gets exercised.  Sequential small integers
+        // share low-order bits which would under-test higher bit windows.
+        let materials: Vec<GameMaterial> = (0..count as u64)
+            .map(|i| {
+                let seed = i.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+                derive_material_from_seed(seed)
+            })
+            .collect();
+
+        // Collect unique values per property to verify the mixer spreads well.
+        let mut unique_density = HashSet::new();
+        let mut unique_thermal = HashSet::new();
+        let mut unique_reactivity = HashSet::new();
+        let mut unique_conductivity = HashSet::new();
+        let mut unique_toxicity = HashSet::new();
+        let mut unique_names = HashSet::new();
+        let mut unique_colors = HashSet::new();
+
+        for mat in &materials {
+            unique_density.insert(mat.density.value.to_bits());
+            unique_thermal.insert(mat.thermal_resistance.value.to_bits());
+            unique_reactivity.insert(mat.reactivity.value.to_bits());
+            unique_conductivity.insert(mat.conductivity.value.to_bits());
+            unique_toxicity.insert(mat.toxicity.value.to_bits());
+            unique_names.insert(mat.name.clone());
+            unique_colors.insert((
+                mat.color[0].to_bits(),
+                mat.color[1].to_bits(),
+                mat.color[2].to_bits(),
+            ));
+        }
+
+        // With 128 seeds and a good mixer, every property should have many
+        // distinct values — at least 10 unique values out of 128.  A degenerate
+        // mixer that collapses to a handful of buckets will fail this.
+        let threshold = 10;
+        assert!(
+            unique_density.len() >= threshold,
+            "density collapsed: only {} unique values out of {count}",
+            unique_density.len()
+        );
+        assert!(
+            unique_thermal.len() >= threshold,
+            "thermal_resistance collapsed: only {} unique values out of {count}",
+            unique_thermal.len()
+        );
+        assert!(
+            unique_reactivity.len() >= threshold,
+            "reactivity collapsed: only {} unique values out of {count}",
+            unique_reactivity.len()
+        );
+        assert!(
+            unique_conductivity.len() >= threshold,
+            "conductivity collapsed: only {} unique values out of {count}",
+            unique_conductivity.len()
+        );
+        assert!(
+            unique_toxicity.len() >= threshold,
+            "toxicity collapsed: only {} unique values out of {count}",
+            unique_toxicity.len()
+        );
+        assert!(
+            unique_names.len() >= threshold,
+            "names collapsed: only {} unique values out of {count}",
+            unique_names.len()
+        );
+        assert!(
+            unique_colors.len() >= threshold,
+            "colors collapsed: only {} unique values out of {count}",
+            unique_colors.len()
+        );
+
+        // Additionally verify no two materials are fully identical (all properties match).
+        for i in 0..materials.len() {
+            for j in (i + 1)..materials.len() {
+                let a = &materials[i];
+                let b = &materials[j];
+                let all_same = a.density.value.to_bits() == b.density.value.to_bits()
+                    && a.thermal_resistance.value.to_bits() == b.thermal_resistance.value.to_bits()
+                    && a.reactivity.value.to_bits() == b.reactivity.value.to_bits()
+                    && a.conductivity.value.to_bits() == b.conductivity.value.to_bits()
+                    && a.toxicity.value.to_bits() == b.toxicity.value.to_bits()
+                    && a.color[0].to_bits() == b.color[0].to_bits()
+                    && a.color[1].to_bits() == b.color[1].to_bits()
+                    && a.color[2].to_bits() == b.color[2].to_bits();
+                assert!(
+                    !all_same,
+                    "seeds {} and {} produced identical materials",
+                    a.seed, b.seed
+                );
+            }
+        }
+    }
+
+    #[test]
     fn mix_seed_deterministic() {
         let a = mix_seed(100, 200);
         let b = mix_seed(100, 200);

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -291,6 +291,24 @@ impl MaterialCatalog {
         &self.by_seed[&seed]
     }
 
+    /// Register a pre-built material (e.g. from the fabricator) in the catalog.
+    ///
+    /// If a material with the same **seed** already exists, the existing entry is
+    /// kept unchanged and a reference to it is returned.  Otherwise the supplied
+    /// material is inserted after applying name disambiguation, and a reference
+    /// to the newly-inserted entry is returned.
+    pub fn register_fabricated(&mut self, mut mat: GameMaterial) -> &GameMaterial {
+        if self.by_seed.contains_key(&mat.seed) {
+            return &self.by_seed[&mat.seed];
+        }
+
+        mat.name = Self::disambiguated_name(&mat.name, mat.seed, &self.by_name);
+        let seed = mat.seed;
+        self.by_name.insert(mat.name.clone(), seed);
+        self.by_seed.insert(seed, mat);
+        &self.by_seed[&seed]
+    }
+
     /// Look up a material by its seed, returning `None` if not yet registered.
     #[allow(dead_code)]
     pub fn get_by_seed(&self, seed: u64) -> Option<&GameMaterial> {

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -188,7 +188,7 @@ fn unit_interval_01(value: u64) -> f32 {
 /// Every property is produced by mixing the seed with a fixed channel constant
 /// and mapping the result to \[0.0, 1.0\]. Color channels (R, G, B) use three
 /// additional channels. The name is generated procedurally via
-/// [`crate::fabricator::procedural_name`].
+/// [`crate::naming::procedural_name`].
 ///
 /// All property visibilities start as [`PropertyVisibility::Hidden`] — the
 /// observation/journal system reveals them through gameplay.

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -26,6 +26,31 @@ pub struct MaterialPlugin;
 
 pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
 
+// ── Seed-derived material property channels ──────────────────────────────
+//
+// Each channel constant is mixed with a material seed via `mix_seed` to
+// deterministically derive a single property value. The 0xA7E1_0001 prefix
+// groups all material-property channels; the low word distinguishes each
+// property. These must never change once shipped — doing so would alter
+// every seed-derived material in every saved world.
+
+/// Channel for deriving material density from a seed.
+pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
+/// Channel for deriving material thermal resistance from a seed.
+pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
+/// Channel for deriving material reactivity from a seed.
+pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
+/// Channel for deriving material conductivity from a seed.
+pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
+/// Channel for deriving material toxicity from a seed.
+pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
+/// Channel for deriving the red component of material color from a seed.
+pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
+/// Channel for deriving the green component of material color from a seed.
+pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
+/// Channel for deriving the blue component of material color from a seed.
+pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
+
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreStartup, load_material_catalog)

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -922,6 +922,100 @@ visibility = "Hidden"
         assert_eq!(a, b);
     }
 
+    /// Verifies that the 10 well-known material seeds each produce a material
+    /// with reasonable, non-degenerate properties.  The derived values will NOT
+    /// match the old hand-authored TOML values — that's expected.  What matters
+    /// is that every property falls in `[0.0, 1.0]`, that no two well-known
+    /// seeds collide on all properties, and that names are non-empty.
+    #[test]
+    fn well_known_seeds_produce_reasonable_materials() {
+        let materials: Vec<GameMaterial> = WELL_KNOWN_MATERIAL_SEEDS
+            .iter()
+            .map(|&(_label, seed)| derive_material_from_seed(seed))
+            .collect();
+
+        for (i, (label, seed)) in WELL_KNOWN_MATERIAL_SEEDS.iter().enumerate() {
+            let mat = &materials[i];
+
+            // Seed round-trips.
+            assert_eq!(
+                mat.seed, *seed,
+                "{label}: seed not preserved (expected {seed}, got {})",
+                mat.seed
+            );
+
+            // Name is non-empty.
+            assert!(
+                !mat.name.is_empty(),
+                "{label} (seed {seed}): derived name is empty"
+            );
+
+            // Every scalar property is in the valid unit interval [0, 1].
+            let props = [
+                ("density", mat.density.value),
+                ("thermal_resistance", mat.thermal_resistance.value),
+                ("reactivity", mat.reactivity.value),
+                ("conductivity", mat.conductivity.value),
+                ("toxicity", mat.toxicity.value),
+            ];
+            for (prop_name, val) in &props {
+                assert!(
+                    (0.0..=1.0).contains(val),
+                    "{label} (seed {seed}): {prop_name} out of range: {val}"
+                );
+            }
+
+            // Color channels in [0, 1].
+            for (ch, &val) in ["R", "G", "B"].iter().zip(mat.color.iter()) {
+                assert!(
+                    (0.0..=1.0).contains(&val),
+                    "{label} (seed {seed}): color {ch} out of range: {val}"
+                );
+            }
+
+            // All properties start hidden.
+            assert_eq!(mat.density.visibility, PropertyVisibility::Hidden);
+            assert_eq!(
+                mat.thermal_resistance.visibility,
+                PropertyVisibility::Hidden
+            );
+            assert_eq!(mat.reactivity.visibility, PropertyVisibility::Hidden);
+            assert_eq!(mat.conductivity.visibility, PropertyVisibility::Hidden);
+            assert_eq!(mat.toxicity.visibility, PropertyVisibility::Hidden);
+        }
+
+        // No two well-known materials share every property (uniqueness).
+        for i in 0..materials.len() {
+            for j in (i + 1)..materials.len() {
+                let a = &materials[i];
+                let b = &materials[j];
+                let all_same = a.density.value.to_bits() == b.density.value.to_bits()
+                    && a.thermal_resistance.value.to_bits() == b.thermal_resistance.value.to_bits()
+                    && a.reactivity.value.to_bits() == b.reactivity.value.to_bits()
+                    && a.conductivity.value.to_bits() == b.conductivity.value.to_bits()
+                    && a.toxicity.value.to_bits() == b.toxicity.value.to_bits();
+                assert!(
+                    !all_same,
+                    "well-known seeds {} ({}) and {} ({}) produced identical properties",
+                    a.seed, WELL_KNOWN_MATERIAL_SEEDS[i].0, b.seed, WELL_KNOWN_MATERIAL_SEEDS[j].0,
+                );
+            }
+        }
+
+        // Spot-check: across 10 materials we expect meaningful spread.  At
+        // least 5 distinct density values among 10 materials ensures the mixer
+        // is not collapsing small sequential seeds into the same bucket.
+        let unique_densities: std::collections::HashSet<u32> = materials
+            .iter()
+            .map(|m| m.density.value.to_bits())
+            .collect();
+        assert!(
+            unique_densities.len() >= 5,
+            "density spread too narrow: only {} distinct values among 10 well-known seeds",
+            unique_densities.len()
+        );
+    }
+
     /// Verifies that `load_material_catalog` inserts an empty [`MaterialCatalog`]
     /// during startup, before any chunk-generation systems have a chance to run.
     /// This mirrors the real plugin's `PreStartup` registration and confirms the

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -196,7 +196,7 @@ fn unit_interval_01(value: u64) -> f32 {
 /// **Determinism guarantee:** same seed always produces the same material.
 #[allow(dead_code)] // Public API for Story 5a.4 Phase 2+ (biome palette integration).
 pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
-    let name = crate::fabricator::procedural_name(seed);
+    let name = crate::naming::procedural_name(seed);
 
     let color = [
         unit_interval_01(mix_seed(seed, MAT_COLOR_R_CHANNEL)),

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -250,7 +250,6 @@ impl MaterialCatalog {
     /// entry unchanged.  If the procedurally generated name collides with a
     /// *different* seed's material, a deterministic disambiguator derived from
     /// the seed is appended (e.g. `"Vexorite-a3f1"`) until the name is unique.
-    #[allow(dead_code)] // Public API for Story 5a.4 Phase 3+ (biome palette integration).
     pub fn derive_and_register(&mut self, seed: u64) -> &GameMaterial {
         // Fast path: already registered (lookup by name of this seed's base material).
         // We check all entries for a matching seed to avoid re-deriving.
@@ -278,7 +277,6 @@ impl MaterialCatalog {
     /// (formatted as lowercase hex).  In the astronomically unlikely case that
     /// *all* eight 16-bit windows also collide, we fall back to the full 16-hex
     /// seed representation which is unique by definition (different seeds).
-    #[allow(dead_code)] // Used by `derive_and_register`; called indirectly in tests.
     fn disambiguated_name(
         base_name: &str,
         seed: u64,

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -897,4 +897,27 @@ visibility = "Hidden"
         let b = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
         assert_eq!(a, b);
     }
+
+    /// Verifies that `load_material_catalog` inserts an empty [`MaterialCatalog`]
+    /// during startup, before any chunk-generation systems have a chance to run.
+    /// This mirrors the real plugin's `PreStartup` registration and confirms the
+    /// "start empty, grow on demand" invariant.
+    #[test]
+    fn catalog_starts_empty_before_chunk_generation() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(PreStartup, load_material_catalog);
+        app.update();
+
+        let catalog = app
+            .world()
+            .get_resource::<MaterialCatalog>()
+            .expect("MaterialCatalog resource must exist after startup");
+        assert!(
+            catalog.is_empty(),
+            "catalog must be empty before any chunk generation; found {} entries",
+            catalog.len()
+        );
+        assert_eq!(catalog.len(), 0);
+    }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -464,8 +464,19 @@ fn spawn_material_objects(
 /// define which material seeds appear in each region, and
 /// [`MaterialCatalog::derive_and_register`] inserts them on first encounter.
 fn load_material_catalog(mut commands: Commands) {
-    let catalog = MaterialCatalog::default();
-    info!("Material catalog initialized (empty — materials are seed-derived on demand)");
+    let mut catalog = MaterialCatalog::default();
+
+    // Pre-seed the catalog with the 10 well-known materials so that indoor
+    // scenes (which spawn material objects at PostStartup) have something to
+    // display before exterior chunk generation populates the catalog further.
+    for &(_name, seed) in WELL_KNOWN_MATERIAL_SEEDS {
+        catalog.derive_and_register(seed);
+    }
+
+    info!(
+        "Material catalog initialized with {} well-known starter materials",
+        catalog.len()
+    );
     commands.insert_resource(catalog);
 }
 
@@ -1009,12 +1020,11 @@ visibility = "Hidden"
         }
     }
 
-    /// Verifies that `load_material_catalog` inserts an empty [`MaterialCatalog`]
-    /// during startup, before any chunk-generation systems have a chance to run.
-    /// This mirrors the real plugin's `PreStartup` registration and confirms the
-    /// "start empty, grow on demand" invariant.
+    /// Verifies that `load_material_catalog` pre-seeds the catalog with the
+    /// well-known materials so that indoor scene spawning (which runs at
+    /// `PostStartup`) has materials to display before exterior chunk generation.
     #[test]
-    fn catalog_starts_empty_before_chunk_generation() {
+    fn catalog_pre_seeded_with_well_known_materials() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_systems(PreStartup, load_material_catalog);
@@ -1024,11 +1034,16 @@ visibility = "Hidden"
             .world()
             .get_resource::<MaterialCatalog>()
             .expect("MaterialCatalog resource must exist after startup");
-        assert!(
-            catalog.is_empty(),
-            "catalog must be empty before any chunk generation; found {} entries",
-            catalog.len()
+        assert_eq!(
+            catalog.len(),
+            WELL_KNOWN_MATERIAL_SEEDS.len(),
+            "catalog must contain exactly the well-known starter materials",
         );
-        assert_eq!(catalog.len(), 0);
+        for &(_name, seed) in WELL_KNOWN_MATERIAL_SEEDS {
+            assert!(
+                catalog.get_by_seed(seed).is_some(),
+                "well-known seed {seed} must be present in the catalog after startup",
+            );
+        }
     }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -1016,6 +1016,24 @@ visibility = "Hidden"
         );
     }
 
+    /// Verifies that every well-known seed material derives a distinct name.
+    /// Duplicate names would confuse the player and break the journal/catalog UX.
+    #[test]
+    fn well_known_seeds_have_distinct_names() {
+        let mut seen: std::collections::HashMap<String, (&str, u64)> =
+            std::collections::HashMap::new();
+        for &(label, seed) in WELL_KNOWN_MATERIAL_SEEDS {
+            let mat = derive_material_from_seed(seed);
+            if let Some(&(prev_label, prev_seed)) = seen.get(&mat.name) {
+                panic!(
+                    "name collision: \"{}\") produced by both {} (seed {:#X}) and {} (seed {:#X})",
+                    mat.name, prev_label, prev_seed, label, seed,
+                );
+            }
+            seen.insert(mat.name.clone(), (label, seed));
+        }
+    }
+
     /// Verifies that `load_material_catalog` inserts an empty [`MaterialCatalog`]
     /// during startup, before any chunk-generation systems have a chance to run.
     /// This mirrors the real plugin's `PreStartup` registration and confirms the

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -35,9 +35,22 @@ pub const SUFFIXES: &[&str] = &[
 /// The mapping is intentionally simple and stable — changing it would rename
 /// every procedurally generated material across all saved worlds.
 pub fn procedural_name(seed: u64) -> String {
-    let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
-    let root_idx = ((seed >> 12) as usize) % ROOTS.len();
-    let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
+    // Hash the seed so that small sequential values (e.g. well-known seeds
+    // 1001..1010) spread across the full bit range.  Uses the same
+    // splitmix64 finaliser employed elsewhere in the codebase for
+    // deterministic mixing.
+    let h = {
+        let mut x = seed;
+        x ^= x >> 30;
+        x = x.wrapping_mul(0xbf58476d1ce4e5b9);
+        x ^= x >> 27;
+        x = x.wrapping_mul(0x94d049bb133111eb);
+        x ^= x >> 31;
+        x
+    };
+    let prefix_idx = ((h) as usize) % PREFIXES.len();
+    let root_idx = ((h >> 16) as usize) % ROOTS.len();
+    let suffix_idx = ((h >> 32) as usize) % SUFFIXES.len();
     format!(
         "{}{}{}",
         PREFIXES[prefix_idx], ROOTS[root_idx], SUFFIXES[suffix_idx]

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,0 +1,65 @@
+//! Procedural name generation for seed-derived materials.
+//!
+//! Both the fabricator (combining two materials into a new one) and the
+//! seed-based material derivation pipeline need to turn a `u64` seed into a
+//! human-readable mineral-ish name.  This module owns the shared vocabulary
+//! tables and the deterministic mapping so neither module depends on the other.
+
+/// Syllable prefixes — evocative, vaguely scientific.  16 entries so a 4-bit
+/// window selects one without bias.
+pub const PREFIXES: &[&str] = &[
+    "Neo", "Aur", "Vex", "Cor", "Nyx", "Zel", "Pyr", "Lux", "Thal", "Kyn", "Ven", "Dra", "Sol",
+    "Mor", "Cyn", "Vir",
+];
+
+/// Syllable suffixes — mineral / chemical flavour.  16 entries, same reasoning.
+pub const SUFFIXES: &[&str] = &[
+    "ite", "ium", "ite", "ane", "ene", "oid", "ate", "ide", "yne", "ase", "ose", "ine", "ile",
+    "ore", "ux", "al",
+];
+
+/// Deterministically produce a mineral-style name from a seed.
+///
+/// The name is built by selecting one prefix and one suffix from fixed
+/// vocabulary tables using different bit windows of the seed.  The mapping is
+/// intentionally simple and stable — changing it would rename every
+/// procedurally generated material across all saved worlds.
+pub fn procedural_name(seed: u64) -> String {
+    let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
+    let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
+    format!("{}{}", PREFIXES[prefix_idx], SUFFIXES[suffix_idx])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_same_seed_same_name() {
+        assert_eq!(procedural_name(42), procedural_name(42));
+    }
+
+    #[test]
+    fn varies_by_seed() {
+        assert_ne!(procedural_name(1000), procedural_name(999_999));
+    }
+
+    #[test]
+    fn prefix_index_stays_in_bounds() {
+        // Exercise edge-case seeds: 0, max, and a handful of arbitrary values.
+        for seed in [0u64, 1, u64::MAX, 0xDEAD_BEEF, 0xCAFE_BABE_1234_5678] {
+            let name = procedural_name(seed);
+            assert!(
+                !name.is_empty(),
+                "name must be non-empty for seed {seed:#X}"
+            );
+        }
+    }
+
+    #[test]
+    fn tables_have_power_of_two_length() {
+        // Not strictly required, but keeps the modulo unbiased for small bit windows.
+        assert!(PREFIXES.len().is_power_of_two());
+        assert!(SUFFIXES.len().is_power_of_two());
+    }
+}

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -12,6 +12,13 @@ pub const PREFIXES: &[&str] = &[
     "Mor", "Cyn", "Vir",
 ];
 
+/// Root syllables — connecting body of the name.  16 entries, selected via a
+/// separate 4-bit window so the same prefix/suffix pair can still produce
+/// distinct names.
+pub const ROOTS: &[&str] = &[
+    "an", "el", "or", "is", "um", "ax", "on", "ir", "et", "ul", "ar", "os", "en", "ix", "al", "ur",
+];
+
 /// Syllable suffixes — mineral / chemical flavour.  16 entries, same reasoning.
 pub const SUFFIXES: &[&str] = &[
     "ite", "ium", "ite", "ane", "ene", "oid", "ate", "ide", "yne", "ase", "ose", "ine", "ile",
@@ -20,14 +27,21 @@ pub const SUFFIXES: &[&str] = &[
 
 /// Deterministically produce a mineral-style name from a seed.
 ///
-/// The name is built by selecting one prefix and one suffix from fixed
-/// vocabulary tables using different bit windows of the seed.  The mapping is
-/// intentionally simple and stable — changing it would rename every
-/// procedurally generated material across all saved worlds.
+/// The name is built by selecting one prefix, one root, and one suffix from
+/// fixed vocabulary tables using different bit windows of the seed.  This
+/// 3-part scheme yields 16 × 16 × 16 = 4 096 unique names (vs 256 with the
+/// previous 2-part approach), substantially reducing collision probability.
+///
+/// The mapping is intentionally simple and stable — changing it would rename
+/// every procedurally generated material across all saved worlds.
 pub fn procedural_name(seed: u64) -> String {
     let prefix_idx = ((seed >> 8) as usize) % PREFIXES.len();
+    let root_idx = ((seed >> 12) as usize) % ROOTS.len();
     let suffix_idx = ((seed >> 16) as usize) % SUFFIXES.len();
-    format!("{}{}", PREFIXES[prefix_idx], SUFFIXES[suffix_idx])
+    format!(
+        "{}{}{}",
+        PREFIXES[prefix_idx], ROOTS[root_idx], SUFFIXES[suffix_idx]
+    )
 }
 
 #[cfg(test)]
@@ -60,6 +74,33 @@ mod tests {
     fn tables_have_power_of_two_length() {
         // Not strictly required, but keeps the modulo unbiased for small bit windows.
         assert!(PREFIXES.len().is_power_of_two());
+        assert!(ROOTS.len().is_power_of_two());
         assert!(SUFFIXES.len().is_power_of_two());
+    }
+
+    #[test]
+    fn name_contains_three_parts() {
+        // Verify the name is longer than any single prefix or suffix, confirming
+        // the root syllable is present.
+        let name = procedural_name(0xABCD_1234_5678_9ABC);
+        // Shortest possible: 2-char prefix + 2-char root + 2-char suffix = 6
+        assert!(
+            name.len() >= 6,
+            "3-part name should be at least 6 chars, got {name:?}"
+        );
+    }
+
+    #[test]
+    fn expanded_namespace_reduces_collisions() {
+        // With 4096 possible names, sampling 200 random-ish seeds should yield
+        // very few (ideally zero) collisions.
+        use std::collections::HashSet;
+        let names: HashSet<String> = (0u64..200).map(|i| procedural_name(i * 7919)).collect();
+        // Allow up to 5% collisions as a generous tolerance.
+        assert!(
+            names.len() > 190,
+            "expected >190 unique names from 200 seeds, got {}",
+            names.len()
+        );
     }
 }

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1442,6 +1442,45 @@ fn default_fallback_biome_key() -> String {
     "mineral_steppe".to_string()
 }
 
+/// Reasonable default material palette for the hardcoded neutral fallback biome.
+///
+/// This mirrors the `mineral_steppe` palette from `biomes.toml` — a balanced
+/// generalist selection so that even when the TOML is missing or misconfigured,
+/// the player still encounters materials during exploration. The seeds here are
+/// well-known values from the original 10-material catalog.
+fn default_fallback_material_palette() -> Vec<PaletteMaterial> {
+    vec![
+        PaletteMaterial {
+            material_seed: 1002,
+            selection_weight: 2.0,
+        }, // Calcium
+        PaletteMaterial {
+            material_seed: 1005,
+            selection_weight: 2.5,
+        }, // Verdant
+        PaletteMaterial {
+            material_seed: 1008,
+            selection_weight: 2.0,
+        }, // Cobaltine
+        PaletteMaterial {
+            material_seed: 1009,
+            selection_weight: 1.5,
+        }, // Silite
+        PaletteMaterial {
+            material_seed: 1001,
+            selection_weight: 1.0,
+        }, // Ferrite
+        PaletteMaterial {
+            material_seed: 1003,
+            selection_weight: 0.5,
+        }, // Sulfurite
+        PaletteMaterial {
+            material_seed: 1010,
+            selection_weight: 0.8,
+        }, // Phosphite
+    ]
+}
+
 impl Default for BiomeRegistry {
     fn default() -> Self {
         Self {
@@ -1548,7 +1587,32 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
                 ("silite".to_string(), 0.8),
                 ("prismate".to_string(), 0.2),
             ]),
-            material_palette: Vec::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 1001,
+                    selection_weight: 3.0,
+                }, // Ferrite
+                PaletteMaterial {
+                    material_seed: 1003,
+                    selection_weight: 2.5,
+                }, // Sulfurite
+                PaletteMaterial {
+                    material_seed: 1006,
+                    selection_weight: 2.0,
+                }, // Osmium
+                PaletteMaterial {
+                    material_seed: 1007,
+                    selection_weight: 1.5,
+                }, // Volatite
+                PaletteMaterial {
+                    material_seed: 1002,
+                    selection_weight: 0.5,
+                }, // Calcium
+                PaletteMaterial {
+                    material_seed: 1009,
+                    selection_weight: 0.3,
+                }, // Silite
+            ],
         },
         BiomeDefinition {
             key: "mineral_steppe".to_string(),
@@ -1559,7 +1623,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             ground_color: [0.26, 0.3, 0.22],
             density_modifier: 1.0,
             deposit_weight_modifiers: HashMap::new(),
-            material_palette: Vec::new(),
+            material_palette: default_fallback_material_palette(),
         },
         BiomeDefinition {
             key: "frost_shelf".to_string(),
@@ -1574,7 +1638,32 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
                 ("silite".to_string(), 1.0),
                 ("prismate".to_string(), 3.0),
             ]),
-            material_palette: Vec::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 1004,
+                    selection_weight: 3.0,
+                }, // Prismate
+                PaletteMaterial {
+                    material_seed: 1009,
+                    selection_weight: 2.0,
+                }, // Silite
+                PaletteMaterial {
+                    material_seed: 1010,
+                    selection_weight: 2.5,
+                }, // Phosphite
+                PaletteMaterial {
+                    material_seed: 1008,
+                    selection_weight: 1.0,
+                }, // Cobaltine
+                PaletteMaterial {
+                    material_seed: 1005,
+                    selection_weight: 0.3,
+                }, // Verdant
+                PaletteMaterial {
+                    material_seed: 1006,
+                    selection_weight: 0.5,
+                }, // Osmium
+            ],
         },
     ]
 }
@@ -1702,7 +1791,7 @@ pub fn derive_chunk_biome(
         ground_color: [0.26, 0.3, 0.22],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
-        material_palette: Vec::new(),
+        material_palette: default_fallback_material_palette(),
     }
 }
 
@@ -2827,9 +2916,10 @@ mod tests {
     }
 
     #[test]
-    fn chunk_biome_hardcoded_default_has_empty_palette() {
+    fn chunk_biome_hardcoded_default_has_reasonable_palette() {
         // When the fallback key itself is missing from the registry, the
-        // hardcoded neutral default must have an empty material palette.
+        // hardcoded neutral default must still provide a non-empty material
+        // palette so that deposits can be generated even without biomes.toml.
         let profile = WorldProfile::from_config(&sample_config());
         let registry = BiomeRegistry {
             fallback_biome_key: "does_not_exist".to_string(),
@@ -2841,9 +2931,18 @@ mod tests {
 
         let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(5, 5));
         assert!(
-            biome.material_palette.is_empty(),
-            "hardcoded neutral default must have an empty material palette"
+            !biome.material_palette.is_empty(),
+            "hardcoded neutral default must have a non-empty material palette"
         );
+        // All weights must be positive.
+        for entry in &biome.material_palette {
+            assert!(
+                entry.selection_weight > 0.0,
+                "palette entry seed {} has non-positive weight {}",
+                entry.material_seed,
+                entry.selection_weight
+            );
+        }
     }
 
     // ── PlanetSurface multi-octave noise tests ──────────────────────────

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1454,6 +1454,32 @@ impl Default for BiomeRegistry {
     }
 }
 
+/// A single entry in a biome's material palette.
+///
+/// Each biome defines a list of `PaletteMaterial` entries that control which
+/// materials can appear in that biome and how likely each one is relative to
+/// the others. The `material_seed` drives deterministic property generation
+/// via `derive_material_from_seed`, and `selection_weight` is used for
+/// weighted random selection when placing deposits.
+///
+/// A given seed may appear in multiple biomes with different weights, allowing
+/// materials to be common in one biome and rare in another.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[allow(dead_code)] // Used by Story 5a.4 phases 4+ (biome palette integration)
+pub struct PaletteMaterial {
+    /// Seed value that deterministically defines this material's properties.
+    ///
+    /// The same seed always produces the same `GameMaterial` (density, color,
+    /// name, etc.) regardless of which biome references it.
+    pub material_seed: u64,
+    /// Relative likelihood of this material being selected when placing a
+    /// deposit in the biome.
+    ///
+    /// Higher values make this material more common. The actual probability
+    /// is `selection_weight / sum(all weights in palette)`. Must be positive.
+    pub selection_weight: f32,
+}
+
 /// One biome definition describing a region of temperature × moisture space.
 ///
 /// Each biome occupies a rectangular region on the two climate axes. A chunk

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1686,10 +1686,8 @@ pub struct ChunkBiome {
     pub deposit_weight_modifiers: HashMap<String, f32>,
     /// Material palette copied from the matched biome definition. Chunk
     /// generation uses this to select which material seeds can appear in
-    /// deposits within this biome region.
-    ///
-    /// Not yet consumed by deposit generation — wired in Story 5a.5.
-    #[allow(dead_code)]
+    /// deposits within this biome region. Consumed by
+    /// `choose_material_seed_from_palette` during deposit site generation.
     pub material_palette: Vec<PaletteMaterial>,
 }
 

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1465,7 +1465,6 @@ impl Default for BiomeRegistry {
 /// A given seed may appear in multiple biomes with different weights, allowing
 /// materials to be common in one biome and rare in another.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[allow(dead_code)] // Used by Story 5a.4 phases 4+ (biome palette integration)
 pub struct PaletteMaterial {
     /// Seed value that deterministically defines this material's properties.
     ///
@@ -1516,6 +1515,13 @@ pub struct BiomeDefinition {
     /// which deposit type to place. Missing keys default to 1.0 (no change).
     #[serde(default)]
     pub deposit_weight_modifiers: HashMap<String, f32>,
+    /// Material palette for this biome: which material seeds can appear and at
+    /// what relative weight. During deposit generation, a seed is chosen from
+    /// this palette via weighted random selection. If a seed hasn't been
+    /// encountered before, it is derived and registered into `MaterialCatalog`
+    /// on first use.
+    #[serde(default)]
+    pub material_palette: Vec<PaletteMaterial>,
 }
 
 fn one_f32() -> f32 {
@@ -1542,6 +1548,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
                 ("silite".to_string(), 0.8),
                 ("prismate".to_string(), 0.2),
             ]),
+            material_palette: Vec::new(),
         },
         BiomeDefinition {
             key: "mineral_steppe".to_string(),
@@ -1552,6 +1559,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             ground_color: [0.26, 0.3, 0.22],
             density_modifier: 1.0,
             deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
         },
         BiomeDefinition {
             key: "frost_shelf".to_string(),
@@ -1566,6 +1574,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
                 ("silite".to_string(), 1.0),
                 ("prismate".to_string(), 3.0),
             ]),
+            material_palette: Vec::new(),
         },
     ]
 }
@@ -2343,6 +2352,7 @@ mod tests {
                     ground_color: [1.0, 0.0, 0.0],
                     density_modifier: 1.0,
                     deposit_weight_modifiers: HashMap::new(),
+                    material_palette: Vec::new(),
                 },
                 // Fallback biome.
                 BiomeDefinition {
@@ -2354,6 +2364,7 @@ mod tests {
                     ground_color: [0.5, 0.5, 0.5],
                     density_modifier: 0.5,
                     deposit_weight_modifiers: HashMap::new(),
+                    material_palette: Vec::new(),
                 },
             ],
         };
@@ -2493,6 +2504,7 @@ mod tests {
                 ground_color: [1.0, 0.0, 0.0],
                 density_modifier: 5.0,
                 deposit_weight_modifiers: HashMap::new(),
+                material_palette: Vec::new(),
             }],
             fallback_biome_key: "does_not_exist".to_string(),
             noise_scale_chunks: 10.0,

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1595,6 +1595,16 @@ pub struct ChunkBiome {
     pub density_modifier: f32,
     /// Per-deposit-key weight multipliers for material selection.
     pub deposit_weight_modifiers: HashMap<String, f32>,
+    /// Material palette copied from the matched biome definition. Chunk
+    /// generation uses this to select which material seeds can appear in
+    /// deposits within this biome region.
+    ///
+    /// Not yet consumed by deposit generation — wired in Story 5a.5.
+    #[expect(
+        dead_code,
+        reason = "populated now, consumed by deposit generation in Story 5a.5"
+    )]
+    pub material_palette: Vec<PaletteMaterial>,
 }
 
 /// Derive the biome for a chunk based on its canonical position on the planet.
@@ -1663,6 +1673,7 @@ pub fn derive_chunk_biome(
                 ground_color: biome_def.ground_color,
                 density_modifier: biome_def.density_modifier,
                 deposit_weight_modifiers: biome_def.deposit_weight_modifiers.clone(),
+                material_palette: biome_def.material_palette.clone(),
             };
         }
     }
@@ -1678,6 +1689,7 @@ pub fn derive_chunk_biome(
             ground_color: fallback.ground_color,
             density_modifier: fallback.density_modifier,
             deposit_weight_modifiers: fallback.deposit_weight_modifiers.clone(),
+            material_palette: fallback.material_palette.clone(),
         };
     }
 
@@ -1693,6 +1705,7 @@ pub fn derive_chunk_biome(
         ground_color: [0.26, 0.3, 0.22],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
+        material_palette: Vec::new(),
     }
 }
 

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -2442,6 +2442,161 @@ mod tests {
             assert_eq!(a.temperature_max, b.temperature_max);
             assert_eq!(a.density_modifier, b.density_modifier);
             assert_eq!(a.deposit_weight_modifiers, b.deposit_weight_modifiers);
+            assert_eq!(a.material_palette.len(), b.material_palette.len());
+            for (pa, pb) in a.material_palette.iter().zip(b.material_palette.iter()) {
+                assert_eq!(pa.material_seed, pb.material_seed);
+                assert_eq!(pa.selection_weight, pb.selection_weight);
+            }
+        }
+    }
+
+    #[test]
+    fn biome_registry_toml_round_trip_with_palette_entries() {
+        // Verify that material palette entries survive a TOML serialize→deserialize cycle,
+        // including hex seed values and fractional weights.
+        let mut registry = BiomeRegistry::default();
+
+        // Inject palette entries into the first biome (or add a biome if none exist).
+        if registry.biomes.is_empty() {
+            registry.biomes.push(BiomeDefinition {
+                key: "test_biome".to_string(),
+                temperature_min: 0.0,
+                temperature_max: 1.0,
+                moisture_min: 0.0,
+                moisture_max: 1.0,
+                ground_color: [0.5, 0.5, 0.5],
+                density_modifier: 1.0,
+                deposit_weight_modifiers: HashMap::new(),
+                material_palette: Vec::new(),
+            });
+        }
+        let palette = &mut registry.biomes[0].material_palette;
+        palette.clear();
+        palette.push(PaletteMaterial {
+            material_seed: 0xFE00_0000_0000_0001,
+            selection_weight: 3.0,
+        });
+        palette.push(PaletteMaterial {
+            material_seed: 0xFE00_0000_0000_0002,
+            selection_weight: 0.5,
+        });
+        palette.push(PaletteMaterial {
+            material_seed: 42,
+            selection_weight: 1.0,
+        });
+
+        let toml_str =
+            toml::to_string(&registry).expect("BiomeRegistry with palettes should serialize");
+        let parsed: BiomeRegistry =
+            toml::from_str(&toml_str).expect("BiomeRegistry with palettes should parse back");
+
+        let original_palette = &registry.biomes[0].material_palette;
+        let parsed_palette = &parsed.biomes[0].material_palette;
+        assert_eq!(
+            original_palette.len(),
+            parsed_palette.len(),
+            "palette length must survive round-trip"
+        );
+        for (orig, rt) in original_palette.iter().zip(parsed_palette.iter()) {
+            assert_eq!(
+                orig.material_seed, rt.material_seed,
+                "material_seed must survive round-trip"
+            );
+            assert_eq!(
+                orig.selection_weight, rt.selection_weight,
+                "selection_weight must survive round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn biome_toml_round_trip_empty_palette() {
+        // A biome with an empty material_palette must round-trip cleanly.
+        let mut registry = BiomeRegistry::default();
+        for biome in &mut registry.biomes {
+            biome.material_palette.clear();
+        }
+        let toml_str = toml::to_string(&registry).expect("serialize with empty palettes");
+        let parsed: BiomeRegistry = toml::from_str(&toml_str).expect("parse with empty palettes");
+        for (a, b) in registry.biomes.iter().zip(parsed.biomes.iter()) {
+            assert!(
+                b.material_palette.is_empty(),
+                "biome '{}' palette should be empty after round-trip",
+                a.key,
+            );
+        }
+    }
+
+    #[test]
+    fn biome_toml_round_trip_shared_seed_across_biomes() {
+        // The same material seed can appear in multiple biomes with different weights.
+        let shared_seed: u64 = 0xABCD_0000_0000_0099;
+        let mut registry = BiomeRegistry::default();
+
+        // Ensure at least two biomes exist.
+        while registry.biomes.len() < 2 {
+            registry.biomes.push(BiomeDefinition {
+                key: format!("synth_biome_{}", registry.biomes.len()),
+                temperature_min: 0.0,
+                temperature_max: 1.0,
+                moisture_min: 0.0,
+                moisture_max: 1.0,
+                ground_color: [0.3, 0.3, 0.3],
+                density_modifier: 1.0,
+                deposit_weight_modifiers: HashMap::new(),
+                material_palette: Vec::new(),
+            });
+        }
+
+        // Place the same seed in the first two biomes with different weights.
+        registry.biomes[0].material_palette = vec![PaletteMaterial {
+            material_seed: shared_seed,
+            selection_weight: 5.0,
+        }];
+        registry.biomes[1].material_palette = vec![PaletteMaterial {
+            material_seed: shared_seed,
+            selection_weight: 0.1,
+        }];
+
+        let toml_str = toml::to_string(&registry).expect("serialize shared-seed registry");
+        let parsed: BiomeRegistry = toml::from_str(&toml_str).expect("parse shared-seed registry");
+
+        assert_eq!(
+            parsed.biomes[0].material_palette[0].material_seed,
+            shared_seed
+        );
+        assert_eq!(parsed.biomes[0].material_palette[0].selection_weight, 5.0);
+        assert_eq!(
+            parsed.biomes[1].material_palette[0].material_seed,
+            shared_seed
+        );
+        assert_eq!(parsed.biomes[1].material_palette[0].selection_weight, 0.1);
+    }
+
+    #[test]
+    fn biome_toml_parses_shipped_asset_file() {
+        // Verify the actual shipped biomes.toml parses correctly, including any
+        // material palette entries defined there.
+        let toml_content =
+            std::fs::read_to_string(BIOME_CONFIG_PATH).expect("shipped biomes.toml must exist");
+        let registry: BiomeRegistry =
+            toml::from_str(&toml_content).expect("shipped biomes.toml must parse");
+
+        assert!(
+            !registry.biomes.is_empty(),
+            "shipped biomes.toml must define at least one biome"
+        );
+
+        // Every palette entry must have a positive weight and non-zero seed.
+        for biome in &registry.biomes {
+            for entry in &biome.material_palette {
+                assert!(
+                    entry.selection_weight > 0.0,
+                    "biome '{}' has palette entry with non-positive weight {}",
+                    biome.key,
+                    entry.selection_weight,
+                );
+            }
         }
     }
 

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1600,10 +1600,7 @@ pub struct ChunkBiome {
     /// deposits within this biome region.
     ///
     /// Not yet consumed by deposit generation — wired in Story 5a.5.
-    #[expect(
-        dead_code,
-        reason = "populated now, consumed by deposit generation in Story 5a.5"
-    )]
+    #[allow(dead_code)]
     pub material_palette: Vec<PaletteMaterial>,
 }
 
@@ -2686,6 +2683,167 @@ mod tests {
         assert_eq!(result.biome_key, "does_not_exist");
         assert_eq!(result.ground_color, [0.26, 0.3, 0.22]);
         assert_eq!(result.density_modifier, 1.0);
+    }
+
+    // ── Story 5a.4: ChunkBiome includes correct palette per biome ──────
+
+    #[test]
+    fn chunk_biome_includes_correct_palette_for_each_biome_type() {
+        // Derive chunks across a large coordinate range, collecting the
+        // material palette returned for each biome key. Verify that every
+        // biome's palette matches the palette defined in its BiomeDefinition.
+        let profile = WorldProfile::from_config(&sample_config());
+        let registry = BiomeRegistry::default();
+
+        // Build expected palettes from the registry, keyed by biome key.
+        let expected: HashMap<String, Vec<(u64, f32)>> = registry
+            .biomes
+            .iter()
+            .map(|b| {
+                let palette = b
+                    .material_palette
+                    .iter()
+                    .map(|p| (p.material_seed, p.selection_weight))
+                    .collect::<Vec<_>>();
+                (b.key.clone(), palette)
+            })
+            .collect();
+
+        // Track which biomes we have verified so we can assert full coverage.
+        let mut verified: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for x in -50..50 {
+            for z in -50..50 {
+                let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, z));
+
+                let Some(expected_palette) = expected.get(&biome.biome_key) else {
+                    panic!(
+                        "derive_chunk_biome returned unknown biome key '{}'",
+                        biome.biome_key
+                    );
+                };
+
+                let actual: Vec<(u64, f32)> = biome
+                    .material_palette
+                    .iter()
+                    .map(|p| (p.material_seed, p.selection_weight))
+                    .collect();
+
+                assert_eq!(
+                    &actual, expected_palette,
+                    "palette mismatch for biome '{}' at chunk ({}, {})",
+                    biome.biome_key, x, z
+                );
+
+                verified.insert(biome.biome_key);
+                if verified.len() == expected.len() {
+                    break;
+                }
+            }
+            if verified.len() == expected.len() {
+                break;
+            }
+        }
+
+        // Ensure we actually hit all three biomes, not just a subset.
+        for key in expected.keys() {
+            assert!(
+                verified.contains(key),
+                "biome '{key}' was never reached in 100×100 scan — cannot verify its palette"
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_biome_fallback_carries_fallback_palette() {
+        // When no biome range matches, the fallback biome's palette must be
+        // propagated into the ChunkBiome, not an empty vec.
+        let profile = WorldProfile::from_config(&sample_config());
+        let fallback_palette = vec![
+            PaletteMaterial {
+                material_seed: 0xAAAA,
+                selection_weight: 1.0,
+            },
+            PaletteMaterial {
+                material_seed: 0xBBBB,
+                selection_weight: 2.0,
+            },
+        ];
+        let registry = BiomeRegistry {
+            noise_scale_chunks: 12.0,
+            temperature_noise_channel: 0xB10E_0001_0000_0001,
+            moisture_noise_channel: 0xB10E_0001_0000_0002,
+            fallback_biome_key: "fb".to_string(),
+            biomes: vec![
+                // Impossibly narrow range — almost nothing will match.
+                BiomeDefinition {
+                    key: "narrow".to_string(),
+                    temperature_min: 0.999,
+                    temperature_max: 1.0,
+                    moisture_min: 0.999,
+                    moisture_max: 1.0,
+                    ground_color: [1.0, 0.0, 0.0],
+                    density_modifier: 1.0,
+                    deposit_weight_modifiers: HashMap::new(),
+                    material_palette: Vec::new(),
+                },
+                BiomeDefinition {
+                    key: "fb".to_string(),
+                    temperature_min: 0.0,
+                    temperature_max: 0.0,
+                    moisture_min: 0.0,
+                    moisture_max: 0.0,
+                    ground_color: [0.5, 0.5, 0.5],
+                    density_modifier: 1.0,
+                    deposit_weight_modifiers: HashMap::new(),
+                    material_palette: fallback_palette.clone(),
+                },
+            ],
+        };
+
+        // Most coords will miss the narrow biome and hit the fallback.
+        let mut found = false;
+        for x in 0..20 {
+            let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, 0));
+            if biome.biome_key == "fb" {
+                assert_eq!(
+                    biome.material_palette.len(),
+                    fallback_palette.len(),
+                    "fallback biome palette length mismatch"
+                );
+                for (actual, expected) in biome.material_palette.iter().zip(fallback_palette.iter())
+                {
+                    assert_eq!(actual.material_seed, expected.material_seed);
+                    assert_eq!(actual.selection_weight, expected.selection_weight);
+                }
+                found = true;
+                break;
+            }
+        }
+        assert!(
+            found,
+            "expected at least one coord to trigger fallback biome"
+        );
+    }
+
+    #[test]
+    fn chunk_biome_hardcoded_default_has_empty_palette() {
+        // When the fallback key itself is missing from the registry, the
+        // hardcoded neutral default must have an empty material palette.
+        let profile = WorldProfile::from_config(&sample_config());
+        let registry = BiomeRegistry {
+            fallback_biome_key: "does_not_exist".to_string(),
+            biomes: Vec::new(),
+            noise_scale_chunks: 12.0,
+            temperature_noise_channel: 0xB10E_0001_0000_0001,
+            moisture_noise_channel: 0xB10E_0001_0000_0002,
+        };
+
+        let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(5, 5));
+        assert!(
+            biome.material_palette.is_empty(),
+            "hardcoded neutral default must have an empty material palette"
+        );
     }
 
     // ── PlanetSurface multi-octave noise tests ──────────────────────────

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4233,4 +4233,128 @@ cluster_compactness = 0.75
             mat_catalog.len()
         );
     }
+
+    #[test]
+    fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
+        use crate::materials::MaterialCatalog;
+
+        let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
+        let biome = ChunkBiome {
+            biome_key: "test_biome".to_string(),
+            ground_color: [0.5, 0.5, 0.5],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: palette_seeds
+                .iter()
+                .map(|&seed| PaletteMaterial {
+                    material_seed: seed,
+                    selection_weight: 1.0,
+                })
+                .collect(),
+        };
+
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = PlanetSurface::new_from_profile(
+            &profile,
+            &WorldGenerationConfig {
+                planet_seed: 2026,
+                chunk_size_world_units: 45.0,
+                active_chunk_radius: 1,
+                building_cell_size: 1.0,
+                planet_surface_min_radius: 500,
+                planet_surface_max_radius: 5000,
+                ..Default::default()
+            },
+        );
+
+        // Generate placements from a first batch of chunks.
+        let mut first_batch_placements = Vec::new();
+        for cx in -2..=2 {
+            for cz in -2..=2 {
+                let chunk = ChunkCoord::new(cx, cz);
+                let placements = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, chunk, &biome,
+                );
+                first_batch_placements.extend(placements);
+            }
+        }
+
+        let valid_first: Vec<_> = first_batch_placements
+            .iter()
+            .filter(|p| p.material_seed != 0)
+            .collect();
+        assert!(
+            !valid_first.is_empty(),
+            "expected deposits from first batch of chunks"
+        );
+
+        // Register all materials from the first batch.
+        let mut mat_catalog = MaterialCatalog::default();
+        for placement in &valid_first {
+            mat_catalog.derive_and_register(placement.material_seed);
+        }
+
+        let catalog_size_after_first_batch = mat_catalog.len();
+        assert!(
+            catalog_size_after_first_batch > 0,
+            "catalog must be non-empty after first batch"
+        );
+
+        // Generate placements from a second batch of chunks (different coords,
+        // same biome). These chunks should only produce seeds already in the
+        // palette, so the catalog must not grow beyond the palette size.
+        let mut second_batch_placements = Vec::new();
+        for cx in 3..=7 {
+            for cz in 3..=7 {
+                let chunk = ChunkCoord::new(cx, cz);
+                let placements = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, chunk, &biome,
+                );
+                second_batch_placements.extend(placements);
+            }
+        }
+
+        let valid_second: Vec<_> = second_batch_placements
+            .iter()
+            .filter(|p| p.material_seed != 0)
+            .collect();
+        assert!(
+            !valid_second.is_empty(),
+            "expected deposits from second batch of chunks"
+        );
+
+        // Register all materials from the second batch.
+        for placement in &valid_second {
+            mat_catalog.derive_and_register(placement.material_seed);
+        }
+
+        // The catalog size must not have grown: all seeds from the second batch
+        // were already registered from the first batch (both batches use the
+        // same biome palette with only 3 seeds).
+        assert_eq!(
+            mat_catalog.len(),
+            catalog_size_after_first_batch,
+            "catalog grew from {} to {} after second batch — duplicate registration occurred",
+            catalog_size_after_first_batch,
+            mat_catalog.len()
+        );
+
+        // Every seed in the catalog belongs to the palette.
+        let palette_seed_set: HashSet<u64> = palette_seeds.iter().copied().collect();
+        for seed in mat_catalog.seeds() {
+            assert!(
+                palette_seed_set.contains(seed),
+                "catalog contains seed {seed} not in biome palette"
+            );
+        }
+
+        // Catalog should contain at most as many entries as the palette.
+        assert!(
+            mat_catalog.len() <= palette_seeds.len(),
+            "catalog has {} entries but palette only has {} seeds",
+            mat_catalog.len(),
+            palette_seeds.len()
+        );
+    }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4917,6 +4917,108 @@ cluster_compactness = 0.75
         );
     }
 
+    // ── Story 5a.4 Phase 9: Deposit pickup yields valid material ───────
+
+    /// Verify that every deposit generated from biome palettes produces a
+    /// `GameMaterial` with a non-empty name, finite color channels, and
+    /// at least one non-zero property. This is the contract the pickup
+    /// system relies on: when a player picks up a deposit it must yield a
+    /// material with meaningful, displayable data — not a default stub.
+    #[test]
+    fn every_deposit_material_is_pickup_ready() {
+        use crate::materials::MaterialCatalog;
+
+        let config = WorldGenerationConfig {
+            planet_seed: 99_887_766,
+            chunk_size_world_units: 45.0,
+            active_chunk_radius: 2,
+            building_cell_size: 1.0,
+            planet_surface_min_radius: 500,
+            planet_surface_max_radius: 5000,
+            ..Default::default()
+        };
+        let profile = WorldProfile::from_config(&config);
+        let catalog = sample_catalog();
+        let surface = PlanetSurface::new_from_profile(&profile, &config);
+
+        let biome = ChunkBiome {
+            biome_key: "scorched_flats".to_string(),
+            ground_color: [0.55, 0.38, 0.22],
+            density_modifier: 1.15,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 1001,
+                    selection_weight: 3.0,
+                },
+                PaletteMaterial {
+                    material_seed: 1003,
+                    selection_weight: 2.0,
+                },
+                PaletteMaterial {
+                    material_seed: 1007,
+                    selection_weight: 1.5,
+                },
+            ],
+        };
+
+        let mut mat_catalog = MaterialCatalog::default();
+        let mut checked = 0_usize;
+
+        for cx in -3..=3 {
+            for cz in -3..=3 {
+                let chunk = ChunkCoord::new(cx, cz);
+                let placements = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, chunk, &biome,
+                );
+
+                for placement in &placements {
+                    if placement.material_seed == 0 {
+                        continue;
+                    }
+
+                    let mat = mat_catalog.derive_and_register(placement.material_seed);
+
+                    // Name must be non-empty (the pickup HUD displays it).
+                    assert!(
+                        !mat.name.is_empty(),
+                        "deposit seed {} produced an empty name",
+                        placement.material_seed,
+                    );
+
+                    // Color channels must be finite and in [0, 1].
+                    for (i, &c) in mat.color.iter().enumerate() {
+                        assert!(
+                            c.is_finite() && (0.0..=1.0).contains(&c),
+                            "deposit seed {} color[{i}] = {c} out of range",
+                            placement.material_seed,
+                        );
+                    }
+
+                    // At least one property must be non-zero so the material
+                    // is distinguishable from a default stub.
+                    let any_nonzero = mat.density.value != 0.0
+                        || mat.thermal_resistance.value != 0.0
+                        || mat.reactivity.value != 0.0
+                        || mat.conductivity.value != 0.0
+                        || mat.toxicity.value != 0.0;
+                    assert!(
+                        any_nonzero,
+                        "deposit seed {} has all-zero properties",
+                        placement.material_seed,
+                    );
+
+                    checked += 1;
+                }
+            }
+        }
+
+        assert!(
+            checked > 0,
+            "expected at least one deposit to verify but found none"
+        );
+    }
+
     // ── Story 5a.4 Phase 9: Restart determinism ──────────────────────────
 
     /// Simulate two independent "restarts" with the same world seed: build

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -167,7 +167,7 @@ fn default_site_min_gap_world_units() -> f32 {
 fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
     vec![
         SurfaceMineralDepositDefinition {
-            key: "ferrite_surface_deposit".into(),
+            key: "dense_cluster_deposit".into(),
             selection_weight: 1.0,
             scale_min: 0.9,
             scale_max: 1.2,
@@ -178,7 +178,7 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
             cluster_compactness: 0.75,
         },
         SurfaceMineralDepositDefinition {
-            key: "silite_surface_deposit".into(),
+            key: "scattered_cluster_deposit".into(),
             selection_weight: 0.8,
             scale_min: 0.85,
             scale_max: 1.15,
@@ -189,7 +189,7 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
             cluster_compactness: 0.68,
         },
         SurfaceMineralDepositDefinition {
-            key: "prismate_surface_deposit".into(),
+            key: "compact_cluster_deposit".into(),
             selection_weight: 0.45,
             scale_min: 0.8,
             scale_max: 1.05,
@@ -2255,7 +2255,7 @@ site_jitter_fraction = 0.28
 site_min_gap_world_units = 2.5
 
 [[deposits]]
-key = "ferrite_surface_deposit"
+key = "dense_cluster_deposit"
 selection_weight = 1.0
 scale_min = 0.9
 scale_max = 1.2
@@ -2270,7 +2270,7 @@ cluster_compactness = 0.75
             toml::from_str(toml_str).expect("surface deposit catalog should parse");
 
         assert_eq!(catalog.deposits.len(), 1);
-        assert_eq!(catalog.deposits[0].key, "ferrite_surface_deposit");
+        assert_eq!(catalog.deposits[0].key, "dense_cluster_deposit");
     }
 
     // ── Story 5.4: Removal delta tests ───────────────────────────────────

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -1623,6 +1623,7 @@ mod tests {
             ground_color: [0.42, 0.45, 0.30],
             density_modifier: 1.0,
             deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
         }
     }
 
@@ -3427,12 +3428,14 @@ cluster_compactness = 0.75
             ground_color: [0.5, 0.5, 0.5],
             density_modifier: 1.0,
             deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
         };
         let dense_biome = ChunkBiome {
             biome_key: "dense".to_string(),
             ground_color: [0.5, 0.5, 0.5],
             density_modifier: 3.0,
             deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
         };
 
         // Sum placements across many chunks to smooth out noise variance.
@@ -3504,6 +3507,7 @@ cluster_compactness = 0.75
             ground_color: [0.5, 0.5, 0.5],
             density_modifier: 0.0,
             deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
         };
 
         // Must not panic. With effective_threshold = threshold / EPSILON ≈ huge,
@@ -3655,6 +3659,7 @@ cluster_compactness = 0.75
             ground_color: [0.1, 0.1, 0.1],
             density_modifier: 1.0,
             deposit_weight_modifiers: modifiers,
+            material_palette: Vec::new(),
         };
 
         let chunk = ChunkCoord::new(0, 0);

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4916,4 +4916,232 @@ cluster_compactness = 0.75
              but only {differing_properties} differed"
         );
     }
+
+    // ── Story 5a.4 Phase 9: Restart determinism ──────────────────────────
+
+    /// Simulate two independent "restarts" with the same world seed: build
+    /// the full pipeline from scratch each time, generate deposits across
+    /// multiple chunks in multiple biomes, derive materials from every
+    /// deposit seed, and verify that both runs produce identical materials
+    /// (same names, same properties, same colors) for every seed encountered.
+    ///
+    /// This is the capstone determinism guarantee: same seed + same biome →
+    /// same deposits → same materials with same names and properties.
+    #[test]
+    fn restart_same_seed_same_biome_yields_identical_materials() {
+        use crate::materials::{MaterialCatalog, derive_material_from_seed};
+
+        let config = WorldGenerationConfig {
+            planet_seed: 54_321_678,
+            chunk_size_world_units: 45.0,
+            active_chunk_radius: 2,
+            building_cell_size: 1.0,
+            planet_surface_min_radius: 500,
+            planet_surface_max_radius: 5000,
+            ..Default::default()
+        };
+
+        // Three distinct biomes with overlapping and unique palette entries.
+        let biomes = [
+            ChunkBiome {
+                biome_key: "scorched_flats".to_string(),
+                ground_color: [0.6, 0.3, 0.1],
+                density_modifier: 0.8,
+                deposit_weight_modifiers: HashMap::new(),
+                material_palette: vec![
+                    PaletteMaterial {
+                        material_seed: 1001,
+                        selection_weight: 3.0,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1003,
+                        selection_weight: 2.5,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1006,
+                        selection_weight: 2.0,
+                    },
+                ],
+            },
+            ChunkBiome {
+                biome_key: "mineral_steppe".to_string(),
+                ground_color: [0.42, 0.45, 0.30],
+                density_modifier: 1.0,
+                deposit_weight_modifiers: HashMap::new(),
+                material_palette: vec![
+                    PaletteMaterial {
+                        material_seed: 1002,
+                        selection_weight: 2.0,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1005,
+                        selection_weight: 2.5,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1008,
+                        selection_weight: 2.0,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1001,
+                        selection_weight: 1.0,
+                    },
+                ],
+            },
+            ChunkBiome {
+                biome_key: "frost_shelf".to_string(),
+                ground_color: [0.7, 0.75, 0.85],
+                density_modifier: 1.2,
+                deposit_weight_modifiers: HashMap::new(),
+                material_palette: vec![
+                    PaletteMaterial {
+                        material_seed: 1004,
+                        selection_weight: 3.0,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1009,
+                        selection_weight: 2.0,
+                    },
+                    PaletteMaterial {
+                        material_seed: 1010,
+                        selection_weight: 2.5,
+                    },
+                ],
+            },
+        ];
+
+        let chunks: Vec<ChunkCoord> = vec![
+            ChunkCoord::new(0, 0),
+            ChunkCoord::new(1, -1),
+            ChunkCoord::new(-3, 7),
+            ChunkCoord::new(5, 5),
+            ChunkCoord::new(-2, -4),
+        ];
+
+        /// Represents a single "session": run the pipeline from scratch and
+        /// collect every (material_seed, GameMaterial) pair encountered.
+        fn run_session(
+            config: &WorldGenerationConfig,
+            biomes: &[ChunkBiome],
+            chunks: &[ChunkCoord],
+        ) -> MaterialCatalog {
+            let profile = WorldProfile::from_config(config);
+            let surface = PlanetSurface::new_from_profile(&profile, config);
+            let deposit_catalog = SurfaceMineralDepositCatalog {
+                site_spawn_threshold: 0.0,
+                ..SurfaceMineralDepositCatalog::default()
+            };
+
+            let mut mat_catalog = MaterialCatalog::default();
+
+            for biome in biomes {
+                for &chunk in chunks {
+                    let placements = generate_surface_mineral_chunk_baseline(
+                        &profile,
+                        &deposit_catalog,
+                        &surface,
+                        chunk,
+                        biome,
+                    );
+                    for placement in &placements {
+                        if placement.material_seed != 0 {
+                            mat_catalog.derive_and_register(placement.material_seed);
+                        }
+                    }
+                }
+            }
+
+            mat_catalog
+        }
+
+        // ── Run 1 ────────────────────────────────────────────────────────
+        let catalog_a = run_session(&config, &biomes, &chunks);
+
+        // ── Run 2 (fresh from scratch) ───────────────────────────────────
+        let catalog_b = run_session(&config, &biomes, &chunks);
+
+        // Both catalogs must contain the same number of materials.
+        assert_eq!(
+            catalog_a.len(),
+            catalog_b.len(),
+            "catalog sizes differ between restarts: {} vs {}",
+            catalog_a.len(),
+            catalog_b.len()
+        );
+
+        // Must have generated at least some materials.
+        assert!(
+            catalog_a.len() > 0,
+            "expected at least one material in catalog after generation"
+        );
+
+        // Every material in catalog A must exist in catalog B with identical
+        // name, color, and all scalar properties.
+        for mat_a in catalog_a.values() {
+            let mat_b = catalog_b.get_by_seed(mat_a.seed).unwrap_or_else(|| {
+                panic!(
+                    "seed {} ({}) present in run 1 but missing in run 2",
+                    mat_a.seed, mat_a.name
+                )
+            });
+
+            assert_eq!(
+                mat_a.name, mat_b.name,
+                "name mismatch for seed {}: {:?} vs {:?}",
+                mat_a.seed, mat_a.name, mat_b.name
+            );
+            assert_eq!(
+                mat_a.color, mat_b.color,
+                "color mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+            assert_eq!(
+                mat_a.density.value, mat_b.density.value,
+                "density mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+            assert_eq!(
+                mat_a.thermal_resistance.value, mat_b.thermal_resistance.value,
+                "thermal_resistance mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+            assert_eq!(
+                mat_a.reactivity.value, mat_b.reactivity.value,
+                "reactivity mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+            assert_eq!(
+                mat_a.conductivity.value, mat_b.conductivity.value,
+                "conductivity mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+            assert_eq!(
+                mat_a.toxicity.value, mat_b.toxicity.value,
+                "toxicity mismatch for seed {} ({})",
+                mat_a.seed, mat_a.name
+            );
+        }
+
+        // Additionally verify that derive_material_from_seed itself is
+        // deterministic for every seed we encountered (belt-and-suspenders
+        // check independent of catalog registration order).
+        for mat_a in catalog_a.values() {
+            let raw_1 = derive_material_from_seed(mat_a.seed);
+            let raw_2 = derive_material_from_seed(mat_a.seed);
+            assert_eq!(
+                raw_1.name, raw_2.name,
+                "raw derivation name mismatch for seed {}",
+                mat_a.seed
+            );
+            assert_eq!(
+                raw_1.color, raw_2.color,
+                "raw derivation color mismatch for seed {}",
+                mat_a.seed
+            );
+            assert_eq!(
+                raw_1.density.value, raw_2.density.value,
+                "raw derivation density mismatch for seed {}",
+                mat_a.seed
+            );
+        }
+    }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4127,4 +4127,110 @@ cluster_compactness = 0.75
         };
         assert_eq!(placement.material_seed, 0xCAFE_BABE);
     }
+
+    /// Story 5a.4 – Phase 5: first chunk generation populates the material
+    /// catalog with materials drawn from the biome palette.
+    ///
+    /// We generate deposit placements for a single chunk whose biome defines a
+    /// multi-material palette, then feed each placement's `material_seed` into
+    /// `MaterialCatalog::derive_and_register` (mirroring the runtime path in
+    /// `sync_active_exterior_chunks`). Afterward we verify:
+    ///
+    /// 1. The catalog is no longer empty.
+    /// 2. Every registered seed belongs to the biome palette.
+    /// 3. Over enough deposit sites, more than one palette material appears
+    ///    (both seeds have non-trivial weight, so probabilistic certainty is
+    ///    high).
+    #[test]
+    fn first_chunk_generation_populates_catalog_from_biome_palette() {
+        use crate::materials::MaterialCatalog;
+
+        let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
+        let biome = ChunkBiome {
+            biome_key: "test_biome".to_string(),
+            ground_color: [0.5, 0.5, 0.5],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: palette_seeds
+                .iter()
+                .map(|&seed| PaletteMaterial {
+                    material_seed: seed,
+                    selection_weight: 1.0,
+                })
+                .collect(),
+        };
+
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = PlanetSurface::new_from_profile(
+            &profile,
+            &WorldGenerationConfig {
+                planet_seed: 2026,
+                chunk_size_world_units: 45.0,
+                active_chunk_radius: 1,
+                building_cell_size: 1.0,
+                planet_surface_min_radius: 500,
+                planet_surface_max_radius: 5000,
+                ..Default::default()
+            },
+        );
+
+        // Generate placements across several chunks to ensure we get deposits.
+        let mut all_placements = Vec::new();
+        for cx in -2..=2 {
+            for cz in -2..=2 {
+                let chunk = ChunkCoord::new(cx, cz);
+                let placements = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, chunk, &biome,
+                );
+                all_placements.extend(placements);
+            }
+        }
+
+        // Filter to placements with valid material seeds (non-zero).
+        let valid_placements: Vec<_> = all_placements
+            .iter()
+            .filter(|p| p.material_seed != 0)
+            .collect();
+
+        // We expect at least some deposits were generated.
+        assert!(
+            !valid_placements.is_empty(),
+            "expected at least one deposit placement across 25 chunks"
+        );
+
+        // Mirror the runtime registration path: derive_and_register each seed.
+        let mut mat_catalog = MaterialCatalog::default();
+        assert!(
+            mat_catalog.is_empty(),
+            "catalog must start empty (seed-on-demand model)"
+        );
+
+        for placement in &valid_placements {
+            mat_catalog.derive_and_register(placement.material_seed);
+        }
+
+        // 1. Catalog is no longer empty.
+        assert!(
+            !mat_catalog.is_empty(),
+            "catalog must contain materials after chunk generation"
+        );
+
+        // 2. Every registered seed belongs to the biome palette.
+        let palette_seed_set: HashSet<u64> = palette_seeds.iter().copied().collect();
+        for seed in mat_catalog.seeds() {
+            assert!(
+                palette_seed_set.contains(seed),
+                "catalog contains seed {seed} not in biome palette {palette_seed_set:?}"
+            );
+        }
+
+        // 3. Multiple palette materials appear (with equal weights across 25
+        //    chunks, a single-material outcome is astronomically unlikely).
+        assert!(
+            mat_catalog.len() > 1,
+            "expected multiple palette materials in catalog, got {}",
+            mat_catalog.len()
+        );
+    }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -1636,7 +1636,7 @@ fn merge_player_additions(
 mod tests {
     use super::*;
     use crate::world_generation::{
-        FlatSurface, SteppedSurface, TiltedSurface, WorldGenerationConfig,
+        FlatSurface, PlanetSeed, SteppedSurface, TiltedSurface, WorldGenerationConfig,
     };
 
     fn sample_profile() -> WorldProfile {
@@ -3953,5 +3953,178 @@ cluster_compactness = 0.75
                 "non-finite normal at ({x}, {z})"
             );
         }
+    }
+
+    // ── Story 5a.4: Deposit sites carry material_seed from biome palette ─
+
+    #[test]
+    fn deposit_sites_carry_material_seed_from_palette() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let seed_a: u64 = 0xFE00_0000_0000_0001;
+        let seed_b: u64 = 0xFE00_0000_0000_0002;
+        let biome = ChunkBiome {
+            biome_key: "test_biome".to_string(),
+            ground_color: [0.5, 0.5, 0.5],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: seed_a,
+                    selection_weight: 1.0,
+                },
+                PaletteMaterial {
+                    material_seed: seed_b,
+                    selection_weight: 1.0,
+                },
+            ],
+        };
+
+        let sites = generate_surface_mineral_deposit_sites(
+            &profile,
+            &catalog,
+            &surface,
+            ChunkCoord::new(0, -1),
+            &biome,
+        );
+
+        assert!(
+            !sites.is_empty(),
+            "biome with a material palette should produce deposit sites"
+        );
+
+        for site in &sites {
+            assert!(
+                site.material_seed == seed_a || site.material_seed == seed_b,
+                "deposit site material_seed ({:#018X}) must come from the biome palette, \
+                 expected one of {seed_a:#018X} or {seed_b:#018X}",
+                site.material_seed,
+            );
+        }
+    }
+
+    #[test]
+    fn deposit_placements_inherit_material_seed_from_site() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let seed: u64 = 0xAB00_0000_0000_0099;
+        let biome = ChunkBiome {
+            biome_key: "single_mat_biome".to_string(),
+            ground_color: [0.3, 0.3, 0.3],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![PaletteMaterial {
+                material_seed: seed,
+                selection_weight: 1.0,
+            }],
+        };
+
+        let sites = generate_surface_mineral_deposit_sites(
+            &profile,
+            &catalog,
+            &surface,
+            ChunkCoord::new(0, -1),
+            &biome,
+        );
+
+        assert!(!sites.is_empty(), "should produce at least one site");
+
+        for site in &sites {
+            assert_eq!(
+                site.material_seed, seed,
+                "single-material palette: every site must carry the sole seed"
+            );
+
+            let placements = expand_deposit_site_into_cluster(&profile, site, &surface);
+            for placement in &placements {
+                assert_eq!(
+                    placement.material_seed, site.material_seed,
+                    "child placement material_seed must match its parent site"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn empty_palette_produces_zero_material_seed() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        // Biome with no material palette entries.
+        let biome = ChunkBiome {
+            biome_key: "barren_biome".to_string(),
+            ground_color: [0.2, 0.2, 0.2],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
+        };
+
+        let sites = generate_surface_mineral_deposit_sites(
+            &profile,
+            &catalog,
+            &surface,
+            ChunkCoord::new(0, -1),
+            &biome,
+        );
+
+        for site in &sites {
+            assert_eq!(
+                site.material_seed, 0,
+                "empty palette must produce material_seed 0"
+            );
+        }
+    }
+
+    #[test]
+    fn deposit_site_has_no_material_key_field() {
+        // Structural assertion: GeneratedSurfaceMineralDepositSite carries
+        // `material_seed: u64` — not a string-based `material_key`. We verify
+        // this by constructing a site and reading its material_seed, which would
+        // fail to compile if the field were renamed or removed.
+        let site = GeneratedSurfaceMineralDepositSite {
+            site_id: GeneratedDepositSiteId {
+                planet_seed: 1,
+                chunk_coord: ChunkCoord::new(0, 0),
+                definition_key: "test".to_string(),
+                local_site_index: 0,
+                generator_version: 1,
+            },
+            definition_key: "test".to_string(),
+            material_seed: 0xDEAD_BEEF,
+            center_xz: PositionXZ::new(0.0, 0.0),
+            radius_world_units: 1.0,
+            child_count: 1,
+            surface_y: 0.0,
+            surface_normal: [0.0, 1.0, 0.0],
+            scale_min: 0.5,
+            scale_max: 1.0,
+            cluster_compactness: 0.5,
+        };
+        assert_eq!(site.material_seed, 0xDEAD_BEEF);
+
+        // Same for the placement struct.
+        let placement = GeneratedSurfaceMineralPlacement {
+            generated_id: GeneratedObjectId {
+                planet_seed: PlanetSeed(1),
+                chunk_coord: ChunkCoord::new(0, 0),
+                object_kind_key: "test".to_string(),
+                local_candidate_index: 0,
+                generator_version: 1,
+            },
+            deposit_site_id: site.site_id.clone(),
+            definition_key: "test".to_string(),
+            material_seed: 0xCAFE_BABE,
+            position_xz: PositionXZ::new(0.0, 0.0),
+            surface_y: 0.0,
+            surface_normal: [0.0, 1.0, 0.0],
+            visual_scale: 1.0,
+            local_child_index: 0,
+        };
+        assert_eq!(placement.material_seed, 0xCAFE_BABE);
     }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4132,6 +4132,55 @@ cluster_compactness = 0.75
         );
     }
 
+    /// Story 5a.4 – Phase 8: a biome palette containing exactly one entry must
+    /// always select that material seed, regardless of chunk coordinate or site
+    /// index. We sweep a wide grid of chunks and verify every generated deposit
+    /// site carries the sole palette seed.
+    #[test]
+    fn single_palette_entry_always_selected() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let sole_seed: u64 = 0xAA00_0000_0000_0042;
+        let biome = ChunkBiome {
+            biome_key: "mono_biome".to_string(),
+            ground_color: [0.4, 0.4, 0.4],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![PaletteMaterial {
+                material_seed: sole_seed,
+                selection_weight: 5.0,
+            }],
+        };
+
+        let mut total_sites = 0_usize;
+        for cx in -20..20 {
+            for cz in -20..20 {
+                let sites = generate_surface_mineral_deposit_sites(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    ChunkCoord::new(cx, cz),
+                    &biome,
+                );
+                for site in &sites {
+                    total_sites += 1;
+                    assert_eq!(
+                        site.material_seed, sole_seed,
+                        "single-entry palette must always select the sole seed; \
+                         got {:#018X} at chunk ({cx}, {cz})",
+                        site.material_seed,
+                    );
+                }
+            }
+        }
+        assert!(
+            total_sites > 0,
+            "at least some chunks should produce deposit sites with a non-empty palette"
+        );
+    }
+
     #[test]
     fn deposit_site_has_no_material_key_field() {
         // Structural assertion: GeneratedSurfaceMineralDepositSite carries

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4517,6 +4517,116 @@ cluster_compactness = 0.75
         );
     }
 
+    // ── Story 5a.4 Phase 9: Palette swap does not change deposit count ──
+
+    /// Changing a biome's material palette must not alter how many deposits
+    /// spawn — only *which* materials they carry. This test constructs two
+    /// biomes that are identical except for their `material_palette`, then
+    /// generates deposits across many chunks for each and asserts that the
+    /// total deposit count is the same. The material seeds produced must
+    /// differ (proving the palette swap took effect), but the spatial
+    /// distribution of deposit sites is palette-independent.
+    #[test]
+    fn palette_swap_does_not_change_deposit_count() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let palette_a = vec![
+            PaletteMaterial {
+                material_seed: 1001,
+                selection_weight: 3.0,
+            },
+            PaletteMaterial {
+                material_seed: 1003,
+                selection_weight: 2.0,
+            },
+        ];
+        let palette_b = vec![
+            PaletteMaterial {
+                material_seed: 1004,
+                selection_weight: 1.5,
+            },
+            PaletteMaterial {
+                material_seed: 1010,
+                selection_weight: 4.0,
+            },
+        ];
+
+        let biome_a = ChunkBiome {
+            biome_key: "test_a".to_string(),
+            ground_color: [0.5, 0.5, 0.5],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: palette_a,
+        };
+        let biome_b = ChunkBiome {
+            biome_key: "test_b".to_string(),
+            ground_color: [0.5, 0.5, 0.5],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: palette_b,
+        };
+
+        let mut count_a = 0_usize;
+        let mut count_b = 0_usize;
+        let mut seeds_a: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        let mut seeds_b: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        for cx in -10..10 {
+            for cz in -10..10 {
+                let coord = ChunkCoord::new(cx, cz);
+
+                let placements_a = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, coord, &biome_a,
+                );
+                let placements_b = generate_surface_mineral_chunk_baseline(
+                    &profile, &catalog, &surface, coord, &biome_b,
+                );
+
+                // Per-chunk counts must be identical because every generation
+                // decision except material selection is identical.
+                assert_eq!(
+                    placements_a.len(),
+                    placements_b.len(),
+                    "chunk ({cx}, {cz}): palette swap changed deposit count \
+                     ({} vs {})",
+                    placements_a.len(),
+                    placements_b.len()
+                );
+
+                count_a += placements_a.len();
+                count_b += placements_b.len();
+
+                for p in &placements_a {
+                    if p.material_seed != 0 {
+                        seeds_a.insert(p.material_seed);
+                    }
+                }
+                for p in &placements_b {
+                    if p.material_seed != 0 {
+                        seeds_b.insert(p.material_seed);
+                    }
+                }
+            }
+        }
+
+        // Total counts must match exactly.
+        assert_eq!(
+            count_a, count_b,
+            "total deposit count changed with palette swap: {count_a} vs {count_b}"
+        );
+
+        // Sanity: we actually generated some deposits.
+        assert!(count_a > 0, "expected at least some deposits");
+
+        // The material seeds should differ — proving the palette took effect.
+        assert_ne!(
+            seeds_a, seeds_b,
+            "both palettes produced identical material seeds — palette swap had no effect"
+        );
+    }
+
     // ── Story 5a.4 Phase 9: Cross-biome world generation smoke test ──────
 
     /// Smoke test: generate many chunks across diverse coordinates, derive

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -49,8 +49,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     ActiveChunkNeighborhood, BiomeRegistry, ChunkBiome, ChunkCoord,
-    DEFAULT_MAX_PLACEMENT_SLOPE_RADIANS, GeneratedObjectId, PlanetSurface, SurfaceProvider,
-    WorldGenerationConfig, WorldProfile, chunk_origin_xz, derive_chunk_biome,
+    DEFAULT_MAX_PLACEMENT_SLOPE_RADIANS, GeneratedObjectId, PaletteMaterial, PlanetSurface,
+    SurfaceProvider, WorldGenerationConfig, WorldProfile, chunk_origin_xz, derive_chunk_biome,
     derive_chunk_generation_key, derive_generated_object_id, generate_chunk_heightmap_mesh,
     is_placement_valid, surface_alignment_rotation, world_position_to_chunk_coord,
 };
@@ -90,13 +90,15 @@ impl Plugin for ExteriorGenerationPlugin {
 ///
 /// The object type is always "surface mineral deposit". The definition tells us
 /// *which* deposit flavor this is:
-/// - which existing material it should yield / be represented by
 /// - how likely it is relative to sibling deposit definitions
 /// - how large it can appear
+///
+/// Deposit definitions are material-agnostic: they define *how* a deposit
+/// looks (shape, clustering), not *what* material it contains. Material
+/// selection is driven by the biome's `material_palette`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct SurfaceMineralDepositDefinition {
     pub key: String,
-    pub material_key: String,
     pub selection_weight: f32,
     pub scale_min: f32,
     pub scale_max: f32,
@@ -166,7 +168,6 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
     vec![
         SurfaceMineralDepositDefinition {
             key: "ferrite_surface_deposit".into(),
-            material_key: "Ferrite".into(),
             selection_weight: 1.0,
             scale_min: 0.9,
             scale_max: 1.2,
@@ -178,7 +179,6 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
         },
         SurfaceMineralDepositDefinition {
             key: "silite_surface_deposit".into(),
-            material_key: "Silite".into(),
             selection_weight: 0.8,
             scale_min: 0.85,
             scale_max: 1.15,
@@ -190,7 +190,6 @@ fn default_surface_mineral_deposits() -> Vec<SurfaceMineralDepositDefinition> {
         },
         SurfaceMineralDepositDefinition {
             key: "prismate_surface_deposit".into(),
-            material_key: "Prismate".into(),
             selection_weight: 0.45,
             scale_min: 0.8,
             scale_max: 1.05,
@@ -261,7 +260,7 @@ struct GeneratedSurfaceMineralPlacement {
     generated_id: GeneratedObjectId,
     deposit_site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_key: String,
+    material_seed: u64,
     position_xz: PositionXZ,
     surface_y: f32,
     /// Surface normal at the placement point, used for object alignment.
@@ -279,7 +278,7 @@ struct GeneratedSurfaceMineralPlacement {
 struct GeneratedSurfaceMineralDepositSite {
     site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_key: String,
+    material_seed: u64,
     center_xz: PositionXZ,
     radius_world_units: f32,
     child_count: u32,
@@ -497,7 +496,7 @@ fn sync_active_exterior_chunks(
     world_profile: Res<WorldProfile>,
     world_gen_config: Res<WorldGenerationConfig>,
     deposit_catalog: Res<SurfaceMineralDepositCatalog>,
-    material_catalog: Res<MaterialCatalog>,
+    mut material_catalog: ResMut<MaterialCatalog>,
     _exterior_patch: Res<ExteriorGroundPatch>,
     biome_registry: Res<BiomeRegistry>,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -615,16 +614,14 @@ fn sync_active_exterior_chunks(
         }
 
         for placement in placements {
-            let Some(base_material) = material_catalog.materials.get(&placement.material_key)
-            else {
-                warn!(
-                    "Surface mineral deposit '{}' references unknown material '{}'; skipping placement",
-                    placement.definition_key, placement.material_key
-                );
+            // Skip deposits with no material (biome had an empty palette).
+            if placement.material_seed == 0 {
                 continue;
-            };
+            }
 
-            let deposit_material = base_material.clone();
+            let deposit_material = material_catalog
+                .derive_and_register(placement.material_seed)
+                .clone();
             let mesh = deposit_material.mesh_for_density(&mut meshes);
             let render_material = render_materials.add(StandardMaterial {
                 base_color: deposit_material.bevy_color(),
@@ -1104,7 +1101,12 @@ fn generate_surface_mineral_deposit_sites(
                     generator_version: SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION,
                 },
                 definition_key: definition.key.clone(),
-                material_key: definition.material_key.clone(),
+                material_seed: choose_material_seed_from_palette(
+                    &biome.material_palette,
+                    generation_key.placement_variation_key,
+                    chunk_coord,
+                    local_site_index,
+                ),
                 center_xz,
                 radius_world_units,
                 child_count: child_count.max(1),
@@ -1183,7 +1185,7 @@ fn expand_deposit_site_into_cluster(
             ),
             deposit_site_id: site.site_id.clone(),
             definition_key: site.definition_key.clone(),
-            material_key: site.material_key.clone(),
+            material_seed: site.material_seed,
             position_xz,
             surface_y: child_surface.position_y,
             surface_normal: child_surface.normal,
@@ -1245,6 +1247,50 @@ fn choose_deposit_definition<'a>(
     }
 
     definitions.last()
+}
+
+/// Choose a material seed from the biome's material palette using weighted
+/// random selection.
+///
+/// Returns `0` if the palette is empty (the spawning system will skip deposits
+/// with seed `0` since no valid material can be derived). The deterministic
+/// roll uses a distinct channel (`0x4400_0000_0000_0001`) so it does not
+/// correlate with the deposit-definition selection roll.
+fn choose_material_seed_from_palette(
+    palette: &[PaletteMaterial],
+    variation_key: u64,
+    chunk_coord: ChunkCoord,
+    local_candidate_index: u32,
+) -> u64 {
+    if palette.is_empty() {
+        return 0;
+    }
+
+    let total_weight: f32 = palette
+        .iter()
+        .map(|entry| entry.selection_weight.max(0.0))
+        .sum();
+    if total_weight <= f32::EPSILON {
+        return 0;
+    }
+
+    let roll = unit_interval_01(mix_candidate_input(
+        variation_key,
+        chunk_coord,
+        local_candidate_index,
+        0x4400_0000_0000_0001,
+    )) * total_weight;
+
+    let mut running = 0.0_f32;
+    for entry in palette {
+        running += entry.selection_weight.max(0.0);
+        if roll <= running {
+            return entry.material_seed;
+        }
+    }
+
+    // Fallback to last entry (float rounding edge case).
+    palette.last().map(|e| e.material_seed).unwrap_or(0)
 }
 
 fn jitter_offset_xz(
@@ -2210,7 +2256,6 @@ site_min_gap_world_units = 2.5
 
 [[deposits]]
 key = "ferrite_surface_deposit"
-material_key = "Ferrite"
 selection_weight = 1.0
 scale_min = 0.9
 scale_max = 1.2
@@ -2225,7 +2270,7 @@ cluster_compactness = 0.75
             toml::from_str(toml_str).expect("surface deposit catalog should parse");
 
         assert_eq!(catalog.deposits.len(), 1);
-        assert_eq!(catalog.deposits[0].material_key, "Ferrite");
+        assert_eq!(catalog.deposits[0].key, "ferrite_surface_deposit");
     }
 
     // ── Story 5.4: Removal delta tests ───────────────────────────────────
@@ -3322,7 +3367,6 @@ cluster_compactness = 0.75
         // total effective weight is zero.
         let definitions = vec![SurfaceMineralDepositDefinition {
             key: "ferrite".to_string(),
-            material_key: "Ferrite".to_string(),
             selection_weight: 1.0,
             scale_min: 0.9,
             scale_max: 1.2,
@@ -3359,7 +3403,6 @@ cluster_compactness = 0.75
         let definitions = vec![
             SurfaceMineralDepositDefinition {
                 key: "common".to_string(),
-                material_key: "Common".to_string(),
                 selection_weight: 1.0,
                 scale_min: 0.9,
                 scale_max: 1.2,
@@ -3371,7 +3414,6 @@ cluster_compactness = 0.75
             },
             SurfaceMineralDepositDefinition {
                 key: "rare".to_string(),
-                material_key: "Rare".to_string(),
                 selection_weight: 1.0,
                 scale_min: 0.9,
                 scale_max: 1.2,
@@ -3533,7 +3575,6 @@ cluster_compactness = 0.75
         let definitions = vec![
             SurfaceMineralDepositDefinition {
                 key: "only_option".to_string(),
-                material_key: "mat_a".to_string(),
                 selection_weight: 1.0,
                 scale_min: 0.5,
                 scale_max: 1.0,
@@ -3545,7 +3586,6 @@ cluster_compactness = 0.75
             },
             SurfaceMineralDepositDefinition {
                 key: "forbidden".to_string(),
-                material_key: "mat_b".to_string(),
                 selection_weight: 1.0,
                 scale_min: 0.5,
                 scale_max: 1.0,
@@ -3597,7 +3637,6 @@ cluster_compactness = 0.75
         let definitions = vec![
             SurfaceMineralDepositDefinition {
                 key: "a".to_string(),
-                material_key: "mat_a".to_string(),
                 selection_weight: 1.0,
                 scale_min: 0.5,
                 scale_max: 1.0,
@@ -3609,7 +3648,6 @@ cluster_compactness = 0.75
             },
             SurfaceMineralDepositDefinition {
                 key: "b".to_string(),
-                material_key: "mat_b".to_string(),
                 selection_weight: 2.0,
                 scale_min: 0.5,
                 scale_max: 1.0,

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4516,4 +4516,134 @@ cluster_compactness = 0.75
             palette_seeds.len()
         );
     }
+
+    // ── Story 5a.4 Phase 9: Cross-biome world generation smoke test ──────
+
+    /// Smoke test: generate many chunks across diverse coordinates, derive
+    /// per-chunk biomes from the real `BiomeRegistry`, run deposit generation
+    /// through the biome's material palette, and register every produced
+    /// material seed into `MaterialCatalog`. The test succeeds if:
+    /// - no panics occur at any stage,
+    /// - every deposit carries a non-zero `material_seed` that belongs to its
+    ///   biome's palette,
+    /// - every seed registers successfully in the `MaterialCatalog`,
+    /// - at least two distinct biome keys are exercised (proving multi-biome
+    ///   coverage).
+    #[test]
+    fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
+        use crate::materials::MaterialCatalog;
+        use crate::world_generation::{BiomeRegistry, derive_chunk_biome};
+        use std::collections::HashSet;
+
+        let config = WorldGenerationConfig {
+            planet_seed: 55_443_322,
+            chunk_size_world_units: 45.0,
+            active_chunk_radius: 2,
+            building_cell_size: 1.0,
+            planet_surface_min_radius: 500,
+            planet_surface_max_radius: 5000,
+            ..Default::default()
+        };
+        let profile = WorldProfile::from_config(&config);
+        let surface = PlanetSurface::new_from_profile(&profile, &config);
+        let catalog = sample_catalog();
+        let biome_registry = BiomeRegistry::default();
+        let mut mat_catalog = MaterialCatalog::default();
+
+        let diameter = profile.planet_surface_diameter;
+
+        // A broad set of chunk coordinates designed to land in different
+        // temperature/moisture zones and therefore resolve to different biomes.
+        let chunks: Vec<ChunkCoord> = vec![
+            ChunkCoord::new(0, 0),
+            ChunkCoord::new(1, 1),
+            ChunkCoord::new(-1, -1),
+            ChunkCoord::new(10, -10),
+            ChunkCoord::new(-50, 50),
+            ChunkCoord::new(100, 200),
+            ChunkCoord::new(-100, -200),
+            ChunkCoord::new(diameter - 1, diameter - 1),
+            ChunkCoord::new(diameter, diameter),
+            ChunkCoord::new(diameter + 1, 0),
+            ChunkCoord::new(0, diameter + 1),
+            ChunkCoord::new(-diameter, -diameter),
+            ChunkCoord::new(-diameter - 1, -diameter - 1),
+            ChunkCoord::new(diameter / 2, diameter / 2),
+            ChunkCoord::new(diameter / 3, -diameter / 4),
+            // Additional spread to increase biome diversity.
+            ChunkCoord::new(diameter / 5, diameter / 7),
+            ChunkCoord::new(diameter / 10, diameter / 3),
+            ChunkCoord::new(3, 400),
+            ChunkCoord::new(250, 7),
+            ChunkCoord::new(diameter / 4, diameter / 6),
+        ];
+
+        let mut observed_biome_keys: HashSet<String> = HashSet::new();
+        let mut total_deposits = 0_usize;
+
+        for &chunk in &chunks {
+            let biome = derive_chunk_biome(&profile, &biome_registry, chunk);
+            observed_biome_keys.insert(biome.biome_key.clone());
+
+            let palette_seeds: HashSet<u64> = biome
+                .material_palette
+                .iter()
+                .map(|p| p.material_seed)
+                .collect();
+
+            let placements = generate_surface_mineral_chunk_baseline(
+                &profile, &catalog, &surface, chunk, &biome,
+            );
+
+            for placement in &placements {
+                // Positions must be finite.
+                assert!(
+                    placement.position_xz.x.is_finite(),
+                    "NaN/Inf x in deposit at chunk {chunk:?}"
+                );
+                assert!(
+                    placement.position_xz.z.is_finite(),
+                    "NaN/Inf z in deposit at chunk {chunk:?}"
+                );
+                assert!(
+                    placement.surface_y.is_finite(),
+                    "NaN/Inf surface_y in deposit at chunk {chunk:?}"
+                );
+
+                // Deposits from a biome with a non-empty palette must carry a
+                // non-zero seed drawn from that palette.
+                if !palette_seeds.is_empty() && placement.material_seed != 0 {
+                    assert!(
+                        palette_seeds.contains(&placement.material_seed),
+                        "deposit material_seed {:#018X} not in biome '{}' palette \
+                         (chunk {chunk:?})",
+                        placement.material_seed,
+                        biome.biome_key,
+                    );
+
+                    // Material must register without panicking.
+                    let registered = mat_catalog.derive_and_register(placement.material_seed);
+                    assert_eq!(
+                        registered.seed, placement.material_seed,
+                        "registered material seed mismatch"
+                    );
+                }
+            }
+
+            total_deposits += placements.len();
+        }
+
+        // Sanity: the test exercised at least two distinct biome keys.
+        assert!(
+            observed_biome_keys.len() >= 2,
+            "expected at least 2 distinct biomes but only saw: {observed_biome_keys:?}"
+        );
+
+        // Sanity: we actually generated some deposits across all those chunks.
+        assert!(
+            total_deposits > 0,
+            "expected at least some deposits across {} chunks",
+            chunks.len()
+        );
+    }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -234,7 +234,7 @@ struct SurfaceMineralDeposit {
 struct GeneratedDepositSiteId {
     pub planet_seed: u64,
     pub chunk_coord: ChunkCoord,
-    pub deposit_kind_key: String,
+    pub definition_key: String,
     pub local_site_index: u32,
     pub generator_version: u32,
 }
@@ -1096,7 +1096,7 @@ fn generate_surface_mineral_deposit_sites(
                 site_id: GeneratedDepositSiteId {
                     planet_seed: profile.planet_seed.0,
                     chunk_coord,
-                    deposit_kind_key: definition.key.clone(),
+                    definition_key: definition.key.clone(),
                     local_site_index,
                     generator_version: SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION,
                 },

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4132,6 +4132,64 @@ cluster_compactness = 0.75
         );
     }
 
+    /// Story 5a.4 – Phase 8: when every palette entry has `selection_weight` of
+    /// 0.0 the total weight is effectively zero and `choose_material_seed_from_palette`
+    /// returns 0 — the same sentinel as an empty palette. The deposit sites are
+    /// still generated (physical shapes) but every site carries `material_seed 0`,
+    /// which the spawn loop skips so no entities are created without a material.
+    #[test]
+    fn all_zero_weight_palette_produces_zero_material_seed() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let biome = ChunkBiome {
+            biome_key: "zero_weight_biome".to_string(),
+            ground_color: [0.3, 0.3, 0.3],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 0xAA00_0000_0000_0001,
+                    selection_weight: 0.0,
+                },
+                PaletteMaterial {
+                    material_seed: 0xAA00_0000_0000_0002,
+                    selection_weight: 0.0,
+                },
+                PaletteMaterial {
+                    material_seed: 0xAA00_0000_0000_0003,
+                    selection_weight: 0.0,
+                },
+            ],
+        };
+
+        let mut total_sites = 0_usize;
+        for cx in -10..10 {
+            for cz in -10..10 {
+                let sites = generate_surface_mineral_deposit_sites(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    ChunkCoord::new(cx, cz),
+                    &biome,
+                );
+                for site in &sites {
+                    total_sites += 1;
+                    assert_eq!(
+                        site.material_seed, 0,
+                        "all-zero-weight palette must produce material_seed 0, got {} for site in chunk ({}, {})",
+                        site.material_seed, cx, cz
+                    );
+                }
+            }
+        }
+        assert!(
+            total_sites > 0,
+            "at least some chunks should produce deposit sites even with an all-zero-weight palette"
+        );
+    }
+
     /// Story 5a.4 – Phase 8: a biome palette containing exactly one entry must
     /// always select that material seed, regardless of chunk coordinate or site
     /// index. We sweep a wide grid of chunks and verify every generated deposit

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4646,4 +4646,163 @@ cluster_compactness = 0.75
             chunks.len()
         );
     }
+
+    /// Story 5a.4 – Phase 9: different biomes produce different materials.
+    ///
+    /// Constructs two biomes with completely disjoint material palettes (no
+    /// shared seeds), generates deposits for each across many chunks, and
+    /// asserts that the material seed sets are disjoint. This proves that
+    /// walking between biome regions yields genuinely different resources.
+    #[test]
+    fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        // Scorched-style biome: only seeds 1001, 1003, 1007.
+        let scorched_biome = ChunkBiome {
+            biome_key: "scorched_flats".to_string(),
+            ground_color: [0.55, 0.38, 0.22],
+            density_modifier: 1.15,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 1001,
+                    selection_weight: 3.0,
+                },
+                PaletteMaterial {
+                    material_seed: 1003,
+                    selection_weight: 2.5,
+                },
+                PaletteMaterial {
+                    material_seed: 1007,
+                    selection_weight: 1.5,
+                },
+            ],
+        };
+
+        // Frost-style biome: only seeds 1004, 1010, 1008 — completely disjoint.
+        let frost_biome = ChunkBiome {
+            biome_key: "frost_shelf".to_string(),
+            ground_color: [0.42, 0.48, 0.56],
+            density_modifier: 0.7,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: vec![
+                PaletteMaterial {
+                    material_seed: 1004,
+                    selection_weight: 3.0,
+                },
+                PaletteMaterial {
+                    material_seed: 1010,
+                    selection_weight: 2.5,
+                },
+                PaletteMaterial {
+                    material_seed: 1008,
+                    selection_weight: 1.0,
+                },
+            ],
+        };
+
+        let scorched_palette_seeds: std::collections::HashSet<u64> = scorched_biome
+            .material_palette
+            .iter()
+            .map(|p| p.material_seed)
+            .collect();
+        let frost_palette_seeds: std::collections::HashSet<u64> = frost_biome
+            .material_palette
+            .iter()
+            .map(|p| p.material_seed)
+            .collect();
+
+        // Sanity: the two palettes share no seeds.
+        assert!(
+            scorched_palette_seeds
+                .intersection(&frost_palette_seeds)
+                .next()
+                .is_none(),
+            "test precondition: palettes must be disjoint"
+        );
+
+        let mut scorched_observed: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
+        let mut frost_observed: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        // Generate deposits across a grid of chunks for each biome.
+        for cx in -15..15 {
+            for cz in -15..15 {
+                let coord = ChunkCoord::new(cx, cz);
+
+                for site in generate_surface_mineral_deposit_sites(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    coord,
+                    &scorched_biome,
+                ) {
+                    if site.material_seed != 0 {
+                        scorched_observed.insert(site.material_seed);
+                    }
+                }
+
+                for site in generate_surface_mineral_deposit_sites(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    coord,
+                    &frost_biome,
+                ) {
+                    if site.material_seed != 0 {
+                        frost_observed.insert(site.material_seed);
+                    }
+                }
+            }
+        }
+
+        // Both biomes must have produced some deposits.
+        assert!(
+            !scorched_observed.is_empty(),
+            "scorched_flats biome must produce deposits with non-zero material seeds"
+        );
+        assert!(
+            !frost_observed.is_empty(),
+            "frost_shelf biome must produce deposits with non-zero material seeds"
+        );
+
+        // All observed scorched seeds must come from the scorched palette only.
+        for &seed in &scorched_observed {
+            assert!(
+                scorched_palette_seeds.contains(&seed),
+                "scorched deposit seed {seed:#018X} not in scorched palette"
+            );
+            assert!(
+                !frost_palette_seeds.contains(&seed),
+                "scorched deposit seed {seed:#018X} unexpectedly found in frost palette — \
+                 biomes are not producing distinct materials"
+            );
+        }
+
+        // All observed frost seeds must come from the frost palette only.
+        for &seed in &frost_observed {
+            assert!(
+                frost_palette_seeds.contains(&seed),
+                "frost deposit seed {seed:#018X} not in frost palette"
+            );
+            assert!(
+                !scorched_palette_seeds.contains(&seed),
+                "frost deposit seed {seed:#018X} unexpectedly found in scorched palette — \
+                 biomes are not producing distinct materials"
+            );
+        }
+
+        // The two observed sets must be completely disjoint.
+        let overlap: Vec<u64> = scorched_observed
+            .intersection(&frost_observed)
+            .copied()
+            .collect();
+        assert!(
+            overlap.is_empty(),
+            "scorched and frost deposits must use entirely different material seeds, \
+             but found overlap: {overlap:?}"
+        );
+    }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4064,20 +4064,72 @@ cluster_compactness = 0.75
             material_palette: Vec::new(),
         };
 
-        let sites = generate_surface_mineral_deposit_sites(
-            &profile,
-            &catalog,
-            &surface,
-            ChunkCoord::new(0, -1),
-            &biome,
-        );
-
-        for site in &sites {
-            assert_eq!(
-                site.material_seed, 0,
-                "empty palette must produce material_seed 0"
-            );
+        let mut total_sites = 0_usize;
+        for cx in -10..10 {
+            for cz in -10..10 {
+                let sites = generate_surface_mineral_deposit_sites(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    ChunkCoord::new(cx, cz),
+                    &biome,
+                );
+                for site in &sites {
+                    total_sites += 1;
+                    assert_eq!(
+                        site.material_seed, 0,
+                        "empty palette must produce material_seed 0"
+                    );
+                }
+            }
         }
+        assert!(
+            total_sites > 0,
+            "at least some chunks should produce deposit sites even with an empty palette"
+        );
+    }
+
+    #[test]
+    fn empty_palette_baseline_placements_exist_but_all_have_zero_seed() {
+        // Phase 8: biome with empty material_palette still generates deposit
+        // sites (physical shapes) but every placement carries material_seed 0,
+        // which the spawn loop skips — no entities without material.
+        let profile = sample_profile();
+        let catalog = sample_catalog();
+        let surface = sample_flat_surface();
+
+        let biome = ChunkBiome {
+            biome_key: "barren_biome".to_string(),
+            ground_color: [0.2, 0.2, 0.2],
+            density_modifier: 1.0,
+            deposit_weight_modifiers: HashMap::new(),
+            material_palette: Vec::new(),
+        };
+
+        // Try several chunks to ensure at least one generates placements.
+        let mut total_placements = 0_usize;
+        for cx in -20..20 {
+            for cz in -20..20 {
+                let placements = generate_surface_mineral_chunk_baseline(
+                    &profile,
+                    &catalog,
+                    &surface,
+                    ChunkCoord::new(cx, cz),
+                    &biome,
+                );
+                for p in &placements {
+                    total_placements += 1;
+                    assert_eq!(
+                        p.material_seed, 0,
+                        "all placements from an empty-palette biome must have material_seed 0"
+                    );
+                }
+            }
+        }
+        assert!(
+            total_placements > 0,
+            "at least one chunk should produce deposit placements (physical shapes exist even without materials)"
+        );
     }
 
     #[test]

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -4805,4 +4805,115 @@ cluster_compactness = 0.75
              but found overlap: {overlap:?}"
         );
     }
+
+    /// Story 5a.4 – Phase 9: material properties vary across biomes.
+    ///
+    /// Takes the disjoint palettes from two biomes, derives every material,
+    /// and asserts that the property distributions (density, reactivity,
+    /// conductivity, thermal resistance, toxicity) are not identical across
+    /// the two biome material sets. This proves that exploring a new biome
+    /// rewards the player with materials that behave differently.
+    #[test]
+    fn cross_biome_materials_have_distinct_properties() {
+        use crate::materials::derive_material_from_seed;
+
+        // Scorched-palette seeds (from biomes.toml: ferrite, sulfurite, osmium).
+        let scorched_seeds: Vec<u64> = vec![1001, 1003, 1007];
+        // Frost-palette seeds (from biomes.toml: prismate, phosphite, cobaltine).
+        let frost_seeds: Vec<u64> = vec![1004, 1010, 1008];
+
+        let scorched_materials: Vec<_> = scorched_seeds
+            .iter()
+            .map(|&s| derive_material_from_seed(s))
+            .collect();
+        let frost_materials: Vec<_> = frost_seeds
+            .iter()
+            .map(|&s| derive_material_from_seed(s))
+            .collect();
+
+        // Collect per-biome property value sets for comparison.
+        let extract_props = |mats: &[crate::materials::GameMaterial]| -> Vec<[f32; 5]> {
+            mats.iter()
+                .map(|m| {
+                    [
+                        m.density.value,
+                        m.reactivity.value,
+                        m.conductivity.value,
+                        m.thermal_resistance.value,
+                        m.toxicity.value,
+                    ]
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let scorched_props = extract_props(&scorched_materials);
+        let frost_props = extract_props(&frost_materials);
+
+        // 1) Within each biome, materials must not all be identical — the
+        //    player should encounter variety even within a single region.
+        for (label, props) in [("scorched", &scorched_props), ("frost", &frost_props)] {
+            let first = &props[0];
+            let all_same = props.iter().skip(1).all(|p| p == first);
+            assert!(
+                !all_same,
+                "{label} biome: all materials have identical properties — \
+                 seed derivation is not producing intra-biome variety"
+            );
+        }
+
+        // 2) The two biomes' material sets must differ: collect the sorted
+        //    multisets of property values and verify they are not equal.
+        let mut scorched_sorted = scorched_props.clone();
+        let mut frost_sorted = frost_props.clone();
+        scorched_sorted.sort_by(|a, b| {
+            a.iter()
+                .zip(b.iter())
+                .find_map(|(x, y)| x.partial_cmp(y).filter(|o| !o.is_eq()))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        frost_sorted.sort_by(|a, b| {
+            a.iter()
+                .zip(b.iter())
+                .find_map(|(x, y)| x.partial_cmp(y).filter(|o| !o.is_eq()))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        assert_ne!(
+            scorched_sorted, frost_sorted,
+            "scorched and frost biomes produced identical property distributions — \
+             materials should differ between biomes"
+        );
+
+        // 3) Per-property: the mean value of each property must differ between
+        //    the two biomes for at least 2 out of 5 properties.  This guards
+        //    against a degenerate case where only one property varies.
+        let mean = |props: &[[f32; 5]], idx: usize| -> f32 {
+            props.iter().map(|p| p[idx]).sum::<f32>() / props.len() as f32
+        };
+        let property_names = [
+            "density",
+            "reactivity",
+            "conductivity",
+            "thermal_resistance",
+            "toxicity",
+        ];
+        let mut differing_properties = 0u32;
+        for (i, name) in property_names.iter().enumerate() {
+            let s_mean = mean(&scorched_props, i);
+            let f_mean = mean(&frost_props, i);
+            let delta = (s_mean - f_mean).abs();
+            if delta > 0.001 {
+                differing_properties += 1;
+            } else {
+                eprintln!(
+                    "  note: {name} mean is nearly identical across biomes \
+                     (scorched={s_mean:.4}, frost={f_mean:.4}, delta={delta:.6})"
+                );
+            }
+        }
+        assert!(
+            differing_properties >= 2,
+            "expected at least 2 properties with different mean values across biomes, \
+             but only {differing_properties} differed"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Seed-derived material generation (`derive_material_from_seed`) replaces static TOML material catalog
- Procedural naming system extracted to shared `naming.rs` with collision avoidance
- Biome palette system: each biome defines weighted material seeds in TOML
- Deposit generation selects materials from biome palette instead of global list
- Material catalog keyed by seed, populated on-demand during chunk generation
- Well-known seeds preserved for backward compatibility
- Fabricator compatibility verified (combined seeds, catalog registration)
- Edge cases: empty palette, zero weights, single entry, fallback biome

Closes #302