### PR TITLE
feat: 5b.2 - orbital layout generation

### DIFF
--- a/assets/config/orbital_config.toml
+++ b/assets/config/orbital_config.toml
@@ -1,0 +1,11 @@
+# Orbital layout generation constraints.
+#
+# These values control how many planets a solar system can have and
+# where they can orbit. The generation algorithm draws planet count
+# and orbital distances from seeded RNG, then enforces these bounds.
+
+planet_count_min = 2
+planet_count_max = 8
+inner_orbit_au = 0.3
+outer_orbit_au = 50.0
+min_separation_au = 0.5

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod naming;
 mod observation;
 mod player;
 mod scene;
+mod seed_util;
 mod solar_system;
 mod surface;
 mod world_generation;

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -23,34 +23,14 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::scene::Shelf;
+use crate::seed_util::{
+    MAT_COLOR_B_CHANNEL, MAT_COLOR_G_CHANNEL, MAT_COLOR_R_CHANNEL, MAT_CONDUCTIVITY_CHANNEL,
+    MAT_DENSITY_CHANNEL, MAT_REACTIVITY_CHANNEL, MAT_THERMAL_RESISTANCE_CHANNEL,
+    MAT_TOXICITY_CHANNEL, mix_seed,
+};
 pub struct MaterialPlugin;
 
 pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
-
-// ── Seed-derived material property channels ──────────────────────────────
-//
-// Each channel constant is mixed with a material seed via `mix_seed` to
-// deterministically derive a single property value. The 0xA7E1_0001 prefix
-// groups all material-property channels; the low word distinguishes each
-// property. These must never change once shipped — doing so would alter
-// every seed-derived material in every saved world.
-
-/// Channel for deriving material density from a seed.
-pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
-/// Channel for deriving material thermal resistance from a seed.
-pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
-/// Channel for deriving material reactivity from a seed.
-pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
-/// Channel for deriving material conductivity from a seed.
-pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
-/// Channel for deriving material toxicity from a seed.
-pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
-/// Channel for deriving the red component of material color from a seed.
-pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
-/// Channel for deriving the green component of material color from a seed.
-pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
-/// Channel for deriving the blue component of material color from a seed.
-pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
 
 // ── Well-known material seeds ────────────────────────────────────────────
 //
@@ -179,18 +159,6 @@ impl GameMaterial {
 }
 
 // ── Seed-derived helpers ─────────────────────────────────────────────────
-
-/// Deterministically mix a base seed and a channel into a new 64-bit value.
-///
-/// SplitMix64-style bit mixer — cheap, deterministic, no external crate.
-/// Identical to the mixer in `world_generation`; duplicated here so the
-/// material module has no coupling to world-gen internals.
-fn mix_seed(base: u64, channel: u64) -> u64 {
-    let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^ (z >> 31)
-}
 
 /// Map a `u64` into the closed unit interval \[0.0, 1.0\].
 fn unit_interval_01(value: u64) -> f32 {

--- a/src/seed_util.rs
+++ b/src/seed_util.rs
@@ -1,0 +1,280 @@
+//! Shared seed-mixing utilities and channel constants for deterministic generation.
+//!
+//! Every procedurally generated value in Apeiron Cipher is derived by mixing a
+//! seed with a channel constant. This module provides the core mixing function,
+//! helper conversions, and the authoritative registry of all channel constants
+//! across the codebase.
+//!
+//! ## Channel constant rules
+//!
+//! - Each constant occupies a unique 64-bit value.
+//! - Channel families use distinct prefix spaces to avoid collisions:
+//!   - `0x57A2_0001` — star generation (solar system)
+//!   - `0x02B1_0001` — orbital layout
+//!   - `0xD3E5_17A1` — world generation (placement, biome, surface)
+//!   - `0xE1EF_0001` — elevation
+//!   - `0xA7E1_0001` — material properties
+//! - Adding a new channel? Add it here, not in the consuming module.
+//! - The uniqueness test at the bottom of this file catches collisions at compile time.
+
+// ── Core Mixing Functions ────────────────────────────────────────────────
+
+/// Deterministically mix a base seed and a channel into a new 64-bit value.
+///
+/// SplitMix64-style bit mixer — cheap, deterministic, no external crate.
+/// Avalanches nearby integer inputs into well-mixed outputs so that later
+/// generation systems do not accidentally treat "similar number" as "similar
+/// world feature."
+pub fn mix_seed(base: u64, channel: u64) -> u64 {
+    let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Convert a mixed `u64` into a `f32` in `[0.0, 1.0)`.
+///
+/// Takes the lower 32 bits and divides by `2^32`. This gives ~7 decimal
+/// digits of granularity — more than enough for interpolating physical
+/// parameters that will be displayed to the player as rounded values.
+pub fn seed_to_unit_f32(mixed: u64) -> f32 {
+    (mixed as u32) as f32 / (u32::MAX as f32 + 1.0)
+}
+
+/// Convert an `f32` to a `u64` suitable for seed mixing.
+///
+/// Uses `f32::to_bits` to get the IEEE-754 bit pattern as a `u32`, then
+/// zero-extends to `u64`. This is deterministic and platform-independent for
+/// non-NaN values — the same float always produces the same bits.
+///
+/// Used by orbital layout generation to derive position-based planet seeds:
+/// each planet's seed depends on its orbital distance rather than its index,
+/// so inserting a planet between two existing ones won't change their seeds.
+pub fn f32_to_u64_bits(value: f32) -> u64 {
+    value.to_bits() as u64
+}
+
+/// Linearly interpolate between `min` and `max` using a `[0, 1)` fraction.
+///
+/// Returns exactly `min` when `t == 0.0` and approaches `max` as `t → 1.0`.
+/// Does not clamp — callers are responsible for providing `t` in range.
+///
+/// Note: `carry_feedback.rs` has its own `lerp` that clamps `t` to `[0.0, 1.0]`.
+/// That is intentionally separate — different contract.
+pub fn lerp(min: f32, max: f32, t: f32) -> f32 {
+    min + (max - min) * t
+}
+
+/// Return the next representable `f32` above `value`.
+///
+/// Used in separation enforcement to guarantee that the gap between
+/// consecutive orbits is never fractionally below `min_separation_au` due to
+/// floating-point addition rounding down.
+///
+/// For positive, finite values this bumps the IEEE 754 significand by one ULP.
+/// Special cases (infinity, NaN) pass through unchanged.
+///
+/// TODO: Replace with `f32::next_up()` when stabilized in std
+/// (tracking issue: <https://github.com/rust-lang/rust/issues/91399>).
+pub fn f32_next_up(value: f32) -> f32 {
+    debug_assert!(
+        value.is_finite() && value >= 0.0,
+        "f32_next_up expects a finite non-negative value, got {value}"
+    );
+    if value.is_nan() || value == f32::INFINITY {
+        return value;
+    }
+    if value == f32::NEG_INFINITY {
+        return f32::MIN;
+    }
+    let bits = value.to_bits();
+    let next_bits = if value >= 0.0 { bits + 1 } else { bits - 1 };
+    f32::from_bits(next_bits)
+}
+
+// ── Star Generation Channels (prefix 0x57A2_0001) ───────────────────────
+
+/// Channel for selecting the star type via weighted random.
+pub const STAR_TYPE_CHANNEL: u64 = 0x57A2_0001_0000_0001;
+/// Channel for interpolating luminosity within the selected type's range.
+pub const STAR_LUMINOSITY_CHANNEL: u64 = 0x57A2_0001_0000_0002;
+/// Channel for interpolating surface temperature within the selected type's range.
+pub const STAR_TEMPERATURE_CHANNEL: u64 = 0x57A2_0001_0000_0003;
+/// Channel for interpolating stellar mass within the selected type's range.
+pub const STAR_MASS_CHANNEL: u64 = 0x57A2_0001_0000_0004;
+
+// ── Orbital Layout Channels (prefix 0x02B1_0001) ────────────────────────
+
+/// Channel for deriving planet count from a system seed.
+pub const PLANET_COUNT_CHANNEL: u64 = 0x02B1_0001_0000_0001;
+/// Channel for seeding the orbital distance RNG.
+pub const ORBITAL_LAYOUT_CHANNEL: u64 = 0x02B1_0001_0000_0002;
+
+// ── World Generation Channels (prefix 0xD3E5_17A1) ─────────────────────
+
+/// Channel for deriving placement density seed from planet seed.
+pub const PLACEMENT_DENSITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0001;
+/// Channel for deriving placement variation seed from planet seed.
+pub const PLACEMENT_VARIATION_CHANNEL: u64 = 0xD3E5_17A1_0000_0002;
+/// Channel for deriving object identity seed from planet seed.
+pub const OBJECT_IDENTITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0003;
+/// Channel for deriving the planet surface radius from the planet seed.
+///
+/// The planet surface radius (measured in chunks) determines how large the
+/// planet is. It is derived deterministically from the planet seed so that
+/// each planet has a consistent, reproducible size.
+pub const PLANET_SURFACE_RADIUS_CHANNEL: u64 = 0xD3E5_17A1_0000_0004;
+/// Channel for deriving the biome climate seed from the planet seed.
+///
+/// The biome climate seed is mixed with sub-channel constants (temperature and
+/// moisture) to produce two independent coherent noise fields that together
+/// determine the biome at each chunk position.
+pub const BIOME_CLIMATE_CHANNEL: u64 = 0xD3E5_17A1_0000_0005;
+
+// ── Elevation Channels (prefix 0xE1EF_0001) ─────────────────────────────
+
+/// Channel for deriving the elevation seed from the planet seed.
+///
+/// The elevation seed drives multi-octave value noise that produces terrain
+/// height variation across the planet surface.
+pub const ELEVATION_CHANNEL: u64 = 0xE1EF_0001_0000_0001;
+/// Sub-channel for chunk-level detail noise layered on top of the base
+/// elevation field. Derived from the elevation seed (not the planet seed)
+/// so it is guaranteed independent of the base octaves.
+pub const ELEVATION_DETAIL_CHANNEL: u64 = 0xE1EF_0001_0000_0002;
+
+// ── Material Property Channels (prefix 0xA7E1_0001) ────────────────────
+
+/// Channel for deriving material density from a seed.
+pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
+/// Channel for deriving material thermal resistance from a seed.
+pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
+/// Channel for deriving material reactivity from a seed.
+pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
+/// Channel for deriving material conductivity from a seed.
+pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
+/// Channel for deriving material toxicity from a seed.
+pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
+/// Channel for deriving the red component of material color from a seed.
+pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
+/// Channel for deriving the green component of material color from a seed.
+pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
+/// Channel for deriving the blue component of material color from a seed.
+pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every channel constant in the codebase must be unique. If this test
+    /// fails, two channels have the same value and seed derivation will
+    /// produce identical outputs for different parameters.
+    #[test]
+    fn all_channel_constants_are_unique() {
+        let channels: &[(&str, u64)] = &[
+            // Star generation
+            ("STAR_TYPE_CHANNEL", STAR_TYPE_CHANNEL),
+            ("STAR_LUMINOSITY_CHANNEL", STAR_LUMINOSITY_CHANNEL),
+            ("STAR_TEMPERATURE_CHANNEL", STAR_TEMPERATURE_CHANNEL),
+            ("STAR_MASS_CHANNEL", STAR_MASS_CHANNEL),
+            // Orbital layout
+            ("PLANET_COUNT_CHANNEL", PLANET_COUNT_CHANNEL),
+            ("ORBITAL_LAYOUT_CHANNEL", ORBITAL_LAYOUT_CHANNEL),
+            // World generation
+            ("PLACEMENT_DENSITY_CHANNEL", PLACEMENT_DENSITY_CHANNEL),
+            ("PLACEMENT_VARIATION_CHANNEL", PLACEMENT_VARIATION_CHANNEL),
+            ("OBJECT_IDENTITY_CHANNEL", OBJECT_IDENTITY_CHANNEL),
+            (
+                "PLANET_SURFACE_RADIUS_CHANNEL",
+                PLANET_SURFACE_RADIUS_CHANNEL,
+            ),
+            ("BIOME_CLIMATE_CHANNEL", BIOME_CLIMATE_CHANNEL),
+            // Elevation
+            ("ELEVATION_CHANNEL", ELEVATION_CHANNEL),
+            ("ELEVATION_DETAIL_CHANNEL", ELEVATION_DETAIL_CHANNEL),
+            // Material properties
+            ("MAT_DENSITY_CHANNEL", MAT_DENSITY_CHANNEL),
+            (
+                "MAT_THERMAL_RESISTANCE_CHANNEL",
+                MAT_THERMAL_RESISTANCE_CHANNEL,
+            ),
+            ("MAT_REACTIVITY_CHANNEL", MAT_REACTIVITY_CHANNEL),
+            ("MAT_CONDUCTIVITY_CHANNEL", MAT_CONDUCTIVITY_CHANNEL),
+            ("MAT_TOXICITY_CHANNEL", MAT_TOXICITY_CHANNEL),
+            ("MAT_COLOR_R_CHANNEL", MAT_COLOR_R_CHANNEL),
+            ("MAT_COLOR_G_CHANNEL", MAT_COLOR_G_CHANNEL),
+            ("MAT_COLOR_B_CHANNEL", MAT_COLOR_B_CHANNEL),
+        ];
+
+        for (i, (name_a, val_a)) in channels.iter().enumerate() {
+            for (name_b, val_b) in channels.iter().skip(i + 1) {
+                assert_ne!(
+                    val_a, val_b,
+                    "channel collision: {name_a} ({val_a:#018X}) == {name_b} ({val_b:#018X})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mix_seed_deterministic() {
+        let a = mix_seed(100, 200);
+        let b = mix_seed(100, 200);
+        assert_eq!(a, b, "same inputs must produce same output");
+    }
+
+    #[test]
+    fn mix_seed_different_channels_differ() {
+        let a = mix_seed(100, 1);
+        let b = mix_seed(100, 2);
+        assert_ne!(a, b, "different channels must produce different outputs");
+    }
+
+    #[test]
+    fn seed_to_unit_f32_in_range() {
+        for i in 0..10_000_u64 {
+            let val = seed_to_unit_f32(mix_seed(i, 0));
+            assert!(
+                (0.0..1.0).contains(&val),
+                "seed_to_unit_f32 produced {val} outside [0.0, 1.0)"
+            );
+        }
+    }
+
+    #[test]
+    fn lerp_endpoints() {
+        assert!((lerp(10.0, 20.0, 0.0) - 10.0).abs() < f32::EPSILON);
+        assert!((lerp(10.0, 20.0, 0.5) - 15.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn f32_to_u64_bits_known_values() {
+        assert_eq!(f32_to_u64_bits(0.0_f32), 0x0000_0000_u64);
+        assert_eq!(f32_to_u64_bits(1.0_f32), 0x3F80_0000_u64);
+        assert_eq!(f32_to_u64_bits(-1.0_f32), 0xBF80_0000_u64);
+    }
+
+    #[test]
+    fn f32_to_u64_bits_upper_bits_zero() {
+        let negative = f32_to_u64_bits(-42.0_f32);
+        assert_eq!(
+            negative >> 32,
+            0,
+            "upper 32 bits must be zero even for negative floats"
+        );
+    }
+
+    #[test]
+    fn f32_next_up_increments() {
+        let a = 1.0_f32;
+        let b = f32_next_up(a);
+        assert!(b > a, "f32_next_up must produce a strictly larger value");
+        assert_eq!(
+            a.to_bits() + 1,
+            b.to_bits(),
+            "should be exactly one ULP above"
+        );
+    }
+}

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
-use crate::world_generation::WorldGenerationConfig;
+use crate::world_generation::{PlanetSeed, WorldGenerationConfig};
 
 // ── Seed Channel Constants ───────────────────────────────────────────────
 //
@@ -37,8 +37,19 @@ const STAR_TEMPERATURE_CHANNEL: u64 = 0x57A2_0001_0000_0003;
 /// Channel for interpolating stellar mass within the selected type's range.
 const STAR_MASS_CHANNEL: u64 = 0x57A2_0001_0000_0004;
 
+/// Channel for deriving planet count from a system seed.
+#[allow(dead_code)]
+const PLANET_COUNT_CHANNEL: u64 = 0x02B1_0001_0000_0001;
+
+/// Channel for seeding the orbital distance RNG.
+#[allow(dead_code)]
+const ORBITAL_LAYOUT_CHANNEL: u64 = 0x02B1_0001_0000_0002;
+
 /// Path to the star type definitions TOML file.
 const STAR_TYPES_CONFIG_PATH: &str = "assets/config/star_types.toml";
+
+/// Path to the orbital configuration TOML file.
+const ORBITAL_CONFIG_PATH: &str = "assets/config/orbital_config.toml";
 
 // ── Data Types ───────────────────────────────────────────────────────────
 
@@ -117,6 +128,125 @@ pub struct StarTypeDefinition {
 pub struct StarTypeRegistry {
     /// Ordered list of star type definitions.
     pub star_types: Vec<StarTypeDefinition>,
+}
+
+// ── Orbital Layout Types ────────────────────────────────────────────────
+
+/// A planet's position and identity within the solar system.
+///
+/// Each slot represents one planet at a specific orbital distance. The
+/// `planet_seed` is derived from the system seed and the orbital distance
+/// (not the index), so inserting a planet between two existing ones in a
+/// future story will not change their seeds.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct OrbitalSlot {
+    /// Deterministic seed for this planet, derived from system seed and orbital distance.
+    pub planet_seed: PlanetSeed,
+    /// Distance from the star in astronomical units.
+    pub orbital_distance_au: f32,
+    /// Zero-based index from the star outward.
+    pub orbital_index: u32,
+}
+
+/// Full orbital layout for a solar system.
+///
+/// Contains every planet in the system, sorted by orbital distance from
+/// the star outward. Deterministically derived from a `SolarSystemSeed`
+/// and an `OrbitalConfig`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct OrbitalLayout {
+    /// Planets sorted by orbital distance, innermost first.
+    pub planets: Vec<OrbitalSlot>,
+}
+
+/// Configuration constraints for orbital generation.
+///
+/// All tuning values are data-driven — loaded from
+/// `assets/config/orbital_config.toml` at startup. The defaults here
+/// serve as a hardcoded fallback matching the shipped config file.
+#[derive(Clone, Debug, Resource, Serialize, Deserialize)]
+pub struct OrbitalConfig {
+    /// Minimum number of planets a system can have.
+    pub planet_count_min: u32,
+    /// Maximum number of planets a system can have.
+    pub planet_count_max: u32,
+    /// Closest possible orbit in AU.
+    pub inner_orbit_au: f32,
+    /// Farthest possible orbit in AU.
+    pub outer_orbit_au: f32,
+    /// Minimum distance between adjacent orbits in AU.
+    pub min_separation_au: f32,
+}
+
+impl Default for OrbitalConfig {
+    /// Hardcoded fallback matching the shipped `orbital_config.toml`.
+    ///
+    /// The TOML file is the source of truth for tuning; these values
+    /// ensure the game is playable even when the file is missing.
+    fn default() -> Self {
+        Self {
+            planet_count_min: 2,
+            planet_count_max: 8,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 50.0,
+            min_separation_au: 0.5,
+        }
+    }
+}
+
+impl OrbitalConfig {
+    /// Validate every structural invariant the config must uphold.
+    ///
+    /// Returns `Ok(())` when valid, or `Err` with a human-readable description
+    /// of the first violation found. Checks performed:
+    ///
+    /// 1. `planet_count_min >= 1` — a system must have at least one planet.
+    /// 2. `planet_count_min <= planet_count_max` — range must not be inverted.
+    /// 3. `inner_orbit_au > 0.0` and finite — must be a positive distance.
+    /// 4. `inner_orbit_au < outer_orbit_au` — range must not be inverted.
+    /// 5. `outer_orbit_au` is finite.
+    /// 6. `min_separation_au > 0.0` and finite — must be a positive distance.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.planet_count_min < 1 {
+            return Err(format!(
+                "planet_count_min must be >= 1, got {}",
+                self.planet_count_min
+            ));
+        }
+        if self.planet_count_min > self.planet_count_max {
+            return Err(format!(
+                "planet_count_min ({}) must be <= planet_count_max ({})",
+                self.planet_count_min, self.planet_count_max
+            ));
+        }
+        if !self.inner_orbit_au.is_finite() || self.inner_orbit_au <= 0.0 {
+            return Err(format!(
+                "inner_orbit_au must be positive and finite, got {}",
+                self.inner_orbit_au
+            ));
+        }
+        if !self.outer_orbit_au.is_finite() {
+            return Err(format!(
+                "outer_orbit_au must be finite, got {}",
+                self.outer_orbit_au
+            ));
+        }
+        if self.inner_orbit_au >= self.outer_orbit_au {
+            return Err(format!(
+                "inner_orbit_au ({}) must be < outer_orbit_au ({})",
+                self.inner_orbit_au, self.outer_orbit_au
+            ));
+        }
+        if !self.min_separation_au.is_finite() || self.min_separation_au <= 0.0 {
+            return Err(format!(
+                "min_separation_au must be positive and finite, got {}",
+                self.min_separation_au
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl StarTypeRegistry {
@@ -276,7 +406,8 @@ pub struct SolarSystemPlugin;
 impl Plugin for SolarSystemPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<StarTypeRegistry>()
-            .add_systems(PreStartup, load_star_type_registry)
+            .init_resource::<OrbitalConfig>()
+            .add_systems(PreStartup, (load_star_type_registry, load_orbital_config))
             .add_systems(Startup, log_star_profile_on_startup);
     }
 }
@@ -321,6 +452,53 @@ fn load_star_type_registry(mut commands: Commands) {
     };
 
     commands.insert_resource(registry);
+}
+
+/// Load the orbital configuration from TOML, falling back to hardcoded defaults.
+///
+/// Follows the same pattern as `load_star_type_registry`: check existence →
+/// read → parse → validate → fallback on any error.
+fn load_orbital_config(mut commands: Commands) {
+    let config = if Path::new(ORBITAL_CONFIG_PATH).exists() {
+        match fs::read_to_string(ORBITAL_CONFIG_PATH) {
+            Ok(contents) => match toml::from_str::<OrbitalConfig>(&contents) {
+                Ok(config) => match config.validate() {
+                    Ok(()) => {
+                        info!(
+                            "Loaded orbital config from {ORBITAL_CONFIG_PATH}: \
+                             planets=[{}, {}], orbits=[{}, {}] AU, min_sep={} AU",
+                            config.planet_count_min,
+                            config.planet_count_max,
+                            config.inner_orbit_au,
+                            config.outer_orbit_au,
+                            config.min_separation_au,
+                        );
+                        config
+                    }
+                    Err(validation_error) => {
+                        warn!(
+                            "Orbital config from {ORBITAL_CONFIG_PATH} failed validation, \
+                             using defaults: {validation_error}"
+                        );
+                        OrbitalConfig::default()
+                    }
+                },
+                Err(error) => {
+                    warn!("Could not parse {ORBITAL_CONFIG_PATH}, using defaults: {error}");
+                    OrbitalConfig::default()
+                }
+            },
+            Err(error) => {
+                warn!("Could not read {ORBITAL_CONFIG_PATH}, using defaults: {error}");
+                OrbitalConfig::default()
+            }
+        }
+    } else {
+        warn!("{ORBITAL_CONFIG_PATH} not found, using defaults");
+        OrbitalConfig::default()
+    };
+
+    commands.insert_resource(config);
 }
 
 /// Derive and log the star profile for the current solar system on startup.
@@ -1285,5 +1463,202 @@ weight = 7.0
                 raw
             );
         }
+    }
+
+    // ── OrbitalConfig Validation Tests ───────────────────────────────────
+
+    /// The default orbital config must pass validation.
+    #[test]
+    fn default_orbital_config_validates() {
+        OrbitalConfig::default()
+            .validate()
+            .expect("default OrbitalConfig must pass validation");
+    }
+
+    /// planet_count_min < 1 must be rejected.
+    #[test]
+    fn orbital_config_rejects_zero_planet_count_min() {
+        let mut config = OrbitalConfig::default();
+        config.planet_count_min = 0;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("planet_count_min"),
+            "error should mention planet_count_min, got: {err}"
+        );
+    }
+
+    /// Inverted planet count range must be rejected.
+    #[test]
+    fn orbital_config_rejects_inverted_planet_count() {
+        let mut config = OrbitalConfig::default();
+        config.planet_count_min = 10;
+        config.planet_count_max = 3;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("planet_count_min"),
+            "error should mention planet_count_min, got: {err}"
+        );
+    }
+
+    /// Zero inner_orbit_au must be rejected.
+    #[test]
+    fn orbital_config_rejects_zero_inner_orbit() {
+        let mut config = OrbitalConfig::default();
+        config.inner_orbit_au = 0.0;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("inner_orbit_au"),
+            "error should mention inner_orbit_au, got: {err}"
+        );
+    }
+
+    /// Inverted orbit range must be rejected.
+    #[test]
+    fn orbital_config_rejects_inverted_orbit_range() {
+        let mut config = OrbitalConfig::default();
+        config.inner_orbit_au = 60.0;
+        config.outer_orbit_au = 10.0;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("inner_orbit_au"),
+            "error should mention inner_orbit_au, got: {err}"
+        );
+    }
+
+    /// Zero min_separation_au must be rejected.
+    #[test]
+    fn orbital_config_rejects_zero_separation() {
+        let mut config = OrbitalConfig::default();
+        config.min_separation_au = 0.0;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("min_separation_au"),
+            "error should mention min_separation_au, got: {err}"
+        );
+    }
+
+    /// NaN in outer_orbit_au must be rejected.
+    #[test]
+    fn orbital_config_rejects_nan_outer_orbit() {
+        let mut config = OrbitalConfig::default();
+        config.outer_orbit_au = f32::NAN;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("outer_orbit_au"),
+            "error should mention outer_orbit_au, got: {err}"
+        );
+    }
+
+    /// Equal min and max planet count is valid (deterministic count).
+    #[test]
+    fn orbital_config_accepts_equal_planet_count() {
+        let mut config = OrbitalConfig::default();
+        config.planet_count_min = 5;
+        config.planet_count_max = 5;
+        config
+            .validate()
+            .expect("equal planet_count_min and planet_count_max should be valid");
+    }
+
+    /// OrbitalConfig must round-trip through TOML without data loss.
+    #[test]
+    fn orbital_config_toml_round_trip() {
+        let original = OrbitalConfig::default();
+        let serialized =
+            toml::to_string(&original).expect("OrbitalConfig should serialize to TOML");
+        let deserialized: OrbitalConfig =
+            toml::from_str(&serialized).expect("serialized TOML should deserialize back");
+
+        assert_eq!(
+            original.planet_count_min, deserialized.planet_count_min,
+            "round-trip should preserve planet_count_min"
+        );
+        assert_eq!(
+            original.planet_count_max, deserialized.planet_count_max,
+            "round-trip should preserve planet_count_max"
+        );
+        assert!(
+            (original.inner_orbit_au - deserialized.inner_orbit_au).abs() < f32::EPSILON,
+            "round-trip should preserve inner_orbit_au"
+        );
+        assert!(
+            (original.outer_orbit_au - deserialized.outer_orbit_au).abs() < f32::EPSILON,
+            "round-trip should preserve outer_orbit_au"
+        );
+        assert!(
+            (original.min_separation_au - deserialized.min_separation_au).abs() < f32::EPSILON,
+            "round-trip should preserve min_separation_au"
+        );
+    }
+
+    /// OrbitalSlot must round-trip through serde (JSON) without data loss.
+    #[test]
+    fn orbital_slot_serde_round_trip() {
+        let slot = OrbitalSlot {
+            planet_seed: PlanetSeed(0xCAFE_BABE),
+            orbital_distance_au: 1.5,
+            orbital_index: 2,
+        };
+        let json = serde_json::to_string(&slot).expect("OrbitalSlot should serialize to JSON");
+        let deserialized: OrbitalSlot =
+            serde_json::from_str(&json).expect("OrbitalSlot should deserialize from JSON");
+        assert_eq!(
+            slot, deserialized,
+            "OrbitalSlot must survive JSON round-trip"
+        );
+    }
+
+    /// OrbitalLayout must round-trip through serde (JSON) without data loss.
+    #[test]
+    fn orbital_layout_serde_round_trip() {
+        let layout = OrbitalLayout {
+            planets: vec![
+                OrbitalSlot {
+                    planet_seed: PlanetSeed(1),
+                    orbital_distance_au: 0.5,
+                    orbital_index: 0,
+                },
+                OrbitalSlot {
+                    planet_seed: PlanetSeed(2),
+                    orbital_distance_au: 3.0,
+                    orbital_index: 1,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&layout).expect("OrbitalLayout should serialize to JSON");
+        let deserialized: OrbitalLayout =
+            serde_json::from_str(&json).expect("OrbitalLayout should deserialize from JSON");
+        assert_eq!(
+            layout, deserialized,
+            "OrbitalLayout must survive JSON round-trip"
+        );
+    }
+
+    /// Seed channel constants for orbital layout must not collide with
+    /// existing star generation channels.
+    #[test]
+    fn orbital_channel_constants_do_not_collide_with_star_channels() {
+        let star_channels = [
+            STAR_TYPE_CHANNEL,
+            STAR_LUMINOSITY_CHANNEL,
+            STAR_TEMPERATURE_CHANNEL,
+            STAR_MASS_CHANNEL,
+        ];
+        let orbital_channels = [PLANET_COUNT_CHANNEL, ORBITAL_LAYOUT_CHANNEL];
+
+        for &oc in &orbital_channels {
+            for &sc in &star_channels {
+                assert_ne!(
+                    oc, sc,
+                    "orbital channel {oc:#018X} collides with star channel {sc:#018X}"
+                );
+            }
+        }
+
+        // Orbital channels must also not collide with each other.
+        assert_ne!(
+            PLANET_COUNT_CHANNEL, ORBITAL_LAYOUT_CHANNEL,
+            "PLANET_COUNT_CHANNEL and ORBITAL_LAYOUT_CHANNEL must differ"
+        );
     }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -1963,4 +1963,181 @@ weight = 7.0
             );
         }
     }
+
+    /// Same seed + same config = identical orbital layout. This is the
+    /// fundamental determinism guarantee for orbital generation.
+    #[test]
+    fn orbital_layout_deterministic() {
+        let seed = SolarSystemSeed(0xCAFE_BABE_DEAD_BEEF);
+        let config = OrbitalConfig::default();
+
+        let layout_a = derive_orbital_layout(seed, &config);
+        let layout_b = derive_orbital_layout(seed, &config);
+
+        assert_eq!(
+            layout_a, layout_b,
+            "same seed must produce identical orbital layout"
+        );
+    }
+
+    /// Orbital distances must be sorted innermost-first (ascending).
+    #[test]
+    fn orbital_layout_distances_sorted() {
+        let config = OrbitalConfig::default();
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for window in layout.planets.windows(2) {
+                assert!(
+                    window[0].orbital_distance_au <= window[1].orbital_distance_au,
+                    "seed {i}: distances not sorted — {} > {}",
+                    window[0].orbital_distance_au,
+                    window[1].orbital_distance_au,
+                );
+            }
+        }
+    }
+
+    /// Adjacent orbital distances must respect the configured minimum
+    /// separation. The enforcement pushes overlapping orbits outward.
+    #[test]
+    fn orbital_layout_minimum_separation_enforced() {
+        let config = OrbitalConfig::default();
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for window in layout.planets.windows(2) {
+                let gap = window[1].orbital_distance_au - window[0].orbital_distance_au;
+                assert!(
+                    gap >= config.min_separation_au - f32::EPSILON,
+                    "seed {i}: separation {gap} AU < minimum {} AU",
+                    config.min_separation_au,
+                );
+            }
+        }
+    }
+
+    /// Planet seeds must differ for different orbital positions within the
+    /// same system. Two planets at different distances must not share a seed.
+    #[test]
+    fn orbital_layout_planet_seeds_differ() {
+        let config = OrbitalConfig {
+            planet_count_min: 4,
+            planet_count_max: 4,
+            ..OrbitalConfig::default()
+        };
+
+        for i in 0..100_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for (a_idx, a) in layout.planets.iter().enumerate() {
+                for b in layout.planets.iter().skip(a_idx + 1) {
+                    assert_ne!(
+                        a.planet_seed, b.planet_seed,
+                        "seed {i}: planets at {} AU and {} AU share the same planet seed",
+                        a.orbital_distance_au, b.orbital_distance_au,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Planet seeds are position-based, not index-based. Changing the planet
+    /// count range should not alter the seed of a planet that ends up at the
+    /// same orbital distance. We verify this by comparing a layout where a
+    /// specific planet exists in both a narrow and wide count config — if the
+    /// distance is identical, the seed must be identical.
+    #[test]
+    fn orbital_layout_planet_seeds_position_based() {
+        // Use a seed where we can get a layout with at least 2 planets in
+        // both configs. We use min==max to guarantee exact counts.
+        let seed = SolarSystemSeed(42);
+
+        // Generate a 3-planet layout.
+        let config_3 = OrbitalConfig {
+            planet_count_min: 3,
+            planet_count_max: 3,
+            ..OrbitalConfig::default()
+        };
+        let layout_3 = derive_orbital_layout(seed, &config_3);
+
+        // Generate a 5-planet layout. The first 3 distance draws use the same
+        // sub-seeds (channels 1, 2, 3), so if sorting doesn't interleave new
+        // planets between them, their distances — and therefore seeds — match.
+        let config_5 = OrbitalConfig {
+            planet_count_min: 5,
+            planet_count_max: 5,
+            ..OrbitalConfig::default()
+        };
+        let layout_5 = derive_orbital_layout(seed, &config_5);
+
+        // Find planets that share an orbital distance across the two layouts.
+        // For those planets, the seed must be identical (position-based).
+        for slot_3 in &layout_3.planets {
+            for slot_5 in &layout_5.planets {
+                if (slot_3.orbital_distance_au - slot_5.orbital_distance_au).abs() < f32::EPSILON {
+                    assert_eq!(
+                        slot_3.planet_seed, slot_5.planet_seed,
+                        "planet at {} AU has different seeds across configs",
+                        slot_3.orbital_distance_au,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Orbital indices must be 0-based and sequential from innermost outward.
+    #[test]
+    fn orbital_layout_indices_sequential() {
+        let config = OrbitalConfig::default();
+
+        for i in 0..100_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for (expected_idx, slot) in layout.planets.iter().enumerate() {
+                assert_eq!(
+                    slot.orbital_index, expected_idx as u32,
+                    "seed {i}: expected orbital_index {expected_idx}, got {}",
+                    slot.orbital_index,
+                );
+            }
+        }
+    }
+
+    /// Different system seeds should produce varying orbital layouts. With
+    /// 1000 seeds, we expect to see multiple distinct planet counts and
+    /// distance patterns.
+    #[test]
+    fn orbital_layout_varies_across_seeds() {
+        let config = OrbitalConfig::default();
+        let mut distinct_counts = std::collections::HashSet::new();
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            distinct_counts.insert(layout.planets.len());
+        }
+
+        assert!(
+            distinct_counts.len() >= 3,
+            "expected at least 3 distinct planet counts across 1000 seeds, got {:?}",
+            distinct_counts,
+        );
+    }
+
+    /// All orbital distances must fall at or above the inner orbit bound.
+    /// (They may exceed outer_orbit_au due to min-separation pushing.)
+    #[test]
+    fn orbital_layout_distances_at_least_inner_orbit() {
+        let config = OrbitalConfig::default();
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for slot in &layout.planets {
+                assert!(
+                    slot.orbital_distance_au >= config.inner_orbit_au,
+                    "seed {i}: distance {} AU < inner bound {} AU",
+                    slot.orbital_distance_au,
+                    config.inner_orbit_au,
+                );
+            }
+        }
+    }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -661,6 +661,43 @@ pub fn derive_star_profile(
     }
 }
 
+/// Derive the number of planets for a solar system from its seed and config.
+///
+/// ## Derivation
+///
+/// 1. Mix the system seed with `PLANET_COUNT_CHANNEL` to produce a raw `u64`.
+/// 2. Convert to a `[0, 1)` fraction via `seed_to_unit_f32`.
+/// 3. Lerp into the range `[planet_count_min, planet_count_max + 1)` and
+///    floor to produce an integer uniformly distributed in
+///    `[planet_count_min, planet_count_max]`.
+///
+/// The `+ 1` in the lerp upper bound ensures that `planet_count_max` is
+/// reachable: without it, `seed_to_unit_f32` returning values in `[0, 1)`
+/// would make `planet_count_max` unreachable after flooring.
+///
+/// ## Clamping
+///
+/// A final clamp guards against floating-point edge cases (e.g., `t` very
+/// close to 1.0 producing a value above `planet_count_max` after the `+ 1`
+/// trick). The clamp is a safety net — under normal operation, the lerp +
+/// floor already produces values in range.
+#[allow(dead_code)]
+pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig) -> u32 {
+    let raw = mix_seed(system_seed.0, PLANET_COUNT_CHANNEL);
+    let t = seed_to_unit_f32(raw);
+
+    // Lerp into [min, max + 1) so that flooring produces [min, max].
+    let count_f = lerp(
+        config.planet_count_min as f32,
+        (config.planet_count_max + 1) as f32,
+        t,
+    );
+    let count = count_f as u32;
+
+    // Safety clamp against float edge cases.
+    count.clamp(config.planet_count_min, config.planet_count_max)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1691,5 +1728,123 @@ weight = 7.0
             PLANET_COUNT_CHANNEL, ORBITAL_LAYOUT_CHANNEL,
             "PLANET_COUNT_CHANNEL and ORBITAL_LAYOUT_CHANNEL must differ"
         );
+    }
+
+    // ── Planet Count Derivation Tests ────────────────────────────────
+
+    /// Same seed + same config = same planet count. Fundamental determinism.
+    #[test]
+    fn planet_count_deterministic() {
+        let seed = SolarSystemSeed(0xDEAD_BEEF_CAFE_BABE);
+        let config = OrbitalConfig::default();
+
+        let count_a = derive_planet_count(seed, &config);
+        let count_b = derive_planet_count(seed, &config);
+
+        assert_eq!(count_a, count_b, "same seed must produce same planet count");
+    }
+
+    /// Planet count must always be within [min, max] for a range of seeds.
+    #[test]
+    fn planet_count_within_configured_range() {
+        let config = OrbitalConfig::default();
+
+        for i in 0..10_000_u64 {
+            let count = derive_planet_count(SolarSystemSeed(i), &config);
+            assert!(
+                count >= config.planet_count_min && count <= config.planet_count_max,
+                "seed {i}: planet count {count} outside [{}, {}]",
+                config.planet_count_min,
+                config.planet_count_max,
+            );
+        }
+    }
+
+    /// When min == max, every seed must produce exactly that count.
+    #[test]
+    fn planet_count_fixed_when_min_equals_max() {
+        let config = OrbitalConfig {
+            planet_count_min: 5,
+            planet_count_max: 5,
+            ..OrbitalConfig::default()
+        };
+
+        for i in 0..1_000_u64 {
+            let count = derive_planet_count(SolarSystemSeed(i), &config);
+            assert_eq!(
+                count, 5,
+                "seed {i}: expected exactly 5 planets when min==max, got {count}"
+            );
+        }
+    }
+
+    /// Different seeds should produce varying planet counts — not all the
+    /// same value. With default range [2, 8] and 10,000 seeds, we expect
+    /// at least 3 distinct counts.
+    #[test]
+    fn planet_count_varies_across_seeds() {
+        let config = OrbitalConfig::default();
+        let mut seen = std::collections::HashSet::new();
+
+        for i in 0..10_000_u64 {
+            seen.insert(derive_planet_count(SolarSystemSeed(i), &config));
+        }
+
+        assert!(
+            seen.len() >= 3,
+            "expected at least 3 distinct planet counts from 10,000 seeds, got {}",
+            seen.len()
+        );
+    }
+
+    /// Both min and max planet counts must be reachable. With 10,000 seeds
+    /// and a well-mixed derivation, both endpoints should appear.
+    #[test]
+    fn planet_count_reaches_min_and_max() {
+        let config = OrbitalConfig::default();
+        let mut min_seen = false;
+        let mut max_seen = false;
+
+        for i in 0..10_000_u64 {
+            let count = derive_planet_count(SolarSystemSeed(i), &config);
+            if count == config.planet_count_min {
+                min_seen = true;
+            }
+            if count == config.planet_count_max {
+                max_seen = true;
+            }
+            if min_seen && max_seen {
+                break;
+            }
+        }
+
+        assert!(
+            min_seen,
+            "planet_count_min ({}) was never produced in 10,000 seeds",
+            config.planet_count_min
+        );
+        assert!(
+            max_seen,
+            "planet_count_max ({}) was never produced in 10,000 seeds",
+            config.planet_count_max
+        );
+    }
+
+    /// Planet count respects a custom narrower range.
+    #[test]
+    fn planet_count_respects_custom_range() {
+        let config = OrbitalConfig {
+            planet_count_min: 4,
+            planet_count_max: 6,
+            ..OrbitalConfig::default()
+        };
+
+        for i in 0..10_000_u64 {
+            let count = derive_planet_count(SolarSystemSeed(i), &config);
+            assert!(
+                count >= 4 && count <= 6,
+                "seed {i}: planet count {count} outside custom range [4, 6]"
+            );
+        }
     }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2140,4 +2140,71 @@ weight = 7.0
             }
         }
     }
+
+    /// All orbital distances must fall within [inner_orbit_au, outer_orbit_au]
+    /// when min-separation enforcement cannot push planets beyond the outer
+    /// bound.
+    ///
+    /// With a single planet (min==max==1), no separation enforcement occurs,
+    /// so the raw distance draw must land within [inner, outer]. With
+    /// multiple planets we use a generous range (0.3–500 AU, 0.5 AU sep)
+    /// where pushing is negligible, confirming the base draws respect bounds.
+    #[test]
+    fn orbital_layout_distances_within_inner_outer_range() {
+        // Single-planet config: no separation enforcement, pure draw check.
+        let config_single = OrbitalConfig {
+            planet_count_min: 1,
+            planet_count_max: 1,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 50.0,
+            min_separation_au: 0.5,
+        };
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config_single);
+            for slot in &layout.planets {
+                assert!(
+                    slot.orbital_distance_au >= config_single.inner_orbit_au,
+                    "seed {i}: distance {} AU < inner bound {} AU",
+                    slot.orbital_distance_au,
+                    config_single.inner_orbit_au,
+                );
+                assert!(
+                    slot.orbital_distance_au <= config_single.outer_orbit_au,
+                    "seed {i}: distance {} AU > outer bound {} AU",
+                    slot.orbital_distance_au,
+                    config_single.outer_orbit_au,
+                );
+            }
+        }
+
+        // Multi-planet config with a wide range so separation won't push
+        // past outer. 8 planets × 0.5 AU separation = 3.5 AU worst case,
+        // well within the 500 AU range.
+        let config = OrbitalConfig {
+            planet_count_min: 2,
+            planet_count_max: 8,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 500.0,
+            min_separation_au: 0.5,
+        };
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for slot in &layout.planets {
+                assert!(
+                    slot.orbital_distance_au >= config.inner_orbit_au,
+                    "seed {i}: distance {} AU < inner bound {} AU",
+                    slot.orbital_distance_au,
+                    config.inner_orbit_au,
+                );
+                assert!(
+                    slot.orbital_distance_au <= config.outer_orbit_au,
+                    "seed {i}: distance {} AU > outer bound {} AU",
+                    slot.orbital_distance_au,
+                    config.outer_orbit_au,
+                );
+            }
+        }
+    }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -1591,6 +1591,37 @@ weight = 7.0
         );
     }
 
+    /// OrbitalConfig must round-trip through serde (JSON) without data loss.
+    #[test]
+    fn orbital_config_serde_round_trip() {
+        let original = OrbitalConfig::default();
+        let json =
+            serde_json::to_string(&original).expect("OrbitalConfig should serialize to JSON");
+        let deserialized: OrbitalConfig =
+            serde_json::from_str(&json).expect("OrbitalConfig should deserialize from JSON");
+
+        assert_eq!(
+            original.planet_count_min, deserialized.planet_count_min,
+            "round-trip should preserve planet_count_min"
+        );
+        assert_eq!(
+            original.planet_count_max, deserialized.planet_count_max,
+            "round-trip should preserve planet_count_max"
+        );
+        assert!(
+            (original.inner_orbit_au - deserialized.inner_orbit_au).abs() < f32::EPSILON,
+            "round-trip should preserve inner_orbit_au"
+        );
+        assert!(
+            (original.outer_orbit_au - deserialized.outer_orbit_au).abs() < f32::EPSILON,
+            "round-trip should preserve outer_orbit_au"
+        );
+        assert!(
+            (original.min_separation_au - deserialized.min_separation_au).abs() < f32::EPSILON,
+            "round-trip should preserve min_separation_au"
+        );
+    }
+
     /// OrbitalSlot must round-trip through serde (JSON) without data loss.
     #[test]
     fn orbital_slot_serde_round_trip() {

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2017,6 +2017,81 @@ weight = 7.0
         }
     }
 
+    /// Minimum separation must hold even when many planets are packed into a
+    /// narrow orbital range, forcing heavy outward pushing.
+    #[test]
+    fn orbital_layout_minimum_separation_enforced_tight_range() {
+        let config = OrbitalConfig {
+            planet_count_min: 8,
+            planet_count_max: 8,
+            inner_orbit_au: 1.0,
+            outer_orbit_au: 5.0,
+            min_separation_au: 0.5,
+        };
+
+        for i in 0..500_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            assert_eq!(layout.planets.len(), 8, "seed {i}: expected 8 planets",);
+            for window in layout.planets.windows(2) {
+                let gap = window[1].orbital_distance_au - window[0].orbital_distance_au;
+                assert!(
+                    gap >= config.min_separation_au - 1e-5,
+                    "seed {i}: separation {gap} AU < minimum {} AU (distances: {} AU, {} AU)",
+                    config.min_separation_au,
+                    window[0].orbital_distance_au,
+                    window[1].orbital_distance_au,
+                );
+            }
+        }
+    }
+
+    /// Minimum separation must hold with a custom (large) separation value.
+    #[test]
+    fn orbital_layout_minimum_separation_enforced_custom_separation() {
+        let config = OrbitalConfig {
+            planet_count_min: 4,
+            planet_count_max: 4,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 100.0,
+            min_separation_au: 5.0,
+        };
+
+        for i in 0..500_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            for window in layout.planets.windows(2) {
+                let gap = window[1].orbital_distance_au - window[0].orbital_distance_au;
+                assert!(
+                    gap >= config.min_separation_au - 1e-5,
+                    "seed {i}: separation {gap} AU < minimum {} AU (distances: {} AU, {} AU)",
+                    config.min_separation_au,
+                    window[0].orbital_distance_au,
+                    window[1].orbital_distance_au,
+                );
+            }
+        }
+    }
+
+    /// With a single planet, separation enforcement is trivially satisfied
+    /// (no adjacent pair exists).
+    #[test]
+    fn orbital_layout_minimum_separation_single_planet() {
+        let config = OrbitalConfig {
+            planet_count_min: 1,
+            planet_count_max: 1,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 50.0,
+            min_separation_au: 0.5,
+        };
+
+        for i in 0..100_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            assert_eq!(layout.planets.len(), 1, "seed {i}: expected 1 planet");
+            // windows(2) yields nothing for a single-element vec — no
+            // separation invariant to violate.
+            assert_eq!(layout.planets.windows(2).count(), 0);
+        }
+    }
+
     /// Planet seeds must differ for different orbital positions within the
     /// same system. Two planets at different distances must not share a seed.
     #[test]

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2373,6 +2373,135 @@ weight = 7.0
         }
     }
 
+    // ── Position-based stability tests ────────────────────────────────────
+
+    /// Changing `planet_count_max` must not change the seeds of planets whose
+    /// orbital distances remain the same. Because planet seeds are derived from
+    /// `mix_seed(system_seed, f32_to_u64_bits(distance))`, any planet that
+    /// keeps its distance keeps its seed — regardless of how many siblings
+    /// were added or removed.
+    #[test]
+    fn position_based_stability_across_planet_count_max() {
+        let system_seed = SolarSystemSeed(0xBEEF_CAFE_1234_5678);
+
+        // Narrow config: forces exactly 4 planets.
+        let narrow = OrbitalConfig {
+            planet_count_min: 4,
+            planet_count_max: 4,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 50.0,
+            min_separation_au: 0.5,
+        };
+
+        // Wide config: forces exactly 8 planets.  The first 4 raw distance
+        // draws (layout-seed channels 1–4) are identical to the narrow config;
+        // channels 5–8 are new draws that may interleave after sorting.
+        let wide = OrbitalConfig {
+            planet_count_min: 8,
+            planet_count_max: 8,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 50.0,
+            min_separation_au: 0.5,
+        };
+
+        let narrow_layout = derive_orbital_layout(system_seed, &narrow);
+        let wide_layout = derive_orbital_layout(system_seed, &wide);
+
+        assert_eq!(narrow_layout.planets.len(), 4);
+        assert_eq!(wide_layout.planets.len(), 8);
+
+        // Build a lookup from orbital_distance_au → planet_seed for the wide
+        // layout. We compare by exact f32 bit equality (same derivation path
+        // means bitwise-identical floats).
+        let wide_seed_by_dist: std::collections::HashMap<u64, u64> = wide_layout
+            .planets
+            .iter()
+            .map(|s| (f32_to_u64_bits(s.orbital_distance_au), s.planet_seed.0))
+            .collect();
+
+        // Every narrow-layout planet whose exact distance also appears in the
+        // wide layout must have the identical seed.
+        let mut matched = 0_u32;
+        for slot in &narrow_layout.planets {
+            let dist_bits = f32_to_u64_bits(slot.orbital_distance_au);
+            if let Some(&wide_seed) = wide_seed_by_dist.get(&dist_bits) {
+                assert_eq!(
+                    slot.planet_seed.0, wide_seed,
+                    "planet at distance {} AU has different seeds across configs \
+                     (narrow={:#018X}, wide={:#018X})",
+                    slot.orbital_distance_au, slot.planet_seed.0, wide_seed,
+                );
+                matched += 1;
+            }
+        }
+
+        // We must have matched at least one planet, otherwise the test is
+        // vacuously true and proves nothing.  With the chosen seed and
+        // generous orbital range the first-drawn distances are very likely to
+        // survive sorting + separation unchanged.
+        assert!(
+            matched > 0,
+            "no narrow-layout distances appeared in the wide layout — \
+             test is vacuous; choose a different seed or relax separation",
+        );
+    }
+
+    /// A stronger variant: when `planet_count_max` increases but the *raw*
+    /// distance draws for the original indices are far enough apart that
+    /// separation enforcement doesn't shift them, every original planet must
+    /// keep its seed.  We use a very large orbital range with tiny separation
+    /// to make collisions virtually impossible.
+    #[test]
+    fn position_based_stability_wide_range_no_push() {
+        let system_seed = SolarSystemSeed(0xDEAD_BEEF_0000_0001);
+
+        let base = OrbitalConfig {
+            planet_count_min: 3,
+            planet_count_max: 3,
+            inner_orbit_au: 0.3,
+            outer_orbit_au: 500.0,
+            min_separation_au: 0.01,
+        };
+
+        let expanded = OrbitalConfig {
+            planet_count_min: 6,
+            planet_count_max: 6,
+            ..base.clone()
+        };
+
+        let base_layout = derive_orbital_layout(system_seed, &base);
+        let expanded_layout = derive_orbital_layout(system_seed, &expanded);
+
+        let expanded_seed_by_dist: std::collections::HashMap<u64, u64> = expanded_layout
+            .planets
+            .iter()
+            .map(|s| (f32_to_u64_bits(s.orbital_distance_au), s.planet_seed.0))
+            .collect();
+
+        let mut matched = 0_u32;
+        for slot in &base_layout.planets {
+            let dist_bits = f32_to_u64_bits(slot.orbital_distance_au);
+            if let Some(&exp_seed) = expanded_seed_by_dist.get(&dist_bits) {
+                assert_eq!(
+                    slot.planet_seed.0, exp_seed,
+                    "planet at {} AU changed seed when planet_count_max increased",
+                    slot.orbital_distance_au,
+                );
+                matched += 1;
+            }
+        }
+
+        // With a 500 AU range and 0.01 AU separation, all 3 base distances
+        // should survive untouched in the 6-planet layout.
+        assert_eq!(
+            matched,
+            base_layout.planets.len() as u32,
+            "expected all {} base planets to retain their distances in the expanded layout, \
+             but only {matched} matched",
+            base_layout.planets.len(),
+        );
+    }
+
     // ── f32_to_u64_bits tests ───────────────────────────────────────────
 
     /// `f32_to_u64_bits` must return the IEEE-754 bit pattern zero-extended

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -564,6 +564,19 @@ fn seed_to_unit_f32(mixed: u64) -> f32 {
     (mixed as u32) as f32 / (u32::MAX as f32 + 1.0)
 }
 
+/// Convert an `f32` to a `u64` suitable for seed mixing.
+///
+/// Uses `f32::to_bits` to get the IEEE-754 bit pattern as a `u32`, then
+/// zero-extends to `u64`. This is deterministic and platform-independent for
+/// non-NaN values — the same float always produces the same bits.
+///
+/// Used by orbital layout generation to derive position-based planet seeds:
+/// each planet's seed depends on its orbital distance rather than its index,
+/// so inserting a planet between two existing ones won't change their seeds.
+fn f32_to_u64_bits(value: f32) -> u64 {
+    value.to_bits() as u64
+}
+
 /// Linearly interpolate between `min` and `max` using a `[0, 1)` fraction.
 ///
 /// Returns exactly `min` when `t == 0.0` and approaches `max` as `t → 1.0`.
@@ -763,7 +776,7 @@ pub fn derive_orbital_layout(
         .into_iter()
         .enumerate()
         .map(|(i, dist)| {
-            let planet_seed_raw = mix_seed(system_seed.0, dist.to_bits() as u64);
+            let planet_seed_raw = mix_seed(system_seed.0, f32_to_u64_bits(dist));
             OrbitalSlot {
                 planet_seed: PlanetSeed(planet_seed_raw),
                 orbital_distance_au: dist,
@@ -2358,5 +2371,64 @@ weight = 7.0
                 );
             }
         }
+    }
+
+    // ── f32_to_u64_bits tests ───────────────────────────────────────────
+
+    /// `f32_to_u64_bits` must return the IEEE-754 bit pattern zero-extended
+    /// to `u64`. We verify against known bit patterns.
+    #[test]
+    fn f32_to_u64_bits_known_values() {
+        // 0.0f32 is all-zero bits.
+        assert_eq!(f32_to_u64_bits(0.0_f32), 0x0000_0000_u64);
+
+        // 1.0f32 = 0x3F80_0000 in IEEE-754.
+        assert_eq!(f32_to_u64_bits(1.0_f32), 0x3F80_0000_u64);
+
+        // -1.0f32 = 0xBF80_0000 in IEEE-754.
+        assert_eq!(f32_to_u64_bits(-1.0_f32), 0xBF80_0000_u64);
+
+        // A typical orbital distance value.
+        let dist = 3.5_f32;
+        assert_eq!(f32_to_u64_bits(dist), dist.to_bits() as u64);
+    }
+
+    /// Determinism: same float always produces the same u64.
+    #[test]
+    fn f32_to_u64_bits_deterministic() {
+        let values = [
+            0.3_f32,
+            1.0,
+            50.0,
+            0.123_456_78,
+            f32::MAX,
+            f32::MIN_POSITIVE,
+        ];
+        for v in values {
+            assert_eq!(
+                f32_to_u64_bits(v),
+                f32_to_u64_bits(v),
+                "f32_to_u64_bits must be deterministic for {v}",
+            );
+        }
+    }
+
+    /// Different floats produce different bit patterns (non-degeneracy).
+    #[test]
+    fn f32_to_u64_bits_different_inputs_differ() {
+        let a = f32_to_u64_bits(1.0_f32);
+        let b = f32_to_u64_bits(2.0_f32);
+        assert_ne!(a, b, "different floats must produce different bit patterns");
+    }
+
+    /// The upper 32 bits must always be zero (zero-extension, not sign-extension).
+    #[test]
+    fn f32_to_u64_bits_upper_bits_zero() {
+        let negative = f32_to_u64_bits(-42.0_f32);
+        assert_eq!(
+            negative >> 32,
+            0,
+            "upper 32 bits must be zero even for negative floats",
+        );
     }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2413,6 +2413,40 @@ weight = 7.0
         }
     }
 
+    /// Different system seeds must produce different orbital layouts. We derive
+    /// layouts for 100 consecutive seeds and assert that not all of them are
+    /// identical — the generator must be non-degenerate.
+    #[test]
+    fn different_system_seeds_produce_different_layouts() {
+        let config = OrbitalConfig::default();
+
+        let layouts: Vec<OrbitalLayout> = (0..100_u64)
+            .map(|i| derive_orbital_layout(SolarSystemSeed(i), &config))
+            .collect();
+
+        // At least two layouts must differ (planet count, distances, or seeds).
+        let all_identical = layouts.windows(2).all(|w| w[0] == w[1]);
+        assert!(
+            !all_identical,
+            "100 consecutive seeds all produced identical orbital layouts — generator is degenerate",
+        );
+
+        // Stronger: count distinct layouts. With 100 seeds and a healthy mixer
+        // we expect a large fraction to be unique.
+        let distinct = {
+            let mut seen = std::collections::HashSet::new();
+            for layout in &layouts {
+                // Hash the debug representation as a cheap equality proxy.
+                seen.insert(format!("{layout:?}"));
+            }
+            seen.len()
+        };
+        assert!(
+            distinct >= 10,
+            "only {distinct}/100 distinct layouts — expected at least 10 for non-degeneracy",
+        );
+    }
+
     // ── Position-based stability tests ────────────────────────────────────
 
     /// Changing `planet_count_max` must not change the seeds of planets whose

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2282,4 +2282,81 @@ weight = 7.0
             }
         }
     }
+
+    /// When many planets are crammed into a narrow orbital range, the
+    /// min-separation enforcement pushes later planets beyond the nominal
+    /// outer bound. The algorithm must handle this gracefully: no panics,
+    /// distances still sorted, separation still enforced, and all planet
+    /// seeds remain unique.
+    ///
+    /// Config: 8 planets forced (min==max), range [1.0, 3.0] AU with
+    /// 0.5 AU separation. Worst case needs 1.0 + 7×0.5 = 4.5 AU — well
+    /// past the 3.0 AU outer bound.
+    #[test]
+    fn orbital_layout_many_planets_small_range_pushes_gracefully() {
+        let config = OrbitalConfig {
+            planet_count_min: 8,
+            planet_count_max: 8,
+            inner_orbit_au: 1.0,
+            outer_orbit_au: 3.0,
+            min_separation_au: 0.5,
+        };
+
+        for i in 0..500_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+
+            assert_eq!(layout.planets.len(), 8, "seed {i}: expected 8 planets",);
+
+            // Distances must be sorted ascending.
+            for pair in layout.planets.windows(2) {
+                assert!(
+                    pair[0].orbital_distance_au <= pair[1].orbital_distance_au,
+                    "seed {i}: distances not sorted: {} > {}",
+                    pair[0].orbital_distance_au,
+                    pair[1].orbital_distance_au,
+                );
+            }
+
+            // Minimum separation must hold between every consecutive pair.
+            for pair in layout.planets.windows(2) {
+                let gap = pair[1].orbital_distance_au - pair[0].orbital_distance_au;
+                assert!(
+                    gap >= config.min_separation_au - f32::EPSILON,
+                    "seed {i}: separation {gap} AU < min {} AU (distances: {}, {})",
+                    config.min_separation_au,
+                    pair[0].orbital_distance_au,
+                    pair[1].orbital_distance_au,
+                );
+            }
+
+            // Innermost planet must be at or above the inner bound.
+            assert!(
+                layout.planets[0].orbital_distance_au >= config.inner_orbit_au,
+                "seed {i}: innermost distance {} AU < inner bound {} AU",
+                layout.planets[0].orbital_distance_au,
+                config.inner_orbit_au,
+            );
+
+            // Planet seeds must all be unique (position-based derivation).
+            let seeds: Vec<u64> = layout.planets.iter().map(|s| s.planet_seed.0).collect();
+            for (a_idx, a_seed) in seeds.iter().enumerate() {
+                for (b_idx, b_seed) in seeds.iter().enumerate() {
+                    if a_idx != b_idx {
+                        assert_ne!(
+                            a_seed, b_seed,
+                            "seed {i}: planet seeds at indices {a_idx} and {b_idx} collide",
+                        );
+                    }
+                }
+            }
+
+            // Orbital indices must be sequential 0..N.
+            for (idx, slot) in layout.planets.iter().enumerate() {
+                assert_eq!(
+                    slot.orbital_index, idx as u32,
+                    "seed {i}: orbital_index mismatch at position {idx}",
+                );
+            }
+        }
+    }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -698,6 +698,83 @@ pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig)
     count.clamp(config.planet_count_min, config.planet_count_max)
 }
 
+// ── Orbital Layout Derivation ────────────────────────────────────────────
+
+/// Derive the full orbital layout for a solar system.
+///
+/// ## Derivation Steps
+///
+/// 1. **Planet count** — derived from `mix_seed(system_seed, PLANET_COUNT_CHANNEL)`,
+///    lerped into the configured `[min, max]` range.
+/// 2. **Orbital distances** — a local RNG seeded from
+///    `mix_seed(system_seed, ORBITAL_LAYOUT_CHANNEL)` draws `N` distances in
+///    `[inner_orbit_au, outer_orbit_au]`, sorts them, and enforces
+///    `min_separation_au` by pushing overlapping orbits outward.
+/// 3. **Planet seeds** — for each slot, `PlanetSeed(mix_seed(system_seed,
+///    f32_to_bits_as_u64(distance)))`. This is position-based, not index-based,
+///    so inserting a planet between two existing ones in a future story will
+///    not shift their seeds.
+///
+/// ## Panics
+///
+/// Does not panic. If minimum separation enforcement pushes a planet past
+/// `outer_orbit_au`, it keeps the pushed distance — the alternative (dropping
+/// the planet) would change the count derived from the seed.
+#[allow(dead_code)]
+pub fn derive_orbital_layout(
+    system_seed: SolarSystemSeed,
+    config: &OrbitalConfig,
+) -> OrbitalLayout {
+    let planet_count = derive_planet_count(system_seed, config);
+
+    if planet_count == 0 {
+        return OrbitalLayout {
+            planets: Vec::new(),
+        };
+    }
+
+    // Seed a deterministic sequence for orbital distances.
+    let layout_seed = mix_seed(system_seed.0, ORBITAL_LAYOUT_CHANNEL);
+
+    // Draw N raw distances in [inner, outer] using successive mixes of the
+    // layout seed. Each planet gets its own channel (its 1-based index) so
+    // that adding more planets never changes earlier draws.
+    let mut distances: Vec<f32> = (0..planet_count)
+        .map(|i| {
+            let raw = mix_seed(layout_seed, i as u64 + 1);
+            let t = seed_to_unit_f32(raw);
+            lerp(config.inner_orbit_au, config.outer_orbit_au, t)
+        })
+        .collect();
+
+    // Sort innermost-first.
+    distances.sort_by(|a, b| a.partial_cmp(b).expect("orbital distances must not be NaN"));
+
+    // Enforce minimum separation by pushing outward.
+    for i in 1..distances.len() {
+        let required = distances[i - 1] + config.min_separation_au;
+        if distances[i] < required {
+            distances[i] = required;
+        }
+    }
+
+    // Build slots with position-based planet seeds.
+    let planets = distances
+        .into_iter()
+        .enumerate()
+        .map(|(i, dist)| {
+            let planet_seed_raw = mix_seed(system_seed.0, dist.to_bits() as u64);
+            OrbitalSlot {
+                planet_seed: PlanetSeed(planet_seed_raw),
+                orbital_distance_au: dist,
+                orbital_index: i as u32,
+            }
+        })
+        .collect();
+
+    OrbitalLayout { planets }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1857,6 +1934,32 @@ weight = 7.0
             assert!(
                 count >= 4 && count <= 6,
                 "seed {i}: planet count {count} outside custom range [4, 6]"
+            );
+        }
+    }
+
+    // ── Orbital Layout Tests ────────────────────────────────────────────
+
+    /// When planet_count_min == planet_count_max, every seed must produce
+    /// a layout with exactly that many planets. This exercises the edge
+    /// case where the lerp range collapses to a single value, ensuring
+    /// both `derive_planet_count` and `derive_orbital_layout` handle it
+    /// without off-by-one or float rounding surprises.
+    #[test]
+    fn orbital_layout_fixed_count_when_min_equals_max() {
+        let config = OrbitalConfig {
+            planet_count_min: 3,
+            planet_count_max: 3,
+            ..OrbitalConfig::default()
+        };
+
+        for i in 0..1_000_u64 {
+            let layout = derive_orbital_layout(SolarSystemSeed(i), &config);
+            assert_eq!(
+                layout.planets.len(),
+                3,
+                "seed {i}: expected exactly 3 planets when min==max==3, got {}",
+                layout.planets.len()
             );
         }
     }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -18,39 +18,115 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+use crate::seed_util::{
+    ORBITAL_LAYOUT_CHANNEL, PLANET_COUNT_CHANNEL, STAR_LUMINOSITY_CHANNEL, STAR_MASS_CHANNEL,
+    STAR_TEMPERATURE_CHANNEL, STAR_TYPE_CHANNEL, f32_next_up, f32_to_u64_bits, lerp, mix_seed,
+    seed_to_unit_f32,
+};
 use crate::world_generation::{PlanetSeed, WorldGenerationConfig};
-
-// ── Seed Channel Constants ───────────────────────────────────────────────
-//
-// Each constant occupies a unique 64-bit value in the `0x57A2_0001` prefix
-// space. The prefix is arbitrary but distinct from all other channel families
-// in the codebase (world_generation uses `0xD3E5_17A1`, biomes use
-// `0xB10E_0001`, etc.). One channel per derived parameter ensures that
-// adding or removing a parameter never shifts the derivation of any other.
-
-/// Channel for selecting the star type via weighted random.
-const STAR_TYPE_CHANNEL: u64 = 0x57A2_0001_0000_0001;
-
-/// Channel for interpolating luminosity within the selected type's range.
-const STAR_LUMINOSITY_CHANNEL: u64 = 0x57A2_0001_0000_0002;
-
-/// Channel for interpolating surface temperature within the selected type's range.
-const STAR_TEMPERATURE_CHANNEL: u64 = 0x57A2_0001_0000_0003;
-
-/// Channel for interpolating stellar mass within the selected type's range.
-const STAR_MASS_CHANNEL: u64 = 0x57A2_0001_0000_0004;
-
-/// Channel for deriving planet count from a system seed.
-const PLANET_COUNT_CHANNEL: u64 = 0x02B1_0001_0000_0001;
-
-/// Channel for seeding the orbital distance RNG.
-const ORBITAL_LAYOUT_CHANNEL: u64 = 0x02B1_0001_0000_0002;
 
 /// Path to the star type definitions TOML file.
 const STAR_TYPES_CONFIG_PATH: &str = "assets/config/star_types.toml";
 
 /// Path to the orbital configuration TOML file.
 const ORBITAL_CONFIG_PATH: &str = "assets/config/orbital_config.toml";
+
+// ── Validation Errors ────────────────────────────────────────────────────
+
+/// Errors produced by [`StarTypeRegistry::validate`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum StarRegistryError {
+    /// Registry contains no star types.
+    Empty,
+    /// A star type definition has an empty key. `index` is 0-based.
+    EmptyKey { index: usize },
+    /// Two star types share the same key.
+    DuplicateKey { index: usize, key: String },
+    /// Weight is not positive and finite.
+    InvalidWeight { label: String, value: f32 },
+    /// Luminosity bounds are invalid (non-finite, non-positive min, or inverted).
+    InvalidLuminosity { label: String, detail: String },
+    /// Temperature bounds are invalid (zero min or inverted).
+    InvalidTemperature { label: String, detail: String },
+    /// Mass bounds are invalid (non-finite, non-positive min, or inverted).
+    InvalidMass { label: String, detail: String },
+}
+
+impl std::fmt::Display for StarRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "StarTypeRegistry must contain at least one star type"),
+            Self::EmptyKey { index } => write!(f, "star_types[{index}]: key must not be empty"),
+            Self::DuplicateKey { index, key } => {
+                write!(f, "star_types[{index}] ('{key}'): duplicate key '{key}'")
+            }
+            Self::InvalidWeight { label, value } => {
+                write!(
+                    f,
+                    "{label}: weight must be positive and finite, got {value}"
+                )
+            }
+            Self::InvalidLuminosity { label, detail } => write!(f, "{label}: {detail}"),
+            Self::InvalidTemperature { label, detail } => write!(f, "{label}: {detail}"),
+            Self::InvalidMass { label, detail } => write!(f, "{label}: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for StarRegistryError {}
+
+/// Errors produced by [`OrbitalConfig::validate`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum OrbitalConfigError {
+    /// `planet_count_min` is less than 1.
+    PlanetCountMinTooLow { value: u32 },
+    /// `planet_count_min` exceeds `planet_count_max`.
+    PlanetCountRangeInverted { min: u32, max: u32 },
+    /// `inner_orbit_au` is not positive or not finite.
+    InvalidInnerOrbit { value: f32 },
+    /// `outer_orbit_au` is not finite.
+    InvalidOuterOrbit { value: f32 },
+    /// `inner_orbit_au >= outer_orbit_au`.
+    OrbitRangeInverted { inner: f32, outer: f32 },
+    /// `min_separation_au` is not positive or not finite.
+    InvalidSeparation { value: f32 },
+}
+
+impl std::fmt::Display for OrbitalConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PlanetCountMinTooLow { value } => {
+                write!(f, "planet_count_min must be >= 1, got {value}")
+            }
+            Self::PlanetCountRangeInverted { min, max } => {
+                write!(
+                    f,
+                    "planet_count_min ({min}) must be <= planet_count_max ({max})"
+                )
+            }
+            Self::InvalidInnerOrbit { value } => {
+                write!(f, "inner_orbit_au must be positive and finite, got {value}")
+            }
+            Self::InvalidOuterOrbit { value } => {
+                write!(f, "outer_orbit_au must be finite, got {value}")
+            }
+            Self::OrbitRangeInverted { inner, outer } => {
+                write!(
+                    f,
+                    "inner_orbit_au ({inner}) must be < outer_orbit_au ({outer})"
+                )
+            }
+            Self::InvalidSeparation { value } => {
+                write!(
+                    f,
+                    "min_separation_au must be positive and finite, got {value}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for OrbitalConfigError {}
 
 // ── Data Types ───────────────────────────────────────────────────────────
 
@@ -160,6 +236,34 @@ pub struct OrbitalLayout {
     pub planets: Vec<OrbitalSlot>,
 }
 
+impl std::fmt::Display for OrbitalLayout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} planets [", self.planets.len())?;
+        for (i, slot) in self.planets.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{:.2} AU", slot.orbital_distance_au)?;
+        }
+        write!(f, "]")
+    }
+}
+
+impl std::fmt::Display for StarProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "type={}, L={:.4} sol, T={}K, M={:.4} Msol, HZ=[{:.2}, {:.2}] AU",
+            self.star_type_key,
+            self.luminosity,
+            self.surface_temperature_k,
+            self.mass_solar,
+            self.habitable_zone_inner_au,
+            self.habitable_zone_outer_au,
+        )
+    }
+}
+
 /// Configuration constraints for orbital generation.
 ///
 /// All tuning values are data-driven — loaded from
@@ -207,42 +311,38 @@ impl OrbitalConfig {
     /// 4. `inner_orbit_au < outer_orbit_au` — range must not be inverted.
     /// 5. `outer_orbit_au` is finite.
     /// 6. `min_separation_au > 0.0` and finite — must be a positive distance.
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), OrbitalConfigError> {
         if self.planet_count_min < 1 {
-            return Err(format!(
-                "planet_count_min must be >= 1, got {}",
-                self.planet_count_min
-            ));
+            return Err(OrbitalConfigError::PlanetCountMinTooLow {
+                value: self.planet_count_min,
+            });
         }
         if self.planet_count_min > self.planet_count_max {
-            return Err(format!(
-                "planet_count_min ({}) must be <= planet_count_max ({})",
-                self.planet_count_min, self.planet_count_max
-            ));
+            return Err(OrbitalConfigError::PlanetCountRangeInverted {
+                min: self.planet_count_min,
+                max: self.planet_count_max,
+            });
         }
         if !self.inner_orbit_au.is_finite() || self.inner_orbit_au <= 0.0 {
-            return Err(format!(
-                "inner_orbit_au must be positive and finite, got {}",
-                self.inner_orbit_au
-            ));
+            return Err(OrbitalConfigError::InvalidInnerOrbit {
+                value: self.inner_orbit_au,
+            });
         }
         if !self.outer_orbit_au.is_finite() {
-            return Err(format!(
-                "outer_orbit_au must be finite, got {}",
-                self.outer_orbit_au
-            ));
+            return Err(OrbitalConfigError::InvalidOuterOrbit {
+                value: self.outer_orbit_au,
+            });
         }
         if self.inner_orbit_au >= self.outer_orbit_au {
-            return Err(format!(
-                "inner_orbit_au ({}) must be < outer_orbit_au ({})",
-                self.inner_orbit_au, self.outer_orbit_au
-            ));
+            return Err(OrbitalConfigError::OrbitRangeInverted {
+                inner: self.inner_orbit_au,
+                outer: self.outer_orbit_au,
+            });
         }
         if !self.min_separation_au.is_finite() || self.min_separation_au <= 0.0 {
-            return Err(format!(
-                "min_separation_au must be positive and finite, got {}",
-                self.min_separation_au
-            ));
+            return Err(OrbitalConfigError::InvalidSeparation {
+                value: self.min_separation_au,
+            });
         }
         Ok(())
     }
@@ -261,9 +361,9 @@ impl StarTypeRegistry {
     /// 5. **Valid luminosity range** — `luminosity_min` must be > 0.0, `luminosity_min < luminosity_max`, both finite.
     /// 6. **Valid temperature range** — `temperature_min` must be > 0, `temperature_min < temperature_max`.
     /// 7. **Valid mass range** — `mass_min` must be > 0.0, `mass_min < mass_max`, both finite.
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), StarRegistryError> {
         if self.star_types.is_empty() {
-            return Err("StarTypeRegistry must contain at least one star type".to_string());
+            return Err(StarRegistryError::Empty);
         }
 
         let mut seen_keys = std::collections::HashSet::new();
@@ -277,72 +377,90 @@ impl StarTypeRegistry {
 
             // Key checks.
             if def.key.is_empty() {
-                return Err(format!("{label}: key must not be empty"));
+                return Err(StarRegistryError::EmptyKey { index: i });
             }
             if !seen_keys.insert(&def.key) {
-                return Err(format!("{label}: duplicate key '{}'", def.key));
+                return Err(StarRegistryError::DuplicateKey {
+                    index: i,
+                    key: def.key.clone(),
+                });
             }
 
             // Weight check.
             if !def.weight.is_finite() || def.weight <= 0.0 {
-                return Err(format!(
-                    "{label}: weight must be positive and finite, got {}",
-                    def.weight
-                ));
+                return Err(StarRegistryError::InvalidWeight {
+                    label,
+                    value: def.weight,
+                });
             }
 
             // Luminosity range.
             if !def.luminosity_min.is_finite() || !def.luminosity_max.is_finite() {
-                return Err(format!(
-                    "{label}: luminosity bounds must be finite, got [{}, {}]",
-                    def.luminosity_min, def.luminosity_max
-                ));
+                return Err(StarRegistryError::InvalidLuminosity {
+                    label,
+                    detail: format!(
+                        "luminosity bounds must be finite, got [{}, {}]",
+                        def.luminosity_min, def.luminosity_max
+                    ),
+                });
             }
             if def.luminosity_min <= 0.0 {
-                return Err(format!(
-                    "{label}: luminosity_min must be > 0.0, got {}",
-                    def.luminosity_min
-                ));
+                return Err(StarRegistryError::InvalidLuminosity {
+                    label,
+                    detail: format!("luminosity_min must be > 0.0, got {}", def.luminosity_min),
+                });
             }
             if def.luminosity_min >= def.luminosity_max {
-                return Err(format!(
-                    "{label}: luminosity_min ({}) must be < luminosity_max ({})",
-                    def.luminosity_min, def.luminosity_max
-                ));
+                return Err(StarRegistryError::InvalidLuminosity {
+                    label,
+                    detail: format!(
+                        "luminosity_min ({}) must be < luminosity_max ({})",
+                        def.luminosity_min, def.luminosity_max
+                    ),
+                });
             }
 
             // Temperature range.
             if def.temperature_min == 0 {
-                return Err(format!(
-                    "{label}: temperature_min must be > 0, got {}",
-                    def.temperature_min
-                ));
+                return Err(StarRegistryError::InvalidTemperature {
+                    label,
+                    detail: format!("temperature_min must be > 0, got {}", def.temperature_min),
+                });
             }
             if def.temperature_min >= def.temperature_max {
-                return Err(format!(
-                    "{label}: temperature_min ({}) must be < temperature_max ({})",
-                    def.temperature_min, def.temperature_max
-                ));
+                return Err(StarRegistryError::InvalidTemperature {
+                    label,
+                    detail: format!(
+                        "temperature_min ({}) must be < temperature_max ({})",
+                        def.temperature_min, def.temperature_max
+                    ),
+                });
             }
 
             // Mass range.
             if !def.mass_min.is_finite() || !def.mass_max.is_finite() {
-                return Err(format!(
-                    "{label}: mass bounds must be finite, got [{}, {}]",
-                    def.mass_min, def.mass_max
-                ));
+                return Err(StarRegistryError::InvalidMass {
+                    label,
+                    detail: format!(
+                        "mass bounds must be finite, got [{}, {}]",
+                        def.mass_min, def.mass_max
+                    ),
+                });
             }
             if def.mass_min <= 0.0 {
-                return Err(format!(
-                    "{label}: mass_min must be > 0.0, got {}",
-                    def.mass_min
-                ));
+                return Err(StarRegistryError::InvalidMass {
+                    label,
+                    detail: format!("mass_min must be > 0.0, got {}", def.mass_min),
+                });
             }
             if def.mass_min >= def.mass_max {
-                return Err(format!(
-                    "{label}: mass_min ({}) must be < mass_max ({})",
-                    def.mass_min, def.mass_max
-                ));
+                return Err(StarRegistryError::InvalidMass {
+                    label,
+                    detail: format!(
+                        "mass_min ({}) must be < mass_max ({})",
+                        def.mass_min, def.mass_max
+                    ),
+                });
             }
         }
 
@@ -550,77 +668,6 @@ fn log_star_profile_on_startup(
 
 // ── Seed Derivation ──────────────────────────────────────────────────────
 
-/// Deterministically mix a base seed and a channel into a new 64-bit value.
-///
-/// This is a SplitMix64-style bit mixer. The algorithm is deterministic, cheap,
-/// and requires no external crate. We are not using it as a cryptographic hash.
-/// We are using it to avalanche nearby integer inputs into well-mixed outputs
-/// so that later generation systems do not accidentally treat "similar number"
-/// as "similar world feature."
-///
-/// Note: This is intentionally a local copy of the same function in
-/// `world_generation`. Each module owns its own copy because the function is
-/// a leaf utility with no state, and sharing it would require either a shared
-/// utility module (architectural change) or `pub` visibility (violates the
-/// no-`pub(crate)` rule). When a shared `seed_util` module is warranted,
-/// these copies can be consolidated.
-fn mix_seed(base: u64, channel: u64) -> u64 {
-    let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^ (z >> 31)
-}
-
-/// Convert a mixed `u64` into a `f32` in `[0.0, 1.0)`.
-///
-/// Takes the lower 32 bits and divides by `2^32`. This gives ~7 decimal
-/// digits of granularity — more than enough for interpolating physical
-/// parameters that will be displayed to the player as rounded values.
-fn seed_to_unit_f32(mixed: u64) -> f32 {
-    (mixed as u32) as f32 / (u32::MAX as f32 + 1.0)
-}
-
-/// Convert an `f32` to a `u64` suitable for seed mixing.
-///
-/// Uses `f32::to_bits` to get the IEEE-754 bit pattern as a `u32`, then
-/// zero-extends to `u64`. This is deterministic and platform-independent for
-/// non-NaN values — the same float always produces the same bits.
-///
-/// Used by orbital layout generation to derive position-based planet seeds:
-/// each planet's seed depends on its orbital distance rather than its index,
-/// so inserting a planet between two existing ones won't change their seeds.
-fn f32_to_u64_bits(value: f32) -> u64 {
-    value.to_bits() as u64
-}
-
-/// Linearly interpolate between `min` and `max` using a `[0, 1)` fraction.
-///
-/// Returns exactly `min` when `t == 0.0` and approaches `max` as `t → 1.0`.
-/// Does not clamp — callers are responsible for providing `t` in range.
-fn lerp(min: f32, max: f32, t: f32) -> f32 {
-    min + (max - min) * t
-}
-
-/// Return the next representable `f32` above `value`.
-///
-/// Used in the separation enforcement loop to guarantee that the gap between
-/// consecutive orbits is never fractionally below `min_separation_au` due to
-/// floating-point addition rounding down.
-///
-/// For positive, finite values this bumps the IEEE 754 significand by one ULP.
-/// Special cases (infinity, NaN) pass through unchanged.
-fn f32_next_up(value: f32) -> f32 {
-    if value.is_nan() || value == f32::INFINITY {
-        return value;
-    }
-    if value == f32::NEG_INFINITY {
-        return f32::MIN;
-    }
-    let bits = value.to_bits();
-    let next_bits = if value >= 0.0 { bits + 1 } else { bits - 1 };
-    f32::from_bits(next_bits)
-}
-
 /// Derive a complete `StarProfile` from a solar system seed and star registry.
 ///
 /// ## Derivation Steps
@@ -748,16 +795,25 @@ pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig)
 
 // ── Orbital Layout Derivation ────────────────────────────────────────────
 
+/// Maximum number of re-draw attempts per planet before giving up.
+///
+/// With a well-sized orbital range this should never be hit. If it is, the
+/// config is pathologically tight (too many planets for the available range)
+/// and the planet gets placed at its last drawn position regardless.
+const MAX_REDRAW_ATTEMPTS: u64 = 100;
+
 /// Derive the full orbital layout for a solar system.
 ///
 /// ## Derivation Steps
 ///
 /// 1. **Planet count** — derived from `mix_seed(system_seed, PLANET_COUNT_CHANNEL)`,
 ///    lerped into the configured `[min, max]` range.
-/// 2. **Orbital distances** — a local RNG seeded from
-///    `mix_seed(system_seed, ORBITAL_LAYOUT_CHANNEL)` draws `N` distances in
-///    `[inner_orbit_au, outer_orbit_au]`, sorts them, and enforces
-///    `min_separation_au` by pushing overlapping orbits outward.
+/// 2. **Orbital distances** — each planet draws a distance from
+///    `[inner_orbit_au, outer_orbit_au]` using a deterministic seed. If the
+///    drawn distance violates `min_separation_au` against any already-placed
+///    planet, a new distance is drawn with a different sub-channel (retry).
+///    This keeps outcomes purely seed-determined without pushing planets to
+///    positions they weren't drawn to.
 /// 3. **Planet seeds** — for each slot, `PlanetSeed(mix_seed(system_seed,
 ///    f32_to_bits_as_u64(distance)))`. This is position-based, not index-based,
 ///    so inserting a planet between two existing ones in a future story will
@@ -765,9 +821,9 @@ pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig)
 ///
 /// ## Panics
 ///
-/// Does not panic. If minimum separation enforcement pushes a planet past
-/// `outer_orbit_au`, it keeps the pushed distance — the alternative (dropping
-/// the planet) would change the count derived from the seed.
+/// Does not panic. If all re-draw attempts fail for a planet (pathologically
+/// tight config), the last drawn distance is used. This preserves the planet
+/// count invariant — we never drop a planet.
 pub fn derive_orbital_layout(
     system_seed: SolarSystemSeed,
     config: &OrbitalConfig,
@@ -783,30 +839,46 @@ pub fn derive_orbital_layout(
     // Seed a deterministic sequence for orbital distances.
     let layout_seed = mix_seed(system_seed.0, ORBITAL_LAYOUT_CHANNEL);
 
-    // Draw N raw distances in [inner, outer] using successive mixes of the
-    // layout seed. Each planet gets its own channel (its 1-based index) so
-    // that adding more planets never changes earlier draws.
-    let mut distances: Vec<f32> = (0..planet_count)
-        .map(|i| {
-            let raw = mix_seed(layout_seed, i as u64 + 1);
+    // Place planets one at a time. For each planet, draw a distance and check
+    // it against all already-placed distances. If it violates min separation,
+    // re-draw with a different sub-channel. The sub-channel is computed as
+    // `(planet_index * MAX_REDRAW_ATTEMPTS) + attempt` to ensure every draw
+    // across all planets and attempts uses a unique channel.
+    let mut distances: Vec<f32> = Vec::with_capacity(planet_count as usize);
+
+    for planet_idx in 0..planet_count {
+        let base_channel = (planet_idx as u64 + 1) * (MAX_REDRAW_ATTEMPTS + 1);
+        let mut best_distance = 0.0_f32;
+
+        for attempt in 0..=MAX_REDRAW_ATTEMPTS {
+            let raw = mix_seed(layout_seed, base_channel + attempt);
             let t = seed_to_unit_f32(raw);
-            lerp(config.inner_orbit_au, config.outer_orbit_au, t)
-        })
-        .collect();
+            let candidate = lerp(config.inner_orbit_au, config.outer_orbit_au, t);
+
+            best_distance = candidate;
+
+            let valid = distances
+                .iter()
+                .all(|&placed| (candidate - placed).abs() >= config.min_separation_au);
+
+            if valid {
+                break;
+            }
+        }
+
+        distances.push(best_distance);
+    }
 
     // Sort innermost-first.
     distances.sort_by(|a, b| a.partial_cmp(b).expect("orbital distances must not be NaN"));
 
-    // Enforce minimum separation by pushing outward. After assignment,
-    // re-read the stored value for the next iteration's comparison to avoid
-    // accumulating f32 rounding error across a chain of pushes.
+    // Safety net: if re-draw couldn't find valid positions for all planets
+    // (pathologically tight config), enforce minimum separation by nudging
+    // outward. This is a fallback, not the primary strategy — well-configured
+    // orbital ranges should resolve during re-draw.
     for i in 1..distances.len() {
         let required = distances[i - 1] + config.min_separation_au;
         if distances[i] < required {
-            // Nudge by one ULP above the exact sum to guarantee the gap
-            // is never fractionally below min_separation_au after the
-            // addition's rounding. f32::EPSILON at magnitude ~50 AU is
-            // ~3.8e-6, well below any meaningful distance.
             distances[i] = f32_next_up(required);
         }
     }
@@ -1114,8 +1186,8 @@ mod tests {
         let registry = StarTypeRegistry { star_types: vec![] };
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("at least one"),
-            "error should mention 'at least one', got: {err}"
+            matches!(err, StarRegistryError::Empty),
+            "expected Empty, got: {err}"
         );
     }
 
@@ -1126,8 +1198,8 @@ mod tests {
         registry.star_types[0].key = String::new();
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("key must not be empty"),
-            "error should mention empty key, got: {err}"
+            matches!(err, StarRegistryError::EmptyKey { .. }),
+            "expected EmptyKey, got: {err}"
         );
     }
 
@@ -1138,8 +1210,8 @@ mod tests {
         registry.star_types[1].key = registry.star_types[0].key.clone();
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("duplicate key"),
-            "error should mention duplicate key, got: {err}"
+            matches!(err, StarRegistryError::DuplicateKey { .. }),
+            "expected DuplicateKey, got: {err}"
         );
     }
 
@@ -1150,8 +1222,8 @@ mod tests {
         registry.star_types[0].weight = 0.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("weight"),
-            "error should mention weight, got: {err}"
+            matches!(err, StarRegistryError::InvalidWeight { .. }),
+            "expected InvalidWeight, got: {err}"
         );
     }
 
@@ -1162,8 +1234,8 @@ mod tests {
         registry.star_types[0].weight = -1.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("weight"),
-            "error should mention weight, got: {err}"
+            matches!(err, StarRegistryError::InvalidWeight { .. }),
+            "expected InvalidWeight, got: {err}"
         );
     }
 
@@ -1174,8 +1246,8 @@ mod tests {
         registry.star_types[0].weight = f32::NAN;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("weight"),
-            "error should mention weight, got: {err}"
+            matches!(err, StarRegistryError::InvalidWeight { .. }),
+            "expected InvalidWeight, got: {err}"
         );
     }
 
@@ -1187,8 +1259,8 @@ mod tests {
         registry.star_types[0].luminosity_max = 1.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("luminosity_min"),
-            "error should mention luminosity_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidLuminosity { .. }),
+            "expected InvalidLuminosity, got: {err}"
         );
     }
 
@@ -1199,8 +1271,8 @@ mod tests {
         registry.star_types[0].luminosity_min = 0.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("luminosity_min"),
-            "error should mention luminosity_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidLuminosity { .. }),
+            "expected InvalidLuminosity, got: {err}"
         );
     }
 
@@ -1212,8 +1284,8 @@ mod tests {
         registry.star_types[0].temperature_max = 1000;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("temperature_min"),
-            "error should mention temperature_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidTemperature { .. }),
+            "expected InvalidTemperature, got: {err}"
         );
     }
 
@@ -1224,8 +1296,8 @@ mod tests {
         registry.star_types[0].temperature_min = 0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("temperature_min"),
-            "error should mention temperature_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidTemperature { .. }),
+            "expected InvalidTemperature, got: {err}"
         );
     }
 
@@ -1237,8 +1309,8 @@ mod tests {
         registry.star_types[0].mass_max = 1.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("mass_min"),
-            "error should mention mass_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidMass { .. }),
+            "expected InvalidMass, got: {err}"
         );
     }
 
@@ -1249,8 +1321,8 @@ mod tests {
         registry.star_types[0].mass_min = 0.0;
         let err = registry.validate().unwrap_err();
         assert!(
-            err.contains("mass_min"),
-            "error should mention mass_min, got: {err}"
+            matches!(err, StarRegistryError::InvalidMass { .. }),
+            "expected InvalidMass, got: {err}"
         );
     }
 
@@ -1378,8 +1450,8 @@ weight = -3.0
                     .validate()
                     .expect_err("empty registry must fail validation");
                 assert!(
-                    err.contains("at least one"),
-                    "error should mention 'at least one', got: {err}"
+                    matches!(err, StarRegistryError::Empty),
+                    "expected Empty, got: {err}"
                 );
             }
         }
@@ -1649,8 +1721,8 @@ weight = 7.0
         config.planet_count_min = 0;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("planet_count_min"),
-            "error should mention planet_count_min, got: {err}"
+            matches!(err, OrbitalConfigError::PlanetCountMinTooLow { .. }),
+            "expected PlanetCountMinTooLow, got: {err}"
         );
     }
 
@@ -1662,8 +1734,8 @@ weight = 7.0
         config.planet_count_max = 3;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("planet_count_min"),
-            "error should mention planet_count_min, got: {err}"
+            matches!(err, OrbitalConfigError::PlanetCountRangeInverted { .. }),
+            "expected PlanetCountRangeInverted, got: {err}"
         );
     }
 
@@ -1674,8 +1746,8 @@ weight = 7.0
         config.inner_orbit_au = 0.0;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("inner_orbit_au"),
-            "error should mention inner_orbit_au, got: {err}"
+            matches!(err, OrbitalConfigError::InvalidInnerOrbit { .. }),
+            "expected InvalidInnerOrbit, got: {err}"
         );
     }
 
@@ -1687,8 +1759,8 @@ weight = 7.0
         config.outer_orbit_au = 10.0;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("inner_orbit_au"),
-            "error should mention inner_orbit_au, got: {err}"
+            matches!(err, OrbitalConfigError::OrbitRangeInverted { .. }),
+            "expected OrbitRangeInverted, got: {err}"
         );
     }
 
@@ -1699,8 +1771,8 @@ weight = 7.0
         config.min_separation_au = 0.0;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("min_separation_au"),
-            "error should mention min_separation_au, got: {err}"
+            matches!(err, OrbitalConfigError::InvalidSeparation { .. }),
+            "expected InvalidSeparation, got: {err}"
         );
     }
 
@@ -1711,8 +1783,8 @@ weight = 7.0
         config.outer_orbit_au = f32::NAN;
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("outer_orbit_au"),
-            "error should mention outer_orbit_au, got: {err}"
+            matches!(err, OrbitalConfigError::InvalidOuterOrbit { .. }),
+            "expected InvalidOuterOrbit, got: {err}"
         );
     }
 

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -585,6 +585,26 @@ fn lerp(min: f32, max: f32, t: f32) -> f32 {
     min + (max - min) * t
 }
 
+/// Return the next representable `f32` above `value`.
+///
+/// Used in the separation enforcement loop to guarantee that the gap between
+/// consecutive orbits is never fractionally below `min_separation_au` due to
+/// floating-point addition rounding down.
+///
+/// For positive, finite values this bumps the IEEE 754 significand by one ULP.
+/// Special cases (infinity, NaN) pass through unchanged.
+fn f32_next_up(value: f32) -> f32 {
+    if value.is_nan() || value == f32::INFINITY {
+        return value;
+    }
+    if value == f32::NEG_INFINITY {
+        return f32::MIN;
+    }
+    let bits = value.to_bits();
+    let next_bits = if value >= 0.0 { bits + 1 } else { bits - 1 };
+    f32::from_bits(next_bits)
+}
+
 /// Derive a complete `StarProfile` from a solar system seed and star registry.
 ///
 /// ## Derivation Steps
@@ -763,11 +783,17 @@ pub fn derive_orbital_layout(
     // Sort innermost-first.
     distances.sort_by(|a, b| a.partial_cmp(b).expect("orbital distances must not be NaN"));
 
-    // Enforce minimum separation by pushing outward.
+    // Enforce minimum separation by pushing outward. After assignment,
+    // re-read the stored value for the next iteration's comparison to avoid
+    // accumulating f32 rounding error across a chain of pushes.
     for i in 1..distances.len() {
         let required = distances[i - 1] + config.min_separation_au;
         if distances[i] < required {
-            distances[i] = required;
+            // Nudge by one ULP above the exact sum to guarantee the gap
+            // is never fractionally below min_separation_au after the
+            // addition's rounding. f32::EPSILON at magnitude ~50 AU is
+            // ~3.8e-6, well below any meaningful distance.
+            distances[i] = f32_next_up(required);
         }
     }
 

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -1927,6 +1927,37 @@ weight = 7.0
         );
     }
 
+    /// Even a small sample of 10 seeds should produce at least 2 distinct
+    /// planet counts with default config [2, 8]. This validates that the
+    /// derivation feels varied at human-observable scale — a player
+    /// visiting a handful of systems should encounter different planet
+    /// counts, not the same number every time.
+    #[test]
+    fn planet_count_feels_varied_small_sample() {
+        let config = OrbitalConfig::default();
+        let seeds: [u64; 10] = [1, 2, 3, 42, 100, 999, 7777, 123_456, 0xCAFE, 0xBEEF];
+        let mut seen = std::collections::HashSet::new();
+
+        for &s in &seeds {
+            let count = derive_planet_count(SolarSystemSeed(s), &config);
+            // Every count must be in range regardless.
+            assert!(
+                count >= config.planet_count_min && count <= config.planet_count_max,
+                "seed {s}: planet count {count} outside [{}, {}]",
+                config.planet_count_min,
+                config.planet_count_max,
+            );
+            seen.insert(count);
+        }
+
+        assert!(
+            seen.len() >= 2,
+            "expected at least 2 distinct planet counts from 10 seeds, got {}: {:?}",
+            seen.len(),
+            seen,
+        );
+    }
+
     /// Both min and max planet counts must be reachable. With 10,000 seeds
     /// and a well-mixed derivation, both endpoints should appear.
     #[test]

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -2600,4 +2600,176 @@ weight = 7.0
             "upper 32 bits must be zero even for negative floats",
         );
     }
+
+    // ── Full Pipeline Tests ─────────────────────────────────────────────
+    //
+    // Phase 5: end-to-end determinism — a single system seed produces a
+    // star profile AND an orbital layout, and the entire result is stable
+    // across repeated invocations.
+
+    /// Full pipeline determinism: same system seed + same configs = identical
+    /// star profile AND identical orbital layout. This is the capstone test
+    /// verifying that the entire generation pipeline — star type selection,
+    /// parameter interpolation, planet count derivation, orbital distance
+    /// placement, separation enforcement, and position-based planet seed
+    /// derivation — is fully deterministic end-to-end.
+    #[test]
+    fn full_pipeline_deterministic() {
+        let seed = SolarSystemSeed(0xF011_0000_DEAD_BEEF);
+        let registry = test_registry();
+        let orbital_config = OrbitalConfig::default();
+
+        // Run the full pipeline twice.
+        let star_a = derive_star_profile(seed, &registry);
+        let layout_a = derive_orbital_layout(seed, &orbital_config);
+
+        let star_b = derive_star_profile(seed, &registry);
+        let layout_b = derive_orbital_layout(seed, &orbital_config);
+
+        assert_eq!(star_a, star_b, "star profile must be deterministic");
+        assert_eq!(layout_a, layout_b, "orbital layout must be deterministic");
+    }
+
+    /// Full pipeline coherence: the star profile and orbital layout derived
+    /// from the same system seed must form a physically coherent system.
+    /// Specifically:
+    /// - Planet count is within the configured range.
+    /// - All orbital distances are sorted and separated.
+    /// - Star parameters are within their type's defined ranges.
+    /// - Planet seeds are all unique within the system.
+    /// - The pipeline produces consistent results across many seeds.
+    #[test]
+    fn full_pipeline_coherence_across_seeds() {
+        let registry = test_registry();
+        let orbital_config = OrbitalConfig::default();
+
+        for i in 0..1_000_u64 {
+            let seed = SolarSystemSeed(i);
+
+            // ── Star derivation ──────────────────────────────────────
+            let star = derive_star_profile(seed, &registry);
+
+            let star_type = registry
+                .star_types
+                .iter()
+                .find(|st| st.key == star.star_type_key)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "seed {i}: star_type_key '{}' not found in registry",
+                        star.star_type_key
+                    )
+                });
+
+            assert!(
+                star.luminosity >= star_type.luminosity_min
+                    && star.luminosity <= star_type.luminosity_max,
+                "seed {i}: luminosity {} outside [{}, {}]",
+                star.luminosity,
+                star_type.luminosity_min,
+                star_type.luminosity_max,
+            );
+            assert!(
+                star.mass_solar >= star_type.mass_min && star.mass_solar <= star_type.mass_max,
+                "seed {i}: mass {} outside [{}, {}]",
+                star.mass_solar,
+                star_type.mass_min,
+                star_type.mass_max,
+            );
+            assert!(
+                star.habitable_zone_inner_au < star.habitable_zone_outer_au,
+                "seed {i}: habitable zone inner ({}) >= outer ({})",
+                star.habitable_zone_inner_au,
+                star.habitable_zone_outer_au,
+            );
+
+            // ── Orbital layout derivation ────────────────────────────
+            let layout = derive_orbital_layout(seed, &orbital_config);
+
+            // Planet count within range.
+            let count = layout.planets.len() as u32;
+            assert!(
+                count >= orbital_config.planet_count_min
+                    && count <= orbital_config.planet_count_max,
+                "seed {i}: planet count {count} outside [{}, {}]",
+                orbital_config.planet_count_min,
+                orbital_config.planet_count_max,
+            );
+
+            // Distances sorted ascending.
+            for pair in layout.planets.windows(2) {
+                assert!(
+                    pair[0].orbital_distance_au <= pair[1].orbital_distance_au,
+                    "seed {i}: distances not sorted: {} > {}",
+                    pair[0].orbital_distance_au,
+                    pair[1].orbital_distance_au,
+                );
+            }
+
+            // Minimum separation enforced.
+            for pair in layout.planets.windows(2) {
+                let gap = pair[1].orbital_distance_au - pair[0].orbital_distance_au;
+                assert!(
+                    gap >= orbital_config.min_separation_au - f32::EPSILON,
+                    "seed {i}: separation {gap} AU < min {} AU",
+                    orbital_config.min_separation_au,
+                );
+            }
+
+            // All planet seeds unique within this system.
+            let mut seen_seeds = std::collections::HashSet::new();
+            for slot in &layout.planets {
+                assert!(
+                    seen_seeds.insert(slot.planet_seed.0),
+                    "seed {i}: duplicate planet seed {:#018X}",
+                    slot.planet_seed.0,
+                );
+            }
+
+            // Orbital indices sequential.
+            for (idx, slot) in layout.planets.iter().enumerate() {
+                assert_eq!(
+                    slot.orbital_index, idx as u32,
+                    "seed {i}: orbital_index mismatch at position {idx}",
+                );
+            }
+        }
+    }
+
+    /// Full pipeline: re-deriving the same system 10 times produces bitwise-
+    /// identical results every time, for multiple distinct seeds. This guards
+    /// against subtle non-determinism (e.g., HashMap iteration order, float
+    /// accumulation drift, or accidental use of thread-local state).
+    #[test]
+    fn full_pipeline_repeated_derivation_stable() {
+        let registry = test_registry();
+        let orbital_config = OrbitalConfig::default();
+        let test_seeds = [
+            SolarSystemSeed(0),
+            SolarSystemSeed(1),
+            SolarSystemSeed(u64::MAX),
+            SolarSystemSeed(0xDEAD_BEEF_CAFE_BABE),
+            SolarSystemSeed(42),
+        ];
+
+        for seed in test_seeds {
+            let star_ref = derive_star_profile(seed, &registry);
+            let layout_ref = derive_orbital_layout(seed, &orbital_config);
+
+            for attempt in 1..=10 {
+                let star = derive_star_profile(seed, &registry);
+                let layout = derive_orbital_layout(seed, &orbital_config);
+
+                assert_eq!(
+                    star_ref, star,
+                    "seed {}: star profile diverged on attempt {attempt}",
+                    seed.0,
+                );
+                assert_eq!(
+                    layout_ref, layout,
+                    "seed {}: orbital layout diverged on attempt {attempt}",
+                    seed.0,
+                );
+            }
+        }
+    }
 }

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -1830,6 +1830,19 @@ weight = 7.0
         );
     }
 
+    /// Same seed + same config = identical planet count. This is the
+    /// fundamental determinism guarantee for orbital layout generation.
+    #[test]
+    fn determinism_same_seed_same_planet_count() {
+        let config = OrbitalConfig::default();
+        let seed = SolarSystemSeed(0xDEAD_BEEF_CAFE_BABE);
+
+        let count_a = derive_planet_count(seed, &config);
+        let count_b = derive_planet_count(seed, &config);
+
+        assert_eq!(count_a, count_b, "same seed must produce same planet count");
+    }
+
     /// Planet count respects a custom narrower range.
     #[test]
     fn planet_count_respects_custom_range() {

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -1,14 +1,17 @@
-//! Solar system generation — deterministic star derivation from a system seed.
+//! Solar system generation — deterministic star and orbital layout derivation from a system seed.
 //!
 //! This module provides the data types and derivation logic for generating
-//! star profiles from a solar system seed. Every parameter is derived via
-//! `mix_seed(system_seed, channel_constant)` — one mix per parameter, no
-//! shared draw order — so the same seed always produces the same star
-//! regardless of call site or future parameter additions.
+//! star profiles and orbital layouts from a solar system seed. Every parameter
+//! is derived via `mix_seed(system_seed, channel_constant)` — one mix per
+//! parameter, no shared draw order — so the same seed always produces the
+//! same star and orbital layout regardless of call site or future parameter
+//! additions.
 //!
 //! Star type definitions are data-driven, loaded from
-//! `assets/config/star_types.toml` at startup. The derivation is pure data —
-//! no rendering, no ECS components, no visual representation.
+//! `assets/config/star_types.toml` at startup. Orbital constraints are
+//! data-driven, loaded from `assets/config/orbital_config.toml` at startup.
+//! All derivation is pure data — no rendering, no ECS components, no visual
+//! representation.
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -38,11 +41,9 @@ const STAR_TEMPERATURE_CHANNEL: u64 = 0x57A2_0001_0000_0003;
 const STAR_MASS_CHANNEL: u64 = 0x57A2_0001_0000_0004;
 
 /// Channel for deriving planet count from a system seed.
-#[allow(dead_code)]
 const PLANET_COUNT_CHANNEL: u64 = 0x02B1_0001_0000_0001;
 
 /// Channel for seeding the orbital distance RNG.
-#[allow(dead_code)]
 const ORBITAL_LAYOUT_CHANNEL: u64 = 0x02B1_0001_0000_0002;
 
 /// Path to the star type definitions TOML file.
@@ -139,7 +140,6 @@ pub struct StarTypeRegistry {
 /// (not the index), so inserting a planet between two existing ones in a
 /// future story will not change their seeds.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[allow(dead_code)]
 pub struct OrbitalSlot {
     /// Deterministic seed for this planet, derived from system seed and orbital distance.
     pub planet_seed: PlanetSeed,
@@ -155,7 +155,6 @@ pub struct OrbitalSlot {
 /// the star outward. Deterministically derived from a `SolarSystemSeed`
 /// and an `OrbitalConfig`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[allow(dead_code)]
 pub struct OrbitalLayout {
     /// Planets sorted by orbital distance, innermost first.
     pub planets: Vec<OrbitalSlot>,
@@ -501,19 +500,21 @@ fn load_orbital_config(mut commands: Commands) {
     commands.insert_resource(config);
 }
 
-/// Derive and log the star profile for the current solar system on startup.
+/// Derive and log the star profile and orbital layout on startup.
 ///
-/// Runs in `Startup` (after `PreStartup` has loaded both the
-/// `WorldGenerationConfig` and `StarTypeRegistry`). Reads the `system_seed`
-/// from the world generation config, derives a `StarProfile`, and logs every
-/// parameter at `info!` level so developers can verify the values look
-/// physically plausible (e.g., red dwarf → low luminosity, blue giant → high
-/// temperature).
+/// Runs in `Startup` (after `PreStartup` has loaded the
+/// `WorldGenerationConfig`, `StarTypeRegistry`, and `OrbitalConfig`).
+/// Reads the `system_seed` from the world generation config, derives a
+/// `StarProfile` and `OrbitalLayout`, and logs every parameter at `info!`
+/// level so developers can verify the values look physically plausible
+/// (e.g., red dwarf → low luminosity, blue giant → high temperature,
+/// planets spaced with minimum separation).
 ///
 /// This system is read-only — it does not insert or mutate any resources.
 fn log_star_profile_on_startup(
     world_config: Res<WorldGenerationConfig>,
     star_registry: Res<StarTypeRegistry>,
+    orbital_config: Res<OrbitalConfig>,
 ) {
     let seed = SolarSystemSeed(world_config.system_seed);
     let profile = derive_star_profile(seed, &star_registry);
@@ -530,6 +531,21 @@ fn log_star_profile_on_startup(
         profile.habitable_zone_inner_au,
         profile.habitable_zone_outer_au,
     );
+
+    let layout = derive_orbital_layout(seed, &orbital_config);
+
+    info!(
+        "Orbital layout derived from system seed {}: {} planets",
+        seed.0,
+        layout.planets.len(),
+    );
+
+    for slot in &layout.planets {
+        info!(
+            "  Planet {}: distance={:.4} AU, seed={:#018X}",
+            slot.orbital_index, slot.orbital_distance_au, slot.planet_seed.0,
+        );
+    }
 }
 
 // ── Seed Derivation ──────────────────────────────────────────────────────
@@ -714,7 +730,6 @@ pub fn derive_star_profile(
 /// close to 1.0 producing a value above `planet_count_max` after the `+ 1`
 /// trick). The clamp is a safety net — under normal operation, the lerp +
 /// floor already produces values in range.
-#[allow(dead_code)]
 pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig) -> u32 {
     let raw = mix_seed(system_seed.0, PLANET_COUNT_CHANNEL);
     let t = seed_to_unit_f32(raw);
@@ -753,7 +768,6 @@ pub fn derive_planet_count(system_seed: SolarSystemSeed, config: &OrbitalConfig)
 /// Does not panic. If minimum separation enforcement pushes a planet past
 /// `outer_orbit_au`, it keeps the pushed distance — the alternative (dropping
 /// the planet) would change the count derived from the seed.
-#[allow(dead_code)]
 pub fn derive_orbital_layout(
     system_seed: SolarSystemSeed,
     config: &OrbitalConfig,

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -40,6 +40,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::player::Player;
 use crate::scene::PositionXZ;
+use crate::seed_util::{
+    BIOME_CLIMATE_CHANNEL, ELEVATION_CHANNEL, ELEVATION_DETAIL_CHANNEL, OBJECT_IDENTITY_CHANNEL,
+    PLACEMENT_DENSITY_CHANNEL, PLACEMENT_VARIATION_CHANNEL, PLANET_SURFACE_RADIUS_CHANNEL,
+    mix_seed,
+};
 
 // ── Surface Query Abstraction (Story 5.3) ────────────────────────────────
 //
@@ -723,30 +728,6 @@ pub fn generate_chunk_heightmap_mesh(
 }
 
 const CONFIG_PATH: &str = "assets/config/world_generation.toml";
-const PLACEMENT_DENSITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0001;
-const PLACEMENT_VARIATION_CHANNEL: u64 = 0xD3E5_17A1_0000_0002;
-const OBJECT_IDENTITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0003;
-/// Channel constant for deriving the planet surface radius from the planet seed.
-///
-/// The planet surface radius (measured in chunks) determines how large the
-/// planet is. It is derived deterministically from the planet seed so that
-/// each planet has a consistent, reproducible size.
-const PLANET_SURFACE_RADIUS_CHANNEL: u64 = 0xD3E5_17A1_0000_0004;
-/// Channel constant for deriving the biome climate seed from the planet seed.
-///
-/// The biome climate seed is mixed with sub-channel constants (temperature and
-/// moisture) to produce two independent coherent noise fields that together
-/// determine the biome at each chunk position.
-const BIOME_CLIMATE_CHANNEL: u64 = 0xD3E5_17A1_0000_0005;
-/// Channel constant for deriving the elevation seed from the planet seed.
-///
-/// The elevation seed drives multi-octave value noise that produces terrain
-/// height variation across the planet surface.
-const ELEVATION_CHANNEL: u64 = 0xE1EF_0001_0000_0001;
-/// Sub-channel for chunk-level detail noise layered on top of the base
-/// elevation field. Derived from the elevation seed (not the planet seed)
-/// so it is guaranteed independent of the base octaves.
-const ELEVATION_DETAIL_CHANNEL: u64 = 0xE1EF_0001_0000_0002;
 
 pub struct WorldGenerationPlugin;
 
@@ -1285,20 +1266,6 @@ pub fn derive_chunk_generation_key(
         placement_variation_key: mix_seed(profile.placement_variation_seed, chunk_mixer),
         object_identity_key: mix_seed(profile.object_identity_seed, chunk_mixer),
     }
-}
-
-/// Deterministically mix a base seed and a channel into a new 64-bit value.
-///
-/// This is a SplitMix64-style bit mixer. The algorithm is deterministic, cheap,
-/// and requires no external crate. We are not using it as a cryptographic hash.
-/// We are using it to avalanche nearby integer inputs into well-mixed outputs
-/// so that later generation systems do not accidentally treat "similar number"
-/// as "similar world feature."
-fn mix_seed(base: u64, channel: u64) -> u64 {
-    let mut z = base.wrapping_add(channel.wrapping_mul(0x9E37_79B9_7F4A_7C15));
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^ (z >> 31)
 }
 
 /// Pack the signed chunk coordinate into a deterministic mixer input.

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -58,6 +58,7 @@ use crate::carry::InCarry;
 use crate::interaction::HeldItem;
 use crate::materials::{GameMaterial, MaterialCatalog, MaterialObject};
 use crate::scene::{ExteriorGroundPatch, PositionXZ, RectXZ};
+use crate::seed_util::lerp;
 
 const DEPOSIT_CONFIG_PATH: &str = "assets/exterior/surface_mineral_deposits.toml";
 const SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION: u32 = 1;
@@ -1406,10 +1407,6 @@ fn signed_unit_interval(value: u64) -> f32 {
 
 fn smoothstep(t: f32) -> f32 {
     t * t * (3.0 - 2.0 * t)
-}
-
-fn lerp(a: f32, b: f32, t: f32) -> f32 {
-    a + (b - a) * t
 }
 
 // ── Story 5.6: Delta-Sync Architecture Validation ───────────────────────


### PR DESCRIPTION
## Summary
- `OrbitalSlot`, `OrbitalLayout`, `OrbitalConfig` data types
- Planet count derivation from system seed within configurable [min, max] range
- Orbital distance generation with minimum separation enforcement
- Position-based planet seed derivation (stable when planet count changes)
- `derive_orbital_layout()` full pipeline with determinism guarantees
- Tests: sorting, separation, range bounds, position stability, edge cases

Closes #305