### PR TITLE
fix: add explanatory comments to all lint suppression attributes

### DIFF
--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -390,6 +390,7 @@ fn clear_output_slot_reference(slot: &mut OutputSlot, entity: Entity) {
     }
 }
 
+// Bevy system — parameter count is driven by ECS query requirements, not design smell.
 #[allow(clippy::too_many_arguments)]
 fn process_place(
     mut commands: Commands,

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -41,6 +41,7 @@ pub enum ConfidenceLevel {
 }
 
 impl ConfidenceLevel {
+    // Will be used when observation-count UI is wired up; keeping the API ready.
     #[allow(dead_code)]
     pub fn from_count(count: u32) -> Self {
         match count {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -116,6 +116,7 @@ impl RoomShellCollision {
 #[derive(Resource, Clone, Debug)]
 pub struct ExteriorGroundPatch {
     pub bounds_xz: RectXZ,
+    // Reserved for future terrain-height queries; not yet read but stored at construction.
     #[expect(dead_code)]
     pub surface_y: f32,
 }
@@ -620,6 +621,7 @@ pub fn build_room_shell_collision(
     }
 }
 
+// Bevy system — parameter count is driven by ECS query requirements, not design smell.
 #[allow(clippy::too_many_arguments)]
 fn setup_scene(
     mut commands: Commands,

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -490,6 +490,7 @@ fn load_surface_mineral_deposit_catalog(mut commands: Commands) {
     commands.insert_resource(catalog);
 }
 
+// Bevy system — parameter count is driven by ECS query requirements, not design smell.
 #[allow(clippy::too_many_arguments)]
 fn sync_active_exterior_chunks(
     mut commands: Commands,
@@ -719,6 +720,7 @@ fn sync_active_exterior_chunks(
     }
 }
 
+// Bevy system — the Query tuple is wide because we need all components for re-parenting.
 #[allow(clippy::type_complexity)]
 fn release_collected_generated_objects(
     mut commands: Commands,
@@ -772,6 +774,7 @@ fn release_collected_generated_objects(
 ///
 /// If the player drops the object again later, `claim_exterior_drops` will
 /// create a fresh record — possibly in a different chunk.
+// Bevy system — same wide-query pattern as release_collected_generated_objects.
 #[allow(clippy::type_complexity)]
 fn release_collected_player_added_objects(
     mut commands: Commands,
@@ -823,6 +826,7 @@ fn release_collected_player_added_objects(
 /// were dropped in a previous frame but not yet claimed (e.g. if claim ran
 /// before process_place). A query-based approach is more robust: it catches
 /// any unclaimed exterior object regardless of when it appeared.
+// Bevy system — query tuple is wide to match any unclaimed exterior object.
 #[allow(clippy::type_complexity)]
 fn claim_exterior_drops(
     mut commands: Commands,


### PR DESCRIPTION
## Summary
- Adds explanatory comments above all 8 `#[allow(...)]` / `#[expect(...)]` attributes that were missing them, fixing the CI lint-suppression-guard check.
- Bevy system parameter counts and wide query tuples are inherent to ECS design; `dead_code` items are reserved for upcoming features.

Closes no issue — this is a CI hygiene fix.