### PR TITLE
fix: architectural review findings from PRs #322 and #323

### DIFF
--- a/src/debug_overlay.rs
+++ b/src/debug_overlay.rs
@@ -55,11 +55,14 @@ fn spawn_debug_panel(mut commands: Commands) {
 fn update_debug_panel(
     player_query: Query<&Transform, With<Player>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     mut text_query: Query<&mut Text, With<DebugText>>,
 ) {
     let Ok(player_tf) = player_query.single() else {
+        return;
+    };
+    let Some(world_profile) = world_profile else {
         return;
     };
     let Ok(mut text) = text_query.single_mut() else {

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -402,11 +402,14 @@ fn process_place(
     material_positions: Query<(Entity, &GlobalTransform, &GameMaterial), With<MaterialObject>>,
     slot_target: Res<SlotTarget>,
     mut slot_query: Query<(&GlobalTransform, &mut InputSlot)>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
     scene: Res<PlayerSceneConfig>,
 ) {
+    let Some(world_profile) = world_profile else {
+        return;
+    };
     for _intent in reader.read() {
         let Some((held_entity, held_material)) = held_query.iter().next() else {
             continue;
@@ -1092,7 +1095,7 @@ mod tests {
             .insert_resource(InteractionTarget::default())
             .insert_resource(SlotTarget::default())
             .insert_resource(SceneConfig::default())
-            .insert_resource(WorldProfile::default())
+            .insert_resource(WorldProfile::from_config(&WorldGenerationConfig::default()).unwrap())
             .insert_resource(WorldGenerationConfig::default())
             .insert_resource(crate::surface::SurfaceOverrideRegistry::default())
             .insert_resource(PlayerSceneConfig::default())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,25 +5,44 @@
 //! in `tests/` can construct headless [`bevy::app::App`] instances and
 //! exercise real system chains without a window or GPU.
 
+#![warn(missing_docs)]
+
 use bevy::prelude::*;
 
+#[allow(missing_docs)]
 pub mod carry;
+#[allow(missing_docs)]
 pub mod carry_feedback;
+#[allow(missing_docs)]
 pub mod combination;
+#[allow(missing_docs)]
 pub mod debug_overlay;
+#[allow(missing_docs)]
 pub mod fabricator;
+#[allow(missing_docs)]
 pub mod heat;
+#[allow(missing_docs)]
 pub mod input;
+#[allow(missing_docs)]
 pub mod interaction;
+#[allow(missing_docs)]
 pub mod journal;
+#[allow(missing_docs)]
 pub mod materials;
+#[allow(missing_docs)]
 pub mod naming;
+#[allow(missing_docs)]
 pub mod observation;
+#[allow(missing_docs)]
 pub mod player;
+#[allow(missing_docs)]
 pub mod scene;
 pub mod seed_util;
+#[allow(missing_docs)]
 pub mod solar_system;
+#[allow(missing_docs)]
 pub mod surface;
+#[allow(missing_docs)]
 pub mod world_generation;
 
 /// Registers every game plugin onto the given [`App`].
@@ -32,21 +51,38 @@ pub mod world_generation;
 /// and the integration-test harness call through here so they can never
 /// drift apart.
 pub fn add_game_plugins(app: &mut App) {
+    // Scene setup: enclosed room, furniture markers, lighting (see scene.toml).
     app.add_plugins(scene::ScenePlugin)
+        // Surface override registry: walkable surfaces layered on terrain.
         .init_resource::<surface::SurfaceOverrideRegistry>()
+        // Player: entity hierarchy with camera, movement, stamina.
         .add_plugins(player::PlayerPlugin)
+        // Carry: config + player carry state foundation for Epic 4.
         .add_plugins(carry::CarryPlugin)
+        // Carry feedback: subtle bob / audio cues driven by current encumbrance.
         .add_plugins(carry_feedback::CarryFeedbackPlugin)
+        // Input: loads TOML config, maps raw inputs to named actions via leafwing.
         .add_plugins(input::InputPlugin)
+        // Materials: data-driven material definitions with observable/hidden properties.
         .add_plugins(materials::MaterialPlugin)
+        // Exterior generation: deterministic baseline surface mineral deposits per active chunk.
         .add_plugins(world_generation::exterior::ExteriorGenerationPlugin)
+        // Interaction: raycast, pickup/place, crosshair UI.
         .add_plugins(interaction::InteractionPlugin)
+        // Heat: burner on workbench, thermal exposure → property revelation.
         .add_plugins(heat::HeatPlugin)
+        // Fabricator: input/output slots on the workbench for material combination.
         .add_plugins(fabricator::FabricatorPlugin)
+        // Combination: data-driven rules for material pair outcomes.
         .add_plugins(combination::CombinationPlugin)
+        // Observation: confidence tracking for player knowledge.
         .add_plugins(observation::ObservationPlugin)
+        // Journal: player-owned record of observations and fabrication history.
         .add_plugins(journal::JournalPlugin)
+        // Solar system: deterministic star/orbital/planet derivation from system seed.
         .add_plugins(solar_system::SolarSystemPlugin)
+        // World generation: deterministic planet/chunk identity foundation for exterior systems.
         .add_plugins(world_generation::WorldGenerationPlugin)
+        // Debug: terrain diagnostic overlay (temporary — remove before shipping).
         .add_plugins(debug_overlay::DebugOverlayPlugin);
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -102,10 +102,14 @@ pub fn spawn_player(
     mut commands: Commands,
     scene: Res<PlayerSceneConfig>,
     carry_movement: Res<CarryMovementState>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
 ) {
+    let Some(world_profile) = world_profile else {
+        error!("WorldProfile resource not available — cannot spawn player.");
+        return;
+    };
     let surface = PlanetSurface::new_from_profile(&world_profile, &world_gen_config);
     let terrain_y = surface.sample_elevation(scene.spawn_x, scene.spawn_z);
     let standing_y = crate::surface::resolve_standing_surface(
@@ -206,7 +210,7 @@ fn player_move(
     scene: Res<PlayerSceneConfig>,
     room_shell: Res<RoomShellCollision>,
     carry_movement: Res<CarryMovementState>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
     mut player_query: Query<
@@ -217,6 +221,9 @@ fn player_move(
     if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
+    let Some(world_profile) = world_profile else {
+        return;
+    };
 
     let Ok((action_state, mut transform, mut stamina)) = player_query.single_mut() else {
         return;

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -13,6 +13,7 @@
 //! All derivation is pure data — no rendering, no ECS components, no visual
 //! representation.
 
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -986,6 +987,20 @@ fn log_star_profile_on_startup(
     }
 }
 
+/// Bundled read-only access to the three solar-system registries that both
+/// `resolve_system_derived_profile` and `derive_and_insert_planet_environment`
+/// need.  Using a `SystemParam` keeps both system function signatures within
+/// the 4-parameter limit mandated by the architecture rules.
+#[derive(SystemParam)]
+pub struct SolarSystemRegistries<'w> {
+    /// Star type definitions loaded from `assets/config/star_types.toml`.
+    pub star_registry: Res<'w, StarTypeRegistry>,
+    /// Orbital layout constraints (planet count, orbit range, separation).
+    pub orbital_config: Res<'w, OrbitalConfig>,
+    /// Planet environment derivation parameters (temperature, gravity, atmosphere).
+    pub env_config: Res<'w, PlanetEnvironmentConfig>,
+}
+
 /// Derive the `PlanetEnvironment` for the player's current planet and insert
 /// it as a resource.
 ///
@@ -1002,11 +1017,16 @@ fn log_star_profile_on_startup(
 fn derive_and_insert_planet_environment(
     mut commands: Commands,
     world_config: Res<WorldGenerationConfig>,
-    world_profile: Res<WorldProfile>,
-    star_registry: Res<StarTypeRegistry>,
-    orbital_config: Res<OrbitalConfig>,
-    env_config: Res<PlanetEnvironmentConfig>,
+    world_profile: Option<Res<WorldProfile>>,
+    registries: SolarSystemRegistries,
 ) {
+    let Some(world_profile) = world_profile else {
+        error!(
+            "WorldProfile resource not available — cannot derive PlanetEnvironment. \
+             This is expected if WorldProfile creation failed during config loading."
+        );
+        return;
+    };
     // In system-derived mode, the WorldProfile already contains the full
     // SystemContext with the PlanetEnvironment. Extract and insert it as
     // a standalone resource for backward compatibility.
@@ -1027,15 +1047,21 @@ fn derive_and_insert_planet_environment(
     }
 
     // Override mode: derive from the orbital layout by matching planet seed.
-    let seed = SolarSystemSeed(world_config.solar_system_seed);
-    let star = derive_star_profile(seed, &star_registry);
-    let layout = derive_orbital_layout(seed, &orbital_config);
+    let Some(raw_planet_seed) = world_config.planet_seed else {
+        error!(
+            "BUG: derive_and_insert_planet_environment reached override-mode path \
+             but planet_seed is None. solar_system_seed={}, planet_index={}. \
+             Inserting default Earth-like PlanetEnvironment as fallback.",
+            world_config.solar_system_seed, world_config.planet_index,
+        );
+        commands.insert_resource(PlanetEnvironment::default());
+        return;
+    };
 
-    let planet_seed = PlanetSeed(
-        world_config
-            .planet_seed
-            .expect("override mode requires planet_seed"),
-    );
+    let seed = SolarSystemSeed(world_config.solar_system_seed);
+    let star = derive_star_profile(seed, &registries.star_registry);
+    let layout = derive_orbital_layout(seed, &registries.orbital_config);
+    let planet_seed = PlanetSeed(raw_planet_seed);
 
     // Find the player's planet in the orbital layout by matching planet seed.
     // When the planet seed is NOT found (override / manual-seed mode), we
@@ -1062,7 +1088,12 @@ fn derive_and_insert_planet_environment(
         }
     };
 
-    let env = derive_planet_environment(&star, orbital_distance_au, planet_seed, &env_config);
+    let env = derive_planet_environment(
+        &star,
+        orbital_distance_au,
+        planet_seed,
+        &registries.env_config,
+    );
 
     info!(
         "Planet environment derived: temp=[{:.0}, {:.0}]K, atmo={:.3}, \
@@ -1281,8 +1312,10 @@ pub fn derive_orbital_layout(
         distances.push(best_distance);
     }
 
-    // Sort innermost-first.
-    distances.sort_by(|a, b| a.partial_cmp(b).expect("orbital distances must not be NaN"));
+    // Sort innermost-first.  `total_cmp` provides a total ordering for f64
+    // that handles NaN deterministically (NaN sorts after all finite values)
+    // without panicking, unlike `partial_cmp().expect(...)`.
+    distances.sort_by(|a, b| a.total_cmp(b));
 
     // Safety net: if re-draw couldn't find valid positions for all planets
     // (pathologically tight config), enforce minimum separation by nudging
@@ -1681,7 +1714,7 @@ mod tests {
                 .star_types
                 .iter()
                 .find(|st| st.star_type == profile.star_type)
-                .expect("profile star_type_key must exist in registry");
+                .expect("profile star_type must exist in registry");
 
             assert!(
                 profile.luminosity >= star_type.luminosity_min
@@ -2205,7 +2238,7 @@ weight = 7.0
                 .find(|st| st.star_type == profile.star_type)
                 .unwrap_or_else(|| {
                     panic!(
-                        "seed {}: star_type_key '{}' not found in registry",
+                        "seed {}: star_type '{:?}' not found in registry",
                         raw, profile.star_type
                     )
                 });

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -46,9 +46,9 @@ use crate::seed_util::{
     mix_seed,
 };
 use crate::solar_system::{
-    OrbitalConfig, OrbitalLayout, PlanetEnvironment, PlanetEnvironmentConfig, SolarSystemSeed,
-    StarProfile, StarTypeRegistry, derive_orbital_layout, derive_planet_environment,
-    derive_star_profile,
+    OrbitalConfig, OrbitalLayout, PlanetEnvironment, PlanetEnvironmentConfig,
+    SolarSystemRegistries, SolarSystemSeed, StarProfile, StarTypeRegistry, derive_orbital_layout,
+    derive_planet_environment, derive_star_profile,
 };
 
 // ── Surface Query Abstraction (Story 5.3) ────────────────────────────────
@@ -739,7 +739,6 @@ pub struct WorldGenerationPlugin;
 impl Plugin for WorldGenerationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WorldGenerationConfig>()
-            .init_resource::<WorldProfile>()
             .init_resource::<ActiveChunkNeighborhood>()
             .init_resource::<BiomeRegistry>()
             .add_systems(
@@ -1263,13 +1262,6 @@ pub struct WorldProfile {
     pub system_context: Option<SystemContext>,
 }
 
-impl Default for WorldProfile {
-    fn default() -> Self {
-        Self::from_config(&WorldGenerationConfig::default())
-            .expect("default WorldGenerationConfig always has planet_seed")
-    }
-}
-
 impl WorldProfile {
     /// Build a world profile in override mode — planet seed taken directly
     /// from config, no system derivation chain.
@@ -1284,7 +1276,7 @@ impl WorldProfile {
             "from_config requires planet_seed to be Some (override mode)".to_string()
         })?;
         let planet_seed = PlanetSeed(raw_seed);
-        Ok(Self::build(planet_seed, config, None))
+        Self::build(planet_seed, config, None)
     }
 
     /// Build a world profile in system-derived mode — planet seed derived
@@ -1331,7 +1323,7 @@ impl WorldProfile {
             planet_orbital_index: config.planet_index,
         };
 
-        Ok(Self::build(planet_seed, config, Some(context)))
+        Self::build(planet_seed, config, Some(context))
     }
 
     /// Shared builder used by both `from_config` and `from_system_seed`.
@@ -1339,7 +1331,7 @@ impl WorldProfile {
         planet_seed: PlanetSeed,
         config: &WorldGenerationConfig,
         system_context: Option<SystemContext>,
-    ) -> Self {
+    ) -> Result<Self, String> {
         // Derive the planet surface radius from the planet seed. We mix the
         // seed with a dedicated channel constant so this derivation is
         // independent of all other seed-derived values (placement density,
@@ -1352,11 +1344,15 @@ impl WorldProfile {
             config.planet_surface_min_radius,
             config.planet_surface_max_radius,
         );
-        let planet_surface_diameter = planet_surface_radius
-            .checked_mul(2)
-            .expect("planet surface diameter must fit in i32");
+        let planet_surface_diameter = planet_surface_radius.checked_mul(2).ok_or_else(|| {
+            format!(
+                "planet_surface_radius {planet_surface_radius} overflows i32 when doubled \
+                 (min_radius={}, max_radius={})",
+                config.planet_surface_min_radius, config.planet_surface_max_radius,
+            )
+        })?;
 
-        Self {
+        Ok(Self {
             planet_seed,
             chunk_size_world_units: config.chunk_size_world_units,
             active_chunk_radius: config.active_chunk_radius,
@@ -1368,7 +1364,7 @@ impl WorldProfile {
             planet_surface_diameter,
             elevation_seed: mix_seed(planet_seed.0, ELEVATION_CHANNEL),
             system_context,
-        }
+        })
     }
 
     /// Whether this profile was derived from a solar system seed.
@@ -1463,15 +1459,33 @@ fn load_world_generation_config(mut commands: Commands) {
 
     match config.seed_mode() {
         SeedMode::Override => {
-            info!(
-                "Seed mode: override (planet_seed={:#018X})",
-                config
-                    .planet_seed
-                    .expect("override mode requires planet_seed"),
-            );
-            let profile = WorldProfile::from_config(&config)
-                .expect("override mode guarantees planet_seed is present");
-            commands.insert_resource(profile);
+            let Some(planet_seed) = config.planet_seed else {
+                error!(
+                    "BUG: seed_mode() returned Override but planet_seed is None. \
+                     Config: solar_system_seed={}, planet_index={}, planet_seed={:?}. \
+                     Falling back to defaults.",
+                    config.solar_system_seed, config.planet_index, config.planet_seed,
+                );
+                commands.insert_resource(config);
+                return;
+            };
+            info!("Seed mode: override (planet_seed={planet_seed:#018X})");
+
+            match WorldProfile::from_config(&config) {
+                Ok(profile) => {
+                    commands.insert_resource(profile);
+                }
+                Err(err) => {
+                    error!(
+                        "Failed to build WorldProfile from config in override mode: {err}. \
+                         Config: planet_seed={planet_seed:#018X}, \
+                         solar_system_seed={}, planet_index={}. \
+                         WorldProfile resource will not be available — systems that \
+                         depend on it will gracefully skip until the config is corrected.",
+                        config.solar_system_seed, config.planet_index,
+                    );
+                }
+            }
         }
         SeedMode::SystemDerived => {
             info!(
@@ -1503,51 +1517,61 @@ fn load_world_generation_config(mut commands: Commands) {
 pub fn resolve_system_derived_profile(
     mut commands: Commands,
     config: Res<WorldGenerationConfig>,
-    star_registry: Res<StarTypeRegistry>,
-    orbital_config: Res<OrbitalConfig>,
-    env_config: Res<PlanetEnvironmentConfig>,
+    registries: SolarSystemRegistries,
     mut app_exit: bevy::ecs::message::MessageWriter<AppExit>,
 ) {
     if config.seed_mode() != SeedMode::SystemDerived {
         return;
     }
 
-    let profile =
-        match WorldProfile::from_system_seed(&config, &star_registry, &orbital_config, &env_config)
-        {
-            Ok(p) => p,
-            Err(err) => {
-                error!(
-                    "Failed to resolve system-derived WorldProfile: {err}. \
+    let profile = match WorldProfile::from_system_seed(
+        &config,
+        &registries.star_registry,
+        &registries.orbital_config,
+        &registries.env_config,
+    ) {
+        Ok(p) => p,
+        Err(err) => {
+            error!(
+                "Failed to resolve system-derived WorldProfile: {err}. \
                      Fix solar_system_seed / planet_index in {CONFIG_PATH} \
                      or switch to override mode by setting planet_seed directly."
-                );
-                app_exit.write(AppExit::error());
-                return;
-            }
-        };
+            );
+            app_exit.write(AppExit::error());
+            return;
+        }
+    };
+
+    let star_type_label = match profile.system_context.as_ref() {
+        Some(ctx) => format!("{}", ctx.star.star_type),
+        None => {
+            error!(
+                "BUG: system-derived WorldProfile has no system_context. \
+                 planet_seed={:#018X}, planet_index={}. \
+                 Inserting profile anyway but downstream systems may behave unexpectedly.",
+                profile.planet_seed.0, config.planet_index,
+            );
+            "<missing>".to_string()
+        }
+    };
 
     info!(
         "Resolved system-derived WorldProfile: planet_seed={:#018X}, \
-         star_type={}, planet_index={}",
-        profile.planet_seed.0,
-        profile
-            .system_context
-            .as_ref()
-            .expect("system-derived profile must have system_context")
-            .star
-            .star_type,
-        config.planet_index,
+         star_type={star_type_label}, planet_index={}",
+        profile.planet_seed.0, config.planet_index,
     );
 
     commands.insert_resource(profile);
 }
 
 fn update_active_chunk_neighborhood(
-    profile: Res<WorldProfile>,
+    profile: Option<Res<WorldProfile>>,
     mut active_chunks: ResMut<ActiveChunkNeighborhood>,
     player_query: Query<&Transform, With<Player>>,
 ) {
+    let Some(profile) = profile else {
+        return;
+    };
     let Ok(player_transform) = player_query.single() else {
         active_chunks.center_chunk = None;
         active_chunks.center_chunk_origin_xz = None;

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -495,7 +495,7 @@ fn load_surface_mineral_deposit_catalog(mut commands: Commands) {
 fn sync_active_exterior_chunks(
     mut commands: Commands,
     active_chunks: Res<ActiveChunkNeighborhood>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     deposit_catalog: Res<SurfaceMineralDepositCatalog>,
     mut material_catalog: ResMut<MaterialCatalog>,
@@ -509,6 +509,9 @@ fn sync_active_exterior_chunks(
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
     planet_env: Option<Res<crate::solar_system::PlanetEnvironment>>,
 ) {
+    let Some(world_profile) = world_profile else {
+        return;
+    };
     let active_chunk_set: HashSet<ChunkCoord> = active_chunks.chunks.iter().copied().collect();
     let inactive_chunks: Vec<ChunkCoord> = spawned_chunks
         .spawned_entities_by_chunk
@@ -837,7 +840,7 @@ fn release_collected_player_added_objects(
 fn claim_exterior_drops(
     mut commands: Commands,
     exterior_patch: Res<ExteriorGroundPatch>,
-    world_profile: Res<WorldProfile>,
+    world_profile: Option<Res<WorldProfile>>,
     mut player_additions: ResMut<ChunkPlayerAdditions>,
     mut id_counter: ResMut<PlayerAddedIdCounter>,
     unclaimed_query: Query<
@@ -851,6 +854,9 @@ fn claim_exterior_drops(
         ),
     >,
 ) {
+    let Some(world_profile) = world_profile else {
+        return;
+    };
     for (entity, material, transform) in unclaimed_query.iter() {
         let pos = transform.translation;
 

--- a/tests/carry_scenarios.rs
+++ b/tests/carry_scenarios.rs
@@ -32,7 +32,7 @@ fn carry_shared_setup(app: &mut App) {
 /// `attach_carry_state_to_player` has already initialised the component.
 fn load_items(world: &mut World, items: &[(String, f32)]) {
     for (name, density) in items {
-        let mat = test_material(name, *density);
+        let mat = test_material(name, *density, 42);
         let item_entity = world.spawn(mat.clone()).id();
 
         let mut q = world.query_filtered::<&mut CarryState, With<Player>>();

--- a/tests/scenarios/helpers.rs
+++ b/tests/scenarios/helpers.rs
@@ -10,15 +10,16 @@ use bevy::prelude::*;
 // ── Factories ────────────────────────────────────────────────────────────
 
 /// Construct a [`GameMaterial`] with the given density.  All other
-/// properties use neutral defaults.
-pub fn test_material(name: &str, density: f32) -> GameMaterial {
+/// properties use neutral defaults.  Pass a unique `seed` per material
+/// so that combination / fabrication determinism tests don't collide.
+pub fn test_material(name: &str, density: f32, seed: u64) -> GameMaterial {
     let prop = |v| MaterialProperty {
         value: v,
         visibility: PropertyVisibility::Observable,
     };
     GameMaterial {
         name: name.into(),
-        seed: 42,
+        seed,
         color: [0.5, 0.5, 0.5],
         density: prop(density),
         thermal_resistance: prop(0.5),


### PR DESCRIPTION
## Summary

Addresses all architectural review findings from post-merge reviews of PRs #322 (5b.4 seed hierarchy) and #323 (scenario test harness).

## Changes

### From PR #322 review:
- **F8.1 (HIGH)**: Created `SolarSystemRegistries<'w>` SystemParam bundle — reduces 6-param systems (`derive_and_insert_planet_environment`, `resolve_system_derived_profile`) to 4 params each
- **F4.3 (MEDIUM)**: Replaced ALL production `.expect()`/`.unwrap()` with proper `error!()` logging and graceful fallbacks — `solar_system.rs` (override mode planet_seed, NaN sort via `total_cmp`), `world_generation.rs` (config loading, system context, `WorldProfile::build()` now returns `Result`)
- **F5.1 (MEDIUM)**: Removed `init_resource::<WorldProfile>()` placeholder and `Default for WorldProfile` impl — all 7 consumers across 6 files now use `Option<Res<WorldProfile>>` with early-return when unavailable

### From PR #323 review:
- **F6.1 (MEDIUM)**: Restored per-plugin inline comments in `lib.rs` `add_game_plugins()` (lost during binary→library refactor)
- **F8.1 (MEDIUM)**: Added `#![warn(missing_docs)]` to `lib.rs` with targeted `#[allow(missing_docs)]` on modules that need doc work (seed_util is clean)
- **F5.1 (LOW)**: Added `seed` parameter to `test_material()` helper in `tests/scenarios/helpers.rs`
- **F4.1 (LOW)**: Fixed stale `star_type_key` references in test panic messages (now `star_type`)

## Testing

- `make check` passes: fmt, clippy, 471 unit tests + 10 integration tests, build
- No new warnings introduced