### PR TITLE
feat: 10.1 - journal data model

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::input::InputAction;
 use crate::interaction::{HOLD_OFFSET, HeldItem};
-use crate::journal::RecordWeightObservation;
+use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MaterialObject};
 use crate::observation::{ConfidenceLevel, ConfidenceTracker};
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
@@ -1172,7 +1172,7 @@ pub fn record_weight_observation(
     carry_strength: f32,
     config: &CarryConfig,
     tracker: &mut ConfidenceTracker,
-    journal_writer: &mut MessageWriter<RecordWeightObservation>,
+    journal_writer: &mut MessageWriter<RecordObservation>,
 ) {
     tracker.record(material.seed, "weight");
     let confidence = tracker.level(material.seed, "weight");
@@ -1182,10 +1182,17 @@ pub fn record_weight_observation(
         confidence,
         &config.weight_descriptions,
     );
-    journal_writer.write(RecordWeightObservation {
-        seed: material.seed,
+    journal_writer.write(RecordObservation {
+        key: JournalKey::Material {
+            seed: material.seed,
+        },
         name: material.name.clone(),
-        description,
+        observation: Observation {
+            category: ObservationCategory::Weight,
+            confidence,
+            description,
+            recorded_at: 0,
+        },
     });
 }
 
@@ -1227,7 +1234,7 @@ fn process_stash_intent(
     mut reader: MessageReader<StashIntent>,
     mut weight_writer: MessageWriter<CarryWeightChanged>,
     mut reject_writer: MessageWriter<CarryActionRejected>,
-    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut tracker: ResMut<ConfidenceTracker>,
     config: Res<CarryConfig>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
@@ -1275,7 +1282,7 @@ fn process_stash_held_for_pickup(
     mut commands: Commands,
     mut reader: MessageReader<StashHeldForPickup>,
     mut weight_writer: MessageWriter<CarryWeightChanged>,
-    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut tracker: ResMut<ConfidenceTracker>,
     config: Res<CarryConfig>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
@@ -1313,7 +1320,7 @@ fn process_stash_held_for_pickup(
 /// Handle standalone weight observation requests from interaction (pickup without stash).
 fn process_observe_weight(
     mut reader: MessageReader<ObserveWeight>,
-    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut tracker: ResMut<ConfidenceTracker>,
     config: Res<CarryConfig>,
     player_query: Query<&CarryStrength, With<Player>>,
@@ -1341,7 +1348,7 @@ fn process_cycle_carry_intent(
     mut reader: MessageReader<CycleCarryIntent>,
     mut weight_writer: MessageWriter<CarryWeightChanged>,
     mut reject_writer: MessageWriter<CarryActionRejected>,
-    mut journal_writer: MessageWriter<RecordWeightObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut tracker: ResMut<ConfidenceTracker>,
     config: Res<CarryConfig>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,

--- a/src/descriptions.rs
+++ b/src/descriptions.rs
@@ -1,0 +1,135 @@
+//! Player-facing descriptive language — translates raw numeric values into
+//! qualitative prose the player reads in the journal, examine panel, and
+//! other UI surfaces.
+//!
+//! Centralising these functions avoids duplication across modules and keeps
+//! the "voice" of the game consistent. Every function here converts a
+//! normalised `0.0–1.0` value (or similar) into a `&'static str` or
+//! `String` that can go straight into UI text.
+
+use crate::observation::ConfidenceLevel;
+
+// ── Generic value ───────────────────────────────────────────────────────
+
+/// Converts a normalised 0–1 property value into a descriptive word.
+pub fn describe_value(value: f32) -> &'static str {
+    if value < 0.15 {
+        "Negligible"
+    } else if value < 0.3 {
+        "Very low"
+    } else if value < 0.45 {
+        "Low"
+    } else if value < 0.55 {
+        "Moderate"
+    } else if value < 0.7 {
+        "High"
+    } else if value < 0.85 {
+        "Very high"
+    } else {
+        "Extreme"
+    }
+}
+
+// ── Density / weight ────────────────────────────────────────────────────
+
+/// Converts a normalised density value into a weight description.
+pub fn describe_density(value: f32) -> &'static str {
+    if value < 0.15 {
+        "Almost weightless"
+    } else if value < 0.3 {
+        "Very light"
+    } else if value < 0.45 {
+        "Light"
+    } else if value < 0.55 {
+        "Medium weight"
+    } else if value < 0.7 {
+        "Heavy"
+    } else if value < 0.85 {
+        "Very heavy"
+    } else {
+        "Extremely dense"
+    }
+}
+
+// ── Color ───────────────────────────────────────────────────────────────
+
+/// Converts an RGB triplet into a qualitative colour description.
+pub fn describe_color(color: &[f32; 3]) -> &'static str {
+    let [r, g, b] = *color;
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+
+    if max - min < 0.08 {
+        if max < 0.25 {
+            "Dark mineral grey"
+        } else if max < 0.7 {
+            "Muted stone grey"
+        } else {
+            "Pale chalk grey"
+        }
+    } else if r >= g && r >= b {
+        "Warm rust tone"
+    } else if g >= r && g >= b {
+        "Verdant green tone"
+    } else {
+        "Cool blue tone"
+    }
+}
+
+// ── Thermal ─────────────────────────────────────────────────────────────
+
+/// Base thermal-behaviour description without confidence framing.
+fn describe_thermal_behavior(value: f32) -> &'static str {
+    if value < 0.25 {
+        "soften quickly under heat"
+    } else if value < 0.5 {
+        "change noticeably under heat"
+    } else if value < 0.75 {
+        "hold together under heat"
+    } else {
+        "barely react to heat"
+    }
+}
+
+/// Thermal observation with confidence-level framing applied.
+pub fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
+    let behavior = describe_thermal_behavior(value);
+    match confidence {
+        ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
+        ConfidenceLevel::Observed => {
+            let mut chars = behavior.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            format!("{}{}", first.to_uppercase(), chars.as_str())
+        }
+        ConfidenceLevel::Confident => format!("Reliably {behavior}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_value_covers_full_range() {
+        assert_eq!(describe_value(0.0), "Negligible");
+        assert_eq!(describe_value(0.2), "Very low");
+        assert_eq!(describe_value(0.35), "Low");
+        assert_eq!(describe_value(0.5), "Moderate");
+        assert_eq!(describe_value(0.6), "High");
+        assert_eq!(describe_value(0.75), "Very high");
+        assert_eq!(describe_value(0.9), "Extreme");
+    }
+
+    #[test]
+    fn describe_density_covers_full_range() {
+        assert_eq!(describe_density(0.1), "Almost weightless");
+        assert_eq!(describe_density(0.25), "Very light");
+        assert_eq!(describe_density(0.4), "Light");
+        assert_eq!(describe_density(0.5), "Medium weight");
+        assert_eq!(describe_density(0.65), "Heavy");
+        assert_eq!(describe_density(0.78), "Very heavy");
+        assert_eq!(describe_density(0.95), "Extremely dense");
+    }
+}

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -14,7 +14,7 @@
 use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
-use crate::journal::RecordFabrication;
+use crate::journal::RecordObservation;
 use crate::materials::{
     GameMaterial, MATERIAL_SURFACE_GAP, MaterialCatalog, MaterialObject, MaterialProperty,
     PropertyVisibility,
@@ -184,7 +184,7 @@ fn tick_processing(
     time: Res<Time>,
     cfg: Res<FabricatorSceneConfig>,
     rules: Res<CombinationRules>,
-    _journal_writer: MessageWriter<RecordFabrication>,
+    _journal_writer: MessageWriter<RecordObservation>,
     mut state: ResMut<FabricatorState>,
     mut catalog: ResMut<MaterialCatalog>,
     mut slots: Query<&mut InputSlot>,

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -14,7 +14,7 @@
 use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
-use crate::journal::RecordObservation;
+use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{
     GameMaterial, MATERIAL_SURFACE_GAP, MaterialCatalog, MaterialObject, MaterialProperty,
     PropertyVisibility,
@@ -184,7 +184,7 @@ fn tick_processing(
     time: Res<Time>,
     cfg: Res<FabricatorSceneConfig>,
     rules: Res<CombinationRules>,
-    _journal_writer: MessageWriter<RecordObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut state: ResMut<FabricatorState>,
     mut catalog: ResMut<MaterialCatalog>,
     mut slots: Query<&mut InputSlot>,
@@ -264,6 +264,26 @@ fn tick_processing(
         .id();
 
     out_slot.material = Some(output_entity);
+
+    // Record the fabrication result in the player's journal so the player
+    // accumulates knowledge about what combinations produce which outputs.
+    let input_names: Vec<&str> = input_mats.iter().map(|m| m.name.as_str()).collect();
+    let description = format!(
+        "Combined {} and {} to produce {}.",
+        input_names[0], input_names[1], output_mat.name
+    );
+    journal_writer.write(RecordObservation {
+        key: JournalKey::Fabrication {
+            output_seed: output_mat.seed,
+        },
+        name: output_mat.name.clone(),
+        observation: Observation {
+            category: ObservationCategory::FabricationResult,
+            confidence: crate::observation::ConfidenceLevel::Confident,
+            description,
+            recorded_at: 0,
+        },
+    });
 
     info!("Fabrication complete — produced '{}'", output_mat.name);
     *state = FabricatorState::Idle;

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -16,9 +16,10 @@
 
 use bevy::prelude::*;
 
+use crate::descriptions::describe_thermal_observation;
 use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
-use crate::observation::{ConfidenceTracker, describe_thermal_observation};
+use crate::observation::ConfidenceTracker;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
 
 pub struct HeatPlugin;

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -16,9 +16,9 @@
 
 use bevy::prelude::*;
 
-use crate::journal::RecordThermalObservation;
+use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
-use crate::observation::ConfidenceTracker;
+use crate::observation::{ConfidenceTracker, describe_thermal_observation};
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
 
 pub struct HeatPlugin;
@@ -265,7 +265,7 @@ fn reveal_thermal_property(
     mut commands: Commands,
     hs_cfg: Res<HeatSourceConfig>,
     mut tracker: ResMut<ConfidenceTracker>,
-    mut journal_writer: MessageWriter<RecordThermalObservation>,
+    mut journal_writer: MessageWriter<RecordObservation>,
     mut material_query: Query<
         (
             Entity,
@@ -303,11 +303,18 @@ fn reveal_thermal_property(
             commands
                 .entity(entity)
                 .insert(ThermalObservationRecordedThisCycle);
-            journal_writer.write(RecordThermalObservation {
-                seed: mat.seed,
+            journal_writer.write(RecordObservation {
+                key: JournalKey::Material { seed: mat.seed },
                 name: mat.name.clone(),
-                thermal_resistance: mat.thermal_resistance.value,
-                confidence: tracker.level(mat.seed, "thermal_resistance"),
+                observation: Observation {
+                    category: ObservationCategory::ThermalBehavior,
+                    confidence: tracker.level(mat.seed, "thermal_resistance"),
+                    description: describe_thermal_observation(
+                        mat.thermal_resistance.value,
+                        tracker.level(mat.seed, "thermal_resistance"),
+                    ),
+                    recorded_at: 0,
+                },
             });
             info!(
                 "'{}' thermal observation recorded (count = {})",
@@ -452,7 +459,7 @@ mod tests {
     #[test]
     fn thermal_observation_repeats_after_cooling_cycle() {
         let mut app = App::new();
-        app.add_message::<RecordThermalObservation>();
+        app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
         app.insert_resource(ConfidenceTracker::default());
         app.add_systems(Update, reveal_thermal_property);
@@ -502,7 +509,7 @@ mod tests {
     #[test]
     fn revealing_one_entity_propagates_visibility_to_same_seed() {
         let mut app = App::new();
-        app.add_message::<RecordThermalObservation>();
+        app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
         app.insert_resource(ConfidenceTracker::default());
         app.add_systems(Update, reveal_thermal_property);

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -21,13 +21,14 @@ use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, Ra
 use bevy::prelude::*;
 
 use crate::carry::{CarryState, ObserveWeight, StashHeldForPickup};
+use crate::descriptions::{
+    describe_color, describe_density, describe_thermal_observation, describe_value,
+};
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
-use crate::journal::{
-    JournalKey, Observation, ObservationCategory, RecordObservation, describe_color,
-};
+use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
-use crate::observation::{ConfidenceLevel, ConfidenceTracker, describe_thermal_observation};
+use crate::observation::{ConfidenceLevel, ConfidenceTracker};
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
 use crate::world_generation::{PlanetSurface, WorldGenerationConfig, WorldProfile};
@@ -825,45 +826,6 @@ fn update_examine_panel(
     text.0 = build_examine_text(mat, &tracker);
 }
 
-// ── Property description ─────────────────────────────────────────────────
-
-/// Converts a normalised 0–1 property value into a descriptive word.
-fn describe_value(value: f32) -> &'static str {
-    if value < 0.15 {
-        "Negligible"
-    } else if value < 0.3 {
-        "Very low"
-    } else if value < 0.45 {
-        "Low"
-    } else if value < 0.55 {
-        "Moderate"
-    } else if value < 0.7 {
-        "High"
-    } else if value < 0.85 {
-        "Very high"
-    } else {
-        "Extreme"
-    }
-}
-
-fn describe_density(value: f32) -> &'static str {
-    if value < 0.15 {
-        "Almost weightless"
-    } else if value < 0.3 {
-        "Very light"
-    } else if value < 0.45 {
-        "Light"
-    } else if value < 0.55 {
-        "Medium weight"
-    } else if value < 0.7 {
-        "Heavy"
-    } else if value < 0.85 {
-        "Very heavy"
-    } else {
-        "Extremely dense"
-    }
-}
-
 fn build_examine_text(mat: &GameMaterial, tracker: &ConfidenceTracker) -> String {
     let mut lines = vec![mat.name.clone()];
     lines.push(String::new());
@@ -937,28 +899,6 @@ mod tests {
             planet_surface_diameter: 10,
             chunk_size_world_units: 45.0,
         }
-    }
-
-    #[test]
-    fn describe_value_covers_full_range() {
-        assert_eq!(describe_value(0.0), "Negligible");
-        assert_eq!(describe_value(0.2), "Very low");
-        assert_eq!(describe_value(0.35), "Low");
-        assert_eq!(describe_value(0.5), "Moderate");
-        assert_eq!(describe_value(0.6), "High");
-        assert_eq!(describe_value(0.75), "Very high");
-        assert_eq!(describe_value(0.9), "Extreme");
-    }
-
-    #[test]
-    fn describe_density_covers_full_range() {
-        assert_eq!(describe_density(0.1), "Almost weightless");
-        assert_eq!(describe_density(0.25), "Very light");
-        assert_eq!(describe_density(0.4), "Light");
-        assert_eq!(describe_density(0.5), "Medium weight");
-        assert_eq!(describe_density(0.65), "Heavy");
-        assert_eq!(describe_density(0.78), "Very heavy");
-        assert_eq!(describe_density(0.95), "Extremely dense");
     }
 
     fn test_material() -> GameMaterial {

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -23,9 +23,11 @@ use bevy::prelude::*;
 use crate::carry::{CarryState, ObserveWeight, StashHeldForPickup};
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
-use crate::journal::RecordEncounter;
+use crate::journal::{
+    JournalKey, Observation, ObservationCategory, RecordObservation, describe_color,
+};
 use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
-use crate::observation::{ConfidenceTracker, describe_thermal_observation};
+use crate::observation::{ConfidenceLevel, ConfidenceTracker, describe_thermal_observation};
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
 use crate::world_generation::{PlanetSurface, WorldGenerationConfig, WorldProfile};
@@ -148,7 +150,7 @@ fn update_interaction_target(
     mut ray_cast: MeshRayCast,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     held_query: Query<(), With<HeldItem>>,
-    mut encounter_writer: MessageWriter<RecordEncounter>,
+    mut encounter_writer: MessageWriter<RecordObservation>,
 ) {
     let previous_target = target.entity;
     target.entity = None;
@@ -183,8 +185,21 @@ fn update_interaction_target(
         && let Some(entity) = target.entity
         && let Ok(material) = material_query.get(entity)
     {
-        encounter_writer.write(RecordEncounter {
-            material: material.clone(),
+        encounter_writer.write(RecordObservation {
+            key: JournalKey::Material {
+                seed: material.seed,
+            },
+            name: material.name.clone(),
+            observation: Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: format!(
+                    "Color: {}\nWeight: {}",
+                    describe_color(&material.color),
+                    describe_density(material.density.value)
+                ),
+                recorded_at: 0,
+            },
         });
     }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1413,4 +1413,153 @@ mod tests {
             "Found near volcanic ridge"
         );
     }
+
+    /// Different `JournalKey`s are stored independently: observations recorded
+    /// against one key never appear in, modify, or interfere with entries keyed
+    /// by a different key — even when seeds overlap across variant types or when
+    /// the same observation category is used for multiple subjects.
+    #[test]
+    fn different_keys_stored_independently() {
+        let mut journal = NewJournal::default();
+
+        // Three keys: two Material keys with different seeds and one
+        // Fabrication key whose output_seed numerically equals the first
+        // Material seed (verifies variant-level isolation).
+        let mat_a = JournalKey::Material { seed: 10 };
+        let mat_b = JournalKey::Material { seed: 20 };
+        let fab_a = JournalKey::Fabrication { output_seed: 10 };
+
+        // Record a surface observation on material A.
+        journal.record(
+            mat_a.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 1,
+            },
+        );
+
+        // Record a surface observation on material B (same category, different key).
+        journal.record(
+            mat_b.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Cool blue tone".into(),
+                recorded_at: 2,
+            },
+        );
+
+        // Record a fabrication result on fab_a (same numeric id as mat_a).
+        journal.record(
+            fab_a.clone(),
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Ferrite + Silite -> Neoite".into(),
+                recorded_at: 3,
+            },
+        );
+
+        // Add a second observation to material A to verify accumulation is
+        // scoped to that key alone.
+        journal.record(
+            mat_a.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Holds together under heat".into(),
+                recorded_at: 4,
+            },
+        );
+
+        // ── Verify entry count ──────────────────────────────────────
+        assert_eq!(
+            journal.entries.len(),
+            3,
+            "three distinct keys = three entries"
+        );
+
+        // ── Verify material A ───────────────────────────────────────
+        let entry_a = journal
+            .entries
+            .get(&mat_a)
+            .expect("mat_a entry should exist");
+        assert_eq!(entry_a.name, "Ferrite");
+        assert_eq!(entry_a.observations.len(), 2);
+        assert_eq!(entry_a.first_observed_at, 1);
+        assert_eq!(entry_a.last_updated_at, 4);
+        assert_eq!(
+            entry_a.observations[0].category,
+            ObservationCategory::SurfaceAppearance
+        );
+        assert_eq!(entry_a.observations[0].description, "Warm rust tone");
+        assert_eq!(
+            entry_a.observations[1].category,
+            ObservationCategory::ThermalBehavior
+        );
+
+        // ── Verify material B ───────────────────────────────────────
+        let entry_b = journal
+            .entries
+            .get(&mat_b)
+            .expect("mat_b entry should exist");
+        assert_eq!(entry_b.name, "Silite");
+        assert_eq!(entry_b.observations.len(), 1);
+        assert_eq!(entry_b.first_observed_at, 2);
+        assert_eq!(entry_b.last_updated_at, 2);
+        assert_eq!(entry_b.observations[0].description, "Cool blue tone");
+
+        // ── Verify fabrication A (same numeric id as mat_a) ─────────
+        let entry_fab = journal
+            .entries
+            .get(&fab_a)
+            .expect("fab_a entry should exist");
+        assert_eq!(entry_fab.name, "Neoite");
+        assert_eq!(entry_fab.observations.len(), 1);
+        assert_eq!(entry_fab.first_observed_at, 3);
+        assert_eq!(entry_fab.last_updated_at, 3);
+        assert_eq!(
+            entry_fab.observations[0].category,
+            ObservationCategory::FabricationResult
+        );
+
+        // ── Cross-contamination checks ──────────────────────────────
+        // Material A must not contain material B's or fab_a's observations.
+        assert!(
+            entry_a
+                .observations
+                .iter()
+                .all(|o| o.description != "Cool blue tone"
+                    && o.description != "Combined Ferrite + Silite -> Neoite"),
+            "mat_a must not contain observations from other keys"
+        );
+
+        // Material B must not contain material A's or fab_a's observations.
+        assert!(
+            entry_b
+                .observations
+                .iter()
+                .all(|o| o.description != "Warm rust tone"
+                    && o.description != "Holds together under heat"
+                    && o.description != "Combined Ferrite + Silite -> Neoite"),
+            "mat_b must not contain observations from other keys"
+        );
+
+        // Fabrication A must not contain either material's observations.
+        assert!(
+            entry_fab
+                .observations
+                .iter()
+                .all(|o| o.description != "Warm rust tone"
+                    && o.description != "Cool blue tone"
+                    && o.description != "Holds together under heat"),
+            "fab_a must not contain observations from other keys"
+        );
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1828,4 +1828,132 @@ mod tests {
             "empty journal must show placeholder message"
         );
     }
+
+    /// A journal with 100+ entries of mixed key types and observation
+    /// categories must not panic during recording, lookup, rendering, or
+    /// serialization round-trip.
+    #[test]
+    fn journal_with_100_plus_mixed_entries_does_not_panic() {
+        let categories = [
+            ObservationCategory::SurfaceAppearance,
+            ObservationCategory::ThermalBehavior,
+            ObservationCategory::Weight,
+            ObservationCategory::FabricationResult,
+            ObservationCategory::LocationNote,
+        ];
+
+        let confidences = [
+            ConfidenceLevel::Tentative,
+            ConfidenceLevel::Observed,
+            ConfidenceLevel::Confident,
+        ];
+
+        let mut journal = NewJournal::default();
+
+        // Record 120 entries: 80 Material keys and 40 Fabrication keys,
+        // each with between 1 and 3 observations across different categories.
+        for i in 0u64..120 {
+            let key = if i % 3 == 0 {
+                JournalKey::Fabrication { output_seed: i }
+            } else {
+                JournalKey::Material { seed: i }
+            };
+
+            let name = format!("Subject-{i}");
+            let tick_base = i * 10;
+
+            // Primary observation — category and confidence rotate through variants.
+            let primary_cat = &categories[i as usize % categories.len()];
+            let primary_conf = confidences[i as usize % confidences.len()];
+            journal.record(
+                key.clone(),
+                &name,
+                Observation {
+                    category: primary_cat.clone(),
+                    confidence: primary_conf,
+                    description: format!("Primary observation for {name}"),
+                    recorded_at: tick_base,
+                },
+            );
+
+            // Every other entry gets a second observation in a different category.
+            if i % 2 == 0 {
+                let secondary_cat = &categories[(i as usize + 1) % categories.len()];
+                journal.record(
+                    key.clone(),
+                    &name,
+                    Observation {
+                        category: secondary_cat.clone(),
+                        confidence: ConfidenceLevel::Tentative,
+                        description: format!("Secondary observation for {name}"),
+                        recorded_at: tick_base + 1,
+                    },
+                );
+            }
+
+            // Every third entry gets a third observation (same category as
+            // primary but different description — should not deduplicate).
+            if i % 3 == 0 {
+                journal.record(
+                    key.clone(),
+                    &name,
+                    Observation {
+                        category: primary_cat.clone(),
+                        confidence: ConfidenceLevel::Confident,
+                        description: format!("Follow-up observation for {name}"),
+                        recorded_at: tick_base + 2,
+                    },
+                );
+            }
+        }
+
+        // Verify entry count.
+        assert!(
+            journal.entries.len() >= 100,
+            "expected at least 100 entries, got {}",
+            journal.entries.len()
+        );
+
+        // Verify both key types are present.
+        let material_count = journal
+            .entries
+            .keys()
+            .filter(|k| matches!(k, JournalKey::Material { .. }))
+            .count();
+        let fabrication_count = journal
+            .entries
+            .keys()
+            .filter(|k| matches!(k, JournalKey::Fabrication { .. }))
+            .count();
+        assert!(material_count > 0, "must contain Material entries");
+        assert!(fabrication_count > 0, "must contain Fabrication entries");
+
+        // Verify all five observation categories are represented.
+        let mut seen_categories = std::collections::HashSet::new();
+        for entry in journal.entries.values() {
+            for cat in entry.observations.keys() {
+                seen_categories.insert(cat.clone());
+            }
+        }
+        for cat in &categories {
+            assert!(
+                seen_categories.contains(cat),
+                "category {cat:?} must be present in the journal"
+            );
+        }
+
+        // Rendering must not panic.
+        let text = build_journal_text(&journal);
+        assert!(!text.is_empty(), "rendered text must not be empty");
+
+        // Serde round-trip must not panic or lose entries.
+        let serialized = serde_json::to_string(&journal).expect("journal must serialize");
+        let deserialized: NewJournal =
+            serde_json::from_str(&serialized).expect("journal must deserialize");
+        assert_eq!(
+            journal.entries.len(),
+            deserialized.entries.len(),
+            "round-trip must preserve entry count"
+        );
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -282,6 +282,7 @@ struct LegacyJournal {
     entries: BTreeMap<u64, LegacyJournalEntry>,
 }
 
+#[expect(dead_code)]
 #[derive(Clone, Debug, Default)]
 struct LegacyJournalEntry {
     name: String,
@@ -459,7 +460,7 @@ fn apply_observations(
 
 fn render_journal(
     state: Res<JournalUiState>,
-    player_query: Query<&LegacyJournal, With<Player>>,
+    player_query: Query<&NewJournal, With<Player>>,
     mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
     mut text_query: Query<&mut Text, With<JournalText>>,
 ) {
@@ -484,42 +485,68 @@ fn render_journal(
     text.0 = build_journal_text(journal);
 }
 
-fn build_journal_text(journal: &LegacyJournal) -> String {
+fn build_journal_text(journal: &NewJournal) -> String {
     if journal.entries.is_empty() {
         return "Journal\n\nNo observations yet.".to_string();
     }
 
     let mut out = vec!["Journal".to_string()];
 
-    if !journal.fabrication_log.is_empty() {
+    // Collect all fabrication result descriptions across all entries, in
+    // insertion order (BTreeMap iteration is deterministic). This mirrors
+    // the legacy "Recent Fabrication" section which was a flat log.
+    let fabrication_descriptions: Vec<&str> = journal
+        .entries
+        .values()
+        .flat_map(|entry| {
+            entry
+                .observations
+                .iter()
+                .filter(|o| o.category == ObservationCategory::FabricationResult)
+                .map(|o| o.description.as_str())
+        })
+        .collect();
+
+    if !fabrication_descriptions.is_empty() {
         out.push(String::new());
         out.push("Recent Fabrication".to_string());
-        for history in &journal.fabrication_log {
-            out.push(history.clone());
+        for desc in &fabrication_descriptions {
+            out.push((*desc).to_string());
         }
     }
 
-    let mut entries: Vec<&LegacyJournalEntry> = journal.entries.values().collect();
+    // Sort entries by name for stable, alphabetical display order.
+    let mut entries: Vec<&JournalEntry> = journal.entries.values().collect();
     entries.sort_by(|a, b| a.name.cmp(&b.name));
 
     for entry in entries {
         out.push(String::new());
         out.push(entry.name.clone());
 
-        for obs in &entry.surface_observations {
-            out.push(format!("Surface: {obs}"));
+        for obs in entry.observations_by_category(&ObservationCategory::SurfaceAppearance) {
+            out.push(format!("Surface: {}", obs.description));
         }
 
-        if let Some(thermal) = &entry.thermal_observation {
-            out.push(format!("Heat: {thermal}"));
+        // Show only the most recent thermal observation (matches legacy
+        // behavior where `thermal_observation` was a single `Option<String>`).
+        if let Some(thermal) = entry
+            .observations_by_category(&ObservationCategory::ThermalBehavior)
+            .last()
+        {
+            out.push(format!("Heat: {}", thermal.description));
         }
 
-        if let Some(weight) = &entry.weight_observation {
-            out.push(format!("Carried: {weight}"));
+        // Show only the most recent weight observation (matches legacy
+        // behavior where `weight_observation` was a single `Option<String>`).
+        if let Some(weight) = entry
+            .observations_by_category(&ObservationCategory::Weight)
+            .last()
+        {
+            out.push(format!("Carried: {}", weight.description));
         }
 
-        for history in &entry.fabrication_history {
-            out.push(history.clone());
+        for obs in entry.observations_by_category(&ObservationCategory::FabricationResult) {
+            out.push(obs.description.clone());
         }
     }
 
@@ -576,9 +603,17 @@ mod tests {
 
     #[test]
     fn journal_omits_unknown_properties() {
-        let mut journal = LegacyJournal::default();
-        let entry = journal.ensure_entry(1, "Ferrite");
-        entry.surface_observations.push("Weight: Heavy".into());
+        let mut journal = NewJournal::default();
+        journal.record(
+            JournalKey::Material { seed: 1 },
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Weight: Heavy".into(),
+                recorded_at: 1,
+            },
+        );
 
         let text = build_journal_text(&journal);
         assert!(text.contains("Weight: Heavy"));
@@ -587,14 +622,17 @@ mod tests {
 
     #[test]
     fn journal_includes_fabrication_history() {
-        let mut journal = LegacyJournal::default();
-        journal
-            .fabrication_log
-            .push("Combined Ferrite + Silite -> Neoite".into());
-        let entry = journal.ensure_entry(2, "Neoite");
-        entry
-            .fabrication_history
-            .push("Combined Ferrite + Silite -> Neoite".into());
+        let mut journal = NewJournal::default();
+        journal.record(
+            JournalKey::Fabrication { output_seed: 2 },
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Ferrite + Silite -> Neoite".into(),
+                recorded_at: 1,
+            },
+        );
 
         let text = build_journal_text(&journal);
         assert!(text.contains("Combined Ferrite + Silite -> Neoite"));
@@ -603,9 +641,17 @@ mod tests {
 
     #[test]
     fn journal_shows_thermal_observation_when_present() {
-        let mut journal = LegacyJournal::default();
-        let entry = journal.ensure_entry(3, "TestMat");
-        entry.thermal_observation = Some("Reliably hold together under heat".into());
+        let mut journal = NewJournal::default();
+        journal.record(
+            JournalKey::Material { seed: 3 },
+            "TestMat",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Reliably hold together under heat".into(),
+                recorded_at: 1,
+            },
+        );
 
         let text = build_journal_text(&journal);
         assert!(text.contains("Heat: Reliably hold together under heat"));
@@ -668,17 +714,32 @@ mod tests {
 
     #[test]
     fn journal_shows_weight_observation_only_when_present() {
-        let mut journal = LegacyJournal::default();
-        let entry = journal.ensure_entry(4, "Ferrite");
-        entry
-            .surface_observations
-            .push("Color: Cool blue tone".into());
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 4 };
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Color: Cool blue tone".into(),
+                recorded_at: 1,
+            },
+        );
 
         let without_weight = build_journal_text(&journal);
         assert!(!without_weight.contains("Carried: Heavy but manageable"));
 
-        let entry = journal.ensure_entry(4, "Ferrite");
-        entry.weight_observation = Some("Heavy but manageable".into());
+        journal.record(
+            key,
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Observed,
+                description: "Heavy but manageable".into(),
+                recorded_at: 2,
+            },
+        );
 
         let with_weight = build_journal_text(&journal);
         assert!(with_weight.contains("Carried: Heavy but manageable"));

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -2037,4 +2037,201 @@ mod tests {
             "round-trip must preserve entry count"
         );
     }
+
+    /// Examining 3+ different materials produces separate journal entries with
+    /// no cross-contamination. Each material's observations are isolated, and
+    /// rendering displays each material as a distinct section with only its
+    /// own observations.
+    #[test]
+    fn multiple_materials_have_separate_entries_and_rendering() {
+        let mut journal = NewJournal::default();
+
+        // ── Material 1: Ferrite ─────────────────────────────────────
+        let key_ferrite = JournalKey::Material { seed: 10 };
+        journal.record(
+            key_ferrite.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 1,
+            },
+        );
+        journal.record(
+            key_ferrite.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Holds together under heat".into(),
+                recorded_at: 2,
+            },
+        );
+
+        // ── Material 2: Silite ──────────────────────────────────────
+        let key_silite = JournalKey::Material { seed: 20 };
+        journal.record(
+            key_silite.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Cool blue tone".into(),
+                recorded_at: 3,
+            },
+        );
+        journal.record(
+            key_silite.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Confident,
+                description: "Feather-light".into(),
+                recorded_at: 4,
+            },
+        );
+
+        // ── Material 3: Volite ──────────────────────────────────────
+        let key_volite = JournalKey::Material { seed: 30 };
+        journal.record(
+            key_volite.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Dark mineral grey".into(),
+                recorded_at: 5,
+            },
+        );
+        journal.record(
+            key_volite.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Confident,
+                description: "Glows faintly when heated".into(),
+                recorded_at: 6,
+            },
+        );
+        journal.record(
+            key_volite.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Observed,
+                description: "Very heavy".into(),
+                recorded_at: 7,
+            },
+        );
+
+        // ── Material 4: Crystite (ensures "3+" is exceeded) ─────────
+        let key_crystite = JournalKey::Material { seed: 40 };
+        journal.record(
+            key_crystite.clone(),
+            "Crystite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Translucent with prismatic flecks".into(),
+                recorded_at: 8,
+            },
+        );
+
+        // ── Verify entry separation ─────────────────────────────────
+        assert_eq!(journal.entries.len(), 4, "four distinct material entries");
+        assert!(journal.entries.contains_key(&key_ferrite));
+        assert!(journal.entries.contains_key(&key_silite));
+        assert!(journal.entries.contains_key(&key_volite));
+        assert!(journal.entries.contains_key(&key_crystite));
+
+        // ── Verify observation counts per entry ─────────────────────
+        let ferrite = journal.entries.get(&key_ferrite).unwrap();
+        assert_eq!(ferrite.observation_count(), 2);
+        assert_eq!(ferrite.name, "Ferrite");
+
+        let silite = journal.entries.get(&key_silite).unwrap();
+        assert_eq!(silite.observation_count(), 2);
+        assert_eq!(silite.name, "Silite");
+
+        let volite = journal.entries.get(&key_volite).unwrap();
+        assert_eq!(volite.observation_count(), 3);
+        assert_eq!(volite.name, "Volite");
+
+        let crystite = journal.entries.get(&key_crystite).unwrap();
+        assert_eq!(crystite.observation_count(), 1);
+        assert_eq!(crystite.name, "Crystite");
+
+        // ── Cross-contamination: each entry contains only its own data ──
+        assert!(
+            ferrite
+                .all_observations()
+                .all(|o| o.description == "Warm rust tone"
+                    || o.description == "Holds together under heat"),
+            "Ferrite must only contain its own observations"
+        );
+        assert!(
+            silite
+                .all_observations()
+                .all(|o| o.description == "Cool blue tone" || o.description == "Feather-light"),
+            "Silite must only contain its own observations"
+        );
+        assert!(
+            volite
+                .all_observations()
+                .all(|o| o.description == "Dark mineral grey"
+                    || o.description == "Glows faintly when heated"
+                    || o.description == "Very heavy"),
+            "Volite must only contain its own observations"
+        );
+        assert!(
+            crystite
+                .all_observations()
+                .all(|o| o.description == "Translucent with prismatic flecks"),
+            "Crystite must only contain its own observations"
+        );
+
+        // ── Verify rendering shows all four materials separated ─────
+        let text = build_journal_text(&journal);
+
+        // All material names appear.
+        assert!(text.contains("Ferrite"));
+        assert!(text.contains("Silite"));
+        assert!(text.contains("Volite"));
+        assert!(text.contains("Crystite"));
+
+        // Each material's observations appear in the rendered text.
+        assert!(text.contains("Surface: Warm rust tone"));
+        assert!(text.contains("Heat: Holds together under heat"));
+        assert!(text.contains("Surface: Cool blue tone"));
+        assert!(text.contains("Carried: Feather-light"));
+        assert!(text.contains("Surface: Dark mineral grey"));
+        assert!(text.contains("Heat: Glows faintly when heated"));
+        assert!(text.contains("Carried: Very heavy"));
+        assert!(text.contains("Surface: Translucent with prismatic flecks"));
+
+        // Entries are rendered alphabetically (Crystite, Ferrite, Silite, Volite).
+        let pos_crystite = text.find("Crystite").unwrap();
+        let pos_ferrite = text.find("Ferrite").unwrap();
+        let pos_silite = text.find("Silite").unwrap();
+        let pos_volite = text.find("Volite").unwrap();
+        assert!(
+            pos_crystite < pos_ferrite && pos_ferrite < pos_silite && pos_silite < pos_volite,
+            "materials must be rendered in alphabetical order"
+        );
+
+        // Thermal observations appear exactly where expected (Ferrite and
+        // Volite have thermal data; Silite and Crystite do not).
+        assert_eq!(
+            text.matches("Heat:").count(),
+            2,
+            "exactly two materials have thermal observations"
+        );
+        // Weight observations: Silite and Volite.
+        assert_eq!(
+            text.matches("Carried:").count(),
+            2,
+            "exactly two materials have weight observations"
+        );
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -534,7 +534,7 @@ fn build_journal_text(journal: &NewJournal) -> String {
         out.push(String::new());
         out.push("Recent Fabrication".to_string());
         for desc in &fabrication_descriptions {
-            out.push((*desc).to_string());
+            out.push(format!("  {desc}"));
         }
     }
 
@@ -543,11 +543,12 @@ fn build_journal_text(journal: &NewJournal) -> String {
     entries.sort_by(|a, b| a.name.cmp(&b.name));
 
     for entry in entries {
+        // Visual separator between entries for legibility.
         out.push(String::new());
-        out.push(entry.name.clone());
+        out.push(format!("--- {} ---", entry.name));
 
         for obs in entry.observations_by_category(&ObservationCategory::SurfaceAppearance) {
-            out.push(format!("Surface: {}", obs.description));
+            out.push(format!("  Surface: {}", obs.description));
         }
 
         // Show only the most recent thermal observation (matches legacy
@@ -556,7 +557,7 @@ fn build_journal_text(journal: &NewJournal) -> String {
             .observations_by_category(&ObservationCategory::ThermalBehavior)
             .last()
         {
-            out.push(format!("Heat: {}", thermal.description));
+            out.push(format!("  Heat: {}", thermal.description));
         }
 
         // Show only the most recent weight observation (matches legacy
@@ -565,11 +566,11 @@ fn build_journal_text(journal: &NewJournal) -> String {
             .observations_by_category(&ObservationCategory::Weight)
             .last()
         {
-            out.push(format!("Carried: {}", weight.description));
+            out.push(format!("  Carried: {}", weight.description));
         }
 
         for obs in entry.observations_by_category(&ObservationCategory::FabricationResult) {
-            out.push(obs.description.clone());
+            out.push(format!("  {}", obs.description));
         }
     }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1643,4 +1643,182 @@ mod tests {
             "fab_a must not contain observations from other keys"
         );
     }
+
+    /// The rendered text from `build_journal_text` preserves all information
+    /// that the legacy POC journal displayed: material names, surface
+    /// observations, thermal observations, weight observations, fabrication
+    /// history, and the "Recent Fabrication" header. This test populates a
+    /// `NewJournal` with the same variety of data the legacy `LegacyJournal`
+    /// held and asserts every piece of information appears in the output.
+    #[test]
+    fn rendered_text_contains_same_information_as_legacy_journal() {
+        let mut journal = NewJournal::default();
+
+        // ── Material entry with surface, thermal, and weight observations ──
+        // Legacy equivalent: LegacyJournalEntry with surface_observations,
+        // thermal_observation, and weight_observation populated.
+        let mat_key = JournalKey::Material { seed: 42 };
+
+        journal.record(
+            mat_key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 1,
+            },
+        );
+        journal.record(
+            mat_key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Slightly rough texture".into(),
+                recorded_at: 2,
+            },
+        );
+        journal.record(
+            mat_key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Holds together under heat".into(),
+                recorded_at: 3,
+            },
+        );
+        journal.record(
+            mat_key,
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Confident,
+                description: "Heavy but manageable".into(),
+                recorded_at: 4,
+            },
+        );
+
+        // ── Second material with only surface observation ───────────────
+        // Legacy equivalent: entry with surface_observations only (no thermal
+        // or weight).
+        let mat_key_b = JournalKey::Material { seed: 99 };
+        journal.record(
+            mat_key_b,
+            "Silite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Cool blue tone".into(),
+                recorded_at: 5,
+            },
+        );
+
+        // ── Fabrication entry ───────────────────────────────────────────
+        // Legacy equivalent: fabrication_log entry + LegacyJournalEntry with
+        // fabrication_history.
+        let fab_key = JournalKey::Fabrication { output_seed: 200 };
+        journal.record(
+            fab_key,
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Ferrite + Silite -> Neoite".into(),
+                recorded_at: 6,
+            },
+        );
+
+        let text = build_journal_text(&journal);
+
+        // ── Header ──────────────────────────────────────────────────────
+        assert!(
+            text.starts_with("Journal"),
+            "rendered text must start with Journal header"
+        );
+
+        // ── Material names displayed ────────────────────────────────────
+        assert!(
+            text.contains("Ferrite"),
+            "material name Ferrite must appear"
+        );
+        assert!(text.contains("Silite"), "material name Silite must appear");
+
+        // ── Surface observations prefixed with "Surface:" ───────────────
+        assert!(
+            text.contains("Surface: Warm rust tone"),
+            "surface observation must appear with Surface: prefix"
+        );
+        assert!(
+            text.contains("Surface: Slightly rough texture"),
+            "multiple surface observations must all appear"
+        );
+        assert!(
+            text.contains("Surface: Cool blue tone"),
+            "second material surface observation must appear"
+        );
+
+        // ── Thermal observation prefixed with "Heat:" ───────────────────
+        assert!(
+            text.contains("Heat: Holds together under heat"),
+            "thermal observation must appear with Heat: prefix"
+        );
+
+        // ── Weight observation prefixed with "Carried:" ─────────────────
+        assert!(
+            text.contains("Carried: Heavy but manageable"),
+            "weight observation must appear with Carried: prefix"
+        );
+
+        // ── Fabrication result in "Recent Fabrication" section ───────────
+        assert!(
+            text.contains("Recent Fabrication"),
+            "fabrication header must appear"
+        );
+        assert!(
+            text.contains("Combined Ferrite + Silite -> Neoite"),
+            "fabrication description must appear"
+        );
+
+        // ── Material without thermal/weight must NOT show those prefixes ─
+        // Split rendered text by material name to isolate Silite's section.
+        // Silite appears after Ferrite alphabetically — but we verify the
+        // overall text does not associate Heat:/Carried: with Silite by
+        // checking that Heat: and Carried: only appear once each (belonging
+        // to Ferrite).
+        let heat_count = text.matches("Heat:").count();
+        assert_eq!(
+            heat_count, 1,
+            "Heat: should appear exactly once (only for Ferrite)"
+        );
+        let carried_count = text.matches("Carried:").count();
+        assert_eq!(
+            carried_count, 1,
+            "Carried: should appear exactly once (only for Ferrite)"
+        );
+
+        // ── Fabrication name listed as an entry ─────────────────────────
+        assert!(
+            text.contains("Neoite"),
+            "fabrication output name must appear as an entry"
+        );
+    }
+
+    /// An empty journal renders without panic and shows the expected
+    /// placeholder text — matching the legacy behavior where an empty
+    /// journal simply displayed a header with no entries.
+    #[test]
+    fn empty_journal_renders_placeholder_text() {
+        let journal = NewJournal::default();
+        let text = build_journal_text(&journal);
+        assert!(
+            text.contains("Journal"),
+            "empty journal must still show header"
+        );
+        assert!(
+            text.contains("No observations yet."),
+            "empty journal must show placeholder message"
+        );
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -304,7 +304,9 @@ fn attach_journal_to_player(mut commands: Commands, player_query: Query<Entity, 
     let Ok(player) = player_query.single() else {
         return;
     };
-    commands.entity(player).insert(LegacyJournal::default());
+    commands
+        .entity(player)
+        .insert((LegacyJournal::default(), NewJournal::default()));
 }
 
 fn spawn_journal_ui(mut commands: Commands) {
@@ -371,13 +373,18 @@ fn toggle_journal_visibility(
 /// migrate rendering to `NewJournal`).
 fn apply_observations(
     mut reader: MessageReader<RecordObservation>,
-    mut player_query: Query<&mut LegacyJournal, With<Player>>,
+    mut player_query: Query<(&mut LegacyJournal, &mut NewJournal), With<Player>>,
 ) {
-    let Ok(mut journal) = player_query.single_mut() else {
+    let Ok((mut journal, mut new_journal)) = player_query.single_mut() else {
         return;
     };
 
     for event in reader.read() {
+        // Write into the new typed journal for all categories.
+        new_journal.record(event.key.clone(), &event.name, event.observation.clone());
+
+        // Also write into the legacy journal so the existing text overlay
+        // keeps working until story 10.2 migrates rendering.
         match event.observation.category {
             ObservationCategory::SurfaceAppearance => {
                 let entry = journal.ensure_entry(

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -914,4 +914,208 @@ mod tests {
         let journal = NewJournal::default();
         assert!(journal.entries.is_empty());
     }
+
+    /// Every type in the journal data model serializes to JSON and deserializes
+    /// back to an identical value. Covers all `JournalKey` variants, all
+    /// `ObservationCategory` variants, all `ConfidenceLevel` variants, the
+    /// `Observation` struct, `JournalEntry`, and a `NewJournal` containing
+    /// entries of every key type with observations of every category.
+    #[test]
+    fn all_types_serde_round_trip() {
+        // ── JournalKey variants ─────────────────────────────────────
+        let keys = vec![
+            JournalKey::Material { seed: 0 },
+            JournalKey::Material { seed: u64::MAX },
+            JournalKey::Fabrication { output_seed: 42 },
+        ];
+        for key in &keys {
+            let json = serde_json::to_string(key).expect("JournalKey should serialize");
+            let rt: JournalKey =
+                serde_json::from_str(&json).expect("JournalKey should deserialize");
+            assert_eq!(*key, rt);
+        }
+
+        // ── ObservationCategory variants ────────────────────────────
+        let categories = vec![
+            ObservationCategory::SurfaceAppearance,
+            ObservationCategory::ThermalBehavior,
+            ObservationCategory::Weight,
+            ObservationCategory::FabricationResult,
+            ObservationCategory::LocationNote,
+        ];
+        for cat in &categories {
+            let json = serde_json::to_string(cat).expect("ObservationCategory should serialize");
+            let rt: ObservationCategory =
+                serde_json::from_str(&json).expect("ObservationCategory should deserialize");
+            assert_eq!(*cat, rt);
+        }
+
+        // ── ConfidenceLevel variants ────────────────────────────────
+        let levels = vec![
+            ConfidenceLevel::Tentative,
+            ConfidenceLevel::Observed,
+            ConfidenceLevel::Confident,
+        ];
+        for level in &levels {
+            let json = serde_json::to_string(level).expect("ConfidenceLevel should serialize");
+            let rt: ConfidenceLevel =
+                serde_json::from_str(&json).expect("ConfidenceLevel should deserialize");
+            assert_eq!(*level, rt);
+        }
+
+        // ── Observation struct ──────────────────────────────────────
+        let observation = Observation {
+            category: ObservationCategory::ThermalBehavior,
+            confidence: ConfidenceLevel::Observed,
+            description: "Holds together under heat".into(),
+            recorded_at: 999,
+        };
+        let json = serde_json::to_string(&observation).expect("Observation should serialize");
+        let rt: Observation = serde_json::from_str(&json).expect("Observation should deserialize");
+        assert_eq!(rt.category, observation.category);
+        assert_eq!(rt.confidence, observation.confidence);
+        assert_eq!(rt.description, observation.description);
+        assert_eq!(rt.recorded_at, observation.recorded_at);
+
+        // ── JournalEntry struct ─────────────────────────────────────
+        let mut entry = JournalEntry::new(JournalKey::Material { seed: 7 }, "Ferrite".into(), 10);
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::Weight,
+            confidence: ConfidenceLevel::Confident,
+            description: "Very heavy".into(),
+            recorded_at: 20,
+        });
+
+        let json = serde_json::to_string(&entry).expect("JournalEntry should serialize");
+        let rt: JournalEntry =
+            serde_json::from_str(&json).expect("JournalEntry should deserialize");
+        assert_eq!(rt.key, entry.key);
+        assert_eq!(rt.name, entry.name);
+        assert_eq!(rt.observations.len(), 2);
+        assert_eq!(rt.first_observed_at, entry.first_observed_at);
+        assert_eq!(rt.last_updated_at, entry.last_updated_at);
+        assert_eq!(
+            rt.observations[0].category,
+            ObservationCategory::SurfaceAppearance
+        );
+        assert_eq!(rt.observations[1].category, ObservationCategory::Weight);
+
+        // ── NewJournal with all key types and all categories ────────
+        let mut journal = NewJournal::default();
+
+        // Material entry with surface, thermal, and weight observations.
+        let mat_key = JournalKey::Material { seed: 100 };
+        journal.record(
+            mat_key.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Cool blue tone".into(),
+                recorded_at: 1,
+            },
+        );
+        journal.record(
+            mat_key.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Softens quickly under heat".into(),
+                recorded_at: 5,
+            },
+        );
+        journal.record(
+            mat_key.clone(),
+            "Silite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Confident,
+                description: "Light".into(),
+                recorded_at: 8,
+            },
+        );
+
+        // Fabrication entry with fabrication result and location note.
+        let fab_key = JournalKey::Fabrication { output_seed: 200 };
+        journal.record(
+            fab_key.clone(),
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Silite + Ferrite -> Neoite".into(),
+                recorded_at: 10,
+            },
+        );
+        journal.record(
+            fab_key.clone(),
+            "Neoite",
+            Observation {
+                category: ObservationCategory::LocationNote,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Found near volcanic ridge".into(),
+                recorded_at: 15,
+            },
+        );
+
+        let json = serde_json::to_string(&journal).expect("NewJournal should serialize");
+        let rt: NewJournal = serde_json::from_str(&json).expect("NewJournal should deserialize");
+
+        // Verify structure preserved.
+        assert_eq!(rt.entries.len(), 2);
+
+        let silite = rt
+            .entries
+            .get(&mat_key)
+            .expect("Material entry should exist");
+        assert_eq!(silite.name, "Silite");
+        assert_eq!(silite.observations.len(), 3);
+        assert_eq!(silite.first_observed_at, 1);
+        assert_eq!(silite.last_updated_at, 8);
+        assert_eq!(
+            silite.observations[0].category,
+            ObservationCategory::SurfaceAppearance
+        );
+        assert_eq!(
+            silite.observations[0].confidence,
+            ConfidenceLevel::Tentative
+        );
+        assert_eq!(
+            silite.observations[1].category,
+            ObservationCategory::ThermalBehavior
+        );
+        assert_eq!(silite.observations[2].category, ObservationCategory::Weight);
+
+        let neoite = rt
+            .entries
+            .get(&fab_key)
+            .expect("Fabrication entry should exist");
+        assert_eq!(neoite.name, "Neoite");
+        assert_eq!(neoite.observations.len(), 2);
+        assert_eq!(neoite.first_observed_at, 10);
+        assert_eq!(neoite.last_updated_at, 15);
+        assert_eq!(
+            neoite.observations[0].category,
+            ObservationCategory::FabricationResult
+        );
+        assert_eq!(
+            neoite.observations[0].confidence,
+            ConfidenceLevel::Confident
+        );
+        assert_eq!(
+            neoite.observations[1].category,
+            ObservationCategory::LocationNote
+        );
+        assert_eq!(
+            neoite.observations[1].description,
+            "Found near volcanic ridge"
+        );
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -987,6 +987,13 @@ mod tests {
     }
 
     #[test]
+    fn empty_journal_renders_no_observations_yet() {
+        let journal = NewJournal::default();
+        let text = build_journal_text(&journal);
+        assert_eq!(text, "Journal\n\nNo observations yet.");
+    }
+
+    #[test]
     fn single_observation_recorded_correctly() {
         let mut journal = NewJournal::default();
         let key = JournalKey::Material { seed: 55 };

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1066,6 +1066,150 @@ mod tests {
         );
     }
 
+    /// Multiple observations recorded against the same `JournalKey` via
+    /// `NewJournal::record` accumulate in chronological order. The entry is
+    /// created once and subsequent observations append without replacing
+    /// earlier ones, timestamps track the full observation window, and each
+    /// observation preserves its own category, confidence, and description.
+    #[test]
+    fn multiple_observations_for_same_key_accumulate() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 77 };
+
+        // First observation — creates the entry.
+        journal.record(
+            key.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Dark mineral grey".into(),
+                recorded_at: 10,
+            },
+        );
+
+        // Second observation — same key, different category.
+        journal.record(
+            key.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Glows faintly when heated".into(),
+                recorded_at: 25,
+            },
+        );
+
+        // Third observation — same key, same category as first but different description.
+        journal.record(
+            key.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Slightly crystalline texture".into(),
+                recorded_at: 40,
+            },
+        );
+
+        // Fourth observation — same key, yet another category.
+        journal.record(
+            key.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::Weight,
+                confidence: ConfidenceLevel::Confident,
+                description: "Very heavy".into(),
+                recorded_at: 60,
+            },
+        );
+
+        // Fifth observation — fabrication result recorded against the same material key.
+        journal.record(
+            key.clone(),
+            "Volite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Volite + Silite -> Crystite".into(),
+                recorded_at: 80,
+            },
+        );
+
+        // Only one entry exists for the key.
+        assert_eq!(journal.entries.len(), 1, "all observations share one entry");
+        let entry = journal.entries.get(&key).expect("entry should exist");
+
+        // Name set by the first record call is retained.
+        assert_eq!(entry.name, "Volite");
+
+        // Timestamps span the full observation window.
+        assert_eq!(entry.first_observed_at, 10);
+        assert_eq!(entry.last_updated_at, 80);
+
+        // All five distinct observations accumulated.
+        assert_eq!(entry.observations.len(), 5);
+
+        // Verify each observation in chronological order.
+        assert_eq!(
+            entry.observations[0].category,
+            ObservationCategory::SurfaceAppearance
+        );
+        assert_eq!(entry.observations[0].description, "Dark mineral grey");
+        assert_eq!(entry.observations[0].confidence, ConfidenceLevel::Tentative);
+        assert_eq!(entry.observations[0].recorded_at, 10);
+
+        assert_eq!(
+            entry.observations[1].category,
+            ObservationCategory::ThermalBehavior
+        );
+        assert_eq!(
+            entry.observations[1].description,
+            "Glows faintly when heated"
+        );
+        assert_eq!(entry.observations[1].confidence, ConfidenceLevel::Observed);
+        assert_eq!(entry.observations[1].recorded_at, 25);
+
+        assert_eq!(
+            entry.observations[2].category,
+            ObservationCategory::SurfaceAppearance
+        );
+        assert_eq!(
+            entry.observations[2].description,
+            "Slightly crystalline texture"
+        );
+        assert_eq!(entry.observations[2].confidence, ConfidenceLevel::Observed);
+        assert_eq!(entry.observations[2].recorded_at, 40);
+
+        assert_eq!(entry.observations[3].category, ObservationCategory::Weight);
+        assert_eq!(entry.observations[3].description, "Very heavy");
+        assert_eq!(entry.observations[3].confidence, ConfidenceLevel::Confident);
+        assert_eq!(entry.observations[3].recorded_at, 60);
+
+        assert_eq!(
+            entry.observations[4].category,
+            ObservationCategory::FabricationResult
+        );
+        assert_eq!(
+            entry.observations[4].description,
+            "Combined Volite + Silite -> Crystite"
+        );
+        assert_eq!(entry.observations[4].confidence, ConfidenceLevel::Confident);
+        assert_eq!(entry.observations[4].recorded_at, 80);
+
+        // Category filtering works across accumulated observations.
+        let surface = entry.observations_by_category(&ObservationCategory::SurfaceAppearance);
+        assert_eq!(surface.len(), 2);
+        let thermal = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
+        assert_eq!(thermal.len(), 1);
+        let weight = entry.observations_by_category(&ObservationCategory::Weight);
+        assert_eq!(weight.len(), 1);
+        let fab = entry.observations_by_category(&ObservationCategory::FabricationResult);
+        assert_eq!(fab.len(), 1);
+        let loc = entry.observations_by_category(&ObservationCategory::LocationNote);
+        assert_eq!(loc.len(), 0);
+    }
+
     /// Every type in the journal data model serializes to JSON and deserializes
     /// back to an identical value. Covers all `JournalKey` variants, all
     /// `ObservationCategory` variants, all `ConfidenceLevel` variants, the

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -17,6 +17,48 @@ use crate::materials::GameMaterial;
 use crate::observation::{ConfidenceLevel, describe_thermal_observation};
 use crate::player::{Player, cursor_is_captured, spawn_player};
 
+// ── Observation data model ──────────────────────────────────────────────
+
+/// Categories of observation — extensible by adding variants.
+///
+/// Each variant represents a distinct *kind* of knowledge the player can
+/// accumulate about a journal subject. New game systems (navigation,
+/// trade, language) add variants here without touching existing match
+/// arms or storage structures.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObservationCategory {
+    /// Visual or tactile surface properties noticed on first examination.
+    SurfaceAppearance,
+    /// How the subject reacts to heat or cold exposure.
+    ThermalBehavior,
+    /// Perceived heft or density when the player picks up the subject.
+    Weight,
+    /// Outcome of combining materials in the fabricator.
+    FabricationResult,
+    /// A note about a specific location (landmark, hazard, resource).
+    LocationNote,
+    // Future: LanguageFragment, CulturalBehavior, TradePrice, etc.
+}
+
+/// A single observation about a journal subject, timestamped.
+///
+/// Observations are the atomic unit of player knowledge. Each one records
+/// *what* was observed ([`ObservationCategory`]), *how confident* the
+/// player should be ([`ConfidenceLevel`]), a human-readable description,
+/// and the game-time tick when it was recorded. Observations accumulate
+/// inside a [`JournalEntry`] over time — the journal never forgets.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Observation {
+    /// What kind of knowledge this observation represents.
+    pub category: ObservationCategory,
+    /// How certain the player is based on repeated evidence.
+    pub confidence: ConfidenceLevel,
+    /// Player-facing prose description of the observation.
+    pub description: String,
+    /// Game-time tick when this observation was recorded.
+    pub recorded_at: u64,
+}
+
 // ── Journal key ─────────────────────────────────────────────────────────
 
 /// Unique key identifying a journal subject.

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -173,13 +173,31 @@ impl JournalEntry {
         }
     }
 
-    /// Append an observation and update the `last_updated_at` timestamp.
+    /// Record an observation, deduplicating against existing entries.
     ///
-    /// The observation's `recorded_at` tick is used as the new
-    /// `last_updated_at` value, so callers must ensure observations are
-    /// appended in monotonically non-decreasing tick order.
+    /// If an observation with the same category **and** the same description
+    /// already exists, the duplicate is not appended. Instead, the existing
+    /// observation's confidence is upgraded to the higher of the two values
+    /// and the `last_updated_at` timestamp is advanced. This prevents the
+    /// journal from bloating when systems repeatedly report the same finding
+    /// (e.g., picking up the same material multiple times).
+    ///
+    /// When the observation is genuinely new (different category or different
+    /// description), it is appended normally.
     pub fn add_observation(&mut self, observation: Observation) {
         self.last_updated_at = observation.recorded_at;
+
+        // Look for an existing observation with the same category and description.
+        if let Some(existing) = self.observations.iter_mut().find(|o| {
+            o.category == observation.category && o.description == observation.description
+        }) {
+            // Upgrade confidence if the new evidence is stronger.
+            if observation.confidence > existing.confidence {
+                existing.confidence = observation.confidence;
+            }
+            return;
+        }
+
         self.observations.push(observation);
     }
 
@@ -882,6 +900,135 @@ mod tests {
     fn new_journal_empty_default() {
         let journal = NewJournal::default();
         assert!(journal.entries.is_empty());
+    }
+
+    #[test]
+    fn duplicate_observation_same_category_and_description_is_skipped() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        });
+        // Same category + same description at a later tick — should NOT add a second entry.
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 20,
+        });
+
+        assert_eq!(entry.observations.len(), 1, "duplicate should be skipped");
+        // Timestamp still advances even when the observation is deduplicated.
+        assert_eq!(entry.last_updated_at, 20);
+    }
+
+    #[test]
+    fn duplicate_observation_upgrades_confidence() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::ThermalBehavior,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Holds together under heat".into(),
+            recorded_at: 10,
+        });
+        // Same category + description but higher confidence — should upgrade.
+        entry.add_observation(Observation {
+            category: ObservationCategory::ThermalBehavior,
+            confidence: ConfidenceLevel::Confident,
+            description: "Holds together under heat".into(),
+            recorded_at: 30,
+        });
+
+        assert_eq!(entry.observations.len(), 1, "duplicate should be skipped");
+        assert_eq!(
+            entry.observations[0].confidence,
+            ConfidenceLevel::Confident,
+            "confidence should be upgraded"
+        );
+        assert_eq!(entry.last_updated_at, 30);
+    }
+
+    #[test]
+    fn duplicate_does_not_downgrade_confidence() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::Weight,
+            confidence: ConfidenceLevel::Confident,
+            description: "Heavy".into(),
+            recorded_at: 10,
+        });
+        // Same category + description but lower confidence — confidence should stay.
+        entry.add_observation(Observation {
+            category: ObservationCategory::Weight,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Heavy".into(),
+            recorded_at: 20,
+        });
+
+        assert_eq!(entry.observations.len(), 1);
+        assert_eq!(
+            entry.observations[0].confidence,
+            ConfidenceLevel::Confident,
+            "confidence should not downgrade"
+        );
+    }
+
+    #[test]
+    fn same_category_different_description_is_not_duplicate() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Slightly rough texture".into(),
+            recorded_at: 20,
+        });
+
+        assert_eq!(
+            entry.observations.len(),
+            2,
+            "different descriptions are distinct observations"
+        );
+    }
+
+    #[test]
+    fn same_description_different_category_is_not_duplicate() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Notable".into(),
+            recorded_at: 10,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::LocationNote,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Notable".into(),
+            recorded_at: 20,
+        });
+
+        assert_eq!(
+            entry.observations.len(),
+            2,
+            "different categories are distinct observations"
+        );
     }
 
     /// Every type in the journal data model serializes to JSON and deserializes

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -24,7 +24,7 @@ use crate::player::{Player, cursor_is_captured, spawn_player};
 /// accumulate about a journal subject. New game systems (navigation,
 /// trade, language) add variants here without touching existing match
 /// arms or storage structures.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ObservationCategory {
     /// Visual or tactile surface properties noticed on first examination.
     SurfaceAppearance,
@@ -148,8 +148,12 @@ pub struct JournalEntry {
     pub key: JournalKey,
     /// Player-facing display name for this subject.
     pub name: String,
-    /// Chronologically ordered observations accumulated over time.
-    pub observations: Vec<Observation>,
+    /// Observations grouped by category, each group in chronological order.
+    ///
+    /// Using a `BTreeMap` gives deterministic iteration order over categories
+    /// (important for rendering stability and save/load reproducibility).
+    /// Within each category the `Vec` preserves insertion (chronological) order.
+    pub observations: BTreeMap<ObservationCategory, Vec<Observation>>,
     /// Game-time tick when the player first recorded *any* observation about
     /// this subject.
     pub first_observed_at: u64,
@@ -167,13 +171,14 @@ impl JournalEntry {
         Self {
             key,
             name,
-            observations: Vec::new(),
+            observations: BTreeMap::new(),
             first_observed_at: tick,
             last_updated_at: tick,
         }
     }
 
-    /// Record an observation, deduplicating against existing entries.
+    /// Record an observation, deduplicating against existing entries in the
+    /// same category group.
     ///
     /// If an observation with the same category **and** the same description
     /// already exists, the duplicate is not appended. Instead, the existing
@@ -183,14 +188,20 @@ impl JournalEntry {
     /// (e.g., picking up the same material multiple times).
     ///
     /// When the observation is genuinely new (different category or different
-    /// description), it is appended normally.
+    /// description), it is appended to the appropriate category group.
     pub fn add_observation(&mut self, observation: Observation) {
         self.last_updated_at = observation.recorded_at;
 
-        // Look for an existing observation with the same category and description.
-        if let Some(existing) = self.observations.iter_mut().find(|o| {
-            o.category == observation.category && o.description == observation.description
-        }) {
+        let group = self
+            .observations
+            .entry(observation.category.clone())
+            .or_default();
+
+        // Look for an existing observation with the same description within this category.
+        if let Some(existing) = group
+            .iter_mut()
+            .find(|o| o.description == observation.description)
+        {
             // Upgrade confidence if the new evidence is stronger.
             if observation.confidence > existing.confidence {
                 existing.confidence = observation.confidence;
@@ -198,15 +209,28 @@ impl JournalEntry {
             return;
         }
 
-        self.observations.push(observation);
+        group.push(observation);
     }
 
     /// Return all observations matching a given category, in recorded order.
-    pub fn observations_by_category(&self, category: &ObservationCategory) -> Vec<&Observation> {
+    ///
+    /// Returns an empty slice if no observations exist for the category.
+    pub fn observations_by_category(&self, category: &ObservationCategory) -> &[Observation] {
         self.observations
-            .iter()
-            .filter(|o| &o.category == category)
-            .collect()
+            .get(category)
+            .map_or(&[], |v| v.as_slice())
+    }
+
+    /// Total number of observations across all categories.
+    pub fn observation_count(&self) -> usize {
+        self.observations.values().map(|v| v.len()).sum()
+    }
+
+    /// Iterator over all observations across all categories, ordered by
+    /// category (deterministic via `BTreeMap`) then by insertion order
+    /// within each category.
+    pub fn all_observations(&self) -> impl Iterator<Item = &Observation> {
+        self.observations.values().flat_map(|v| v.iter())
     }
 }
 
@@ -500,9 +524,8 @@ fn build_journal_text(journal: &NewJournal) -> String {
         .values()
         .flat_map(|entry| {
             entry
-                .observations
+                .observations_by_category(&ObservationCategory::FabricationResult)
                 .iter()
-                .filter(|o| o.category == ObservationCategory::FabricationResult)
                 .map(|o| o.description.as_str())
         })
         .collect();
@@ -770,7 +793,7 @@ mod tests {
             recorded_at: 20,
         });
 
-        assert_eq!(entry.observations.len(), 1);
+        assert_eq!(entry.observation_count(), 1);
         assert_eq!(entry.first_observed_at, 10);
         assert_eq!(entry.last_updated_at, 20);
     }
@@ -799,7 +822,7 @@ mod tests {
             recorded_at: 55,
         });
 
-        assert_eq!(entry.observations.len(), 3);
+        assert_eq!(entry.observation_count(), 3);
         assert_eq!(entry.last_updated_at, 55);
     }
 
@@ -882,7 +905,7 @@ mod tests {
         );
 
         let entry = journal.entries.get(&key).expect("entry should exist");
-        assert_eq!(entry.observations.len(), 2);
+        assert_eq!(entry.observation_count(), 2);
         assert_eq!(entry.first_observed_at, 10);
         assert_eq!(entry.last_updated_at, 50);
     }
@@ -953,7 +976,7 @@ mod tests {
             .get(&JournalKey::Material { seed: 42 })
             .expect("Ferrite entry should exist");
         assert_eq!(ferrite.name, "Ferrite");
-        assert_eq!(ferrite.observations.len(), 1);
+        assert_eq!(ferrite.observation_count(), 1);
         assert_eq!(ferrite.first_observed_at, 10);
     }
 
@@ -990,8 +1013,8 @@ mod tests {
         assert_eq!(entry.last_updated_at, 42);
 
         // Exactly one observation stored.
-        assert_eq!(entry.observations.len(), 1);
-        let obs = &entry.observations[0];
+        assert_eq!(entry.observation_count(), 1);
+        let obs = &entry.observations_by_category(&ObservationCategory::ThermalBehavior)[0];
         assert_eq!(obs.category, ObservationCategory::ThermalBehavior);
         assert_eq!(obs.confidence, ConfidenceLevel::Observed);
         assert_eq!(obs.description, "Cracks under rapid heating");
@@ -1017,7 +1040,7 @@ mod tests {
             recorded_at: 20,
         });
 
-        assert_eq!(entry.observations.len(), 1, "duplicate should be skipped");
+        assert_eq!(entry.observation_count(), 1, "duplicate should be skipped");
         // Timestamp still advances even when the observation is deduplicated.
         assert_eq!(entry.last_updated_at, 20);
     }
@@ -1041,9 +1064,9 @@ mod tests {
             recorded_at: 30,
         });
 
-        assert_eq!(entry.observations.len(), 1, "duplicate should be skipped");
+        assert_eq!(entry.observation_count(), 1, "duplicate should be skipped");
         assert_eq!(
-            entry.observations[0].confidence,
+            entry.observations_by_category(&ObservationCategory::ThermalBehavior)[0].confidence,
             ConfidenceLevel::Confident,
             "confidence should be upgraded"
         );
@@ -1069,9 +1092,9 @@ mod tests {
             recorded_at: 20,
         });
 
-        assert_eq!(entry.observations.len(), 1);
+        assert_eq!(entry.observation_count(), 1);
         assert_eq!(
-            entry.observations[0].confidence,
+            entry.observations_by_category(&ObservationCategory::Weight)[0].confidence,
             ConfidenceLevel::Confident,
             "confidence should not downgrade"
         );
@@ -1096,7 +1119,9 @@ mod tests {
         });
 
         assert_eq!(
-            entry.observations.len(),
+            entry
+                .observations_by_category(&ObservationCategory::SurfaceAppearance)
+                .len(),
             2,
             "different descriptions are distinct observations"
         );
@@ -1121,7 +1146,7 @@ mod tests {
         });
 
         assert_eq!(
-            entry.observations.len(),
+            entry.observation_count(),
             2,
             "different categories are distinct observations"
         );
@@ -1208,65 +1233,37 @@ mod tests {
         assert_eq!(entry.first_observed_at, 10);
         assert_eq!(entry.last_updated_at, 80);
 
-        // All five distinct observations accumulated.
-        assert_eq!(entry.observations.len(), 5);
+        // All five distinct observations accumulated across four categories.
+        assert_eq!(entry.observation_count(), 5);
 
-        // Verify each observation in chronological order.
-        assert_eq!(
-            entry.observations[0].category,
-            ObservationCategory::SurfaceAppearance
-        );
-        assert_eq!(entry.observations[0].description, "Dark mineral grey");
-        assert_eq!(entry.observations[0].confidence, ConfidenceLevel::Tentative);
-        assert_eq!(entry.observations[0].recorded_at, 10);
-
-        assert_eq!(
-            entry.observations[1].category,
-            ObservationCategory::ThermalBehavior
-        );
-        assert_eq!(
-            entry.observations[1].description,
-            "Glows faintly when heated"
-        );
-        assert_eq!(entry.observations[1].confidence, ConfidenceLevel::Observed);
-        assert_eq!(entry.observations[1].recorded_at, 25);
-
-        assert_eq!(
-            entry.observations[2].category,
-            ObservationCategory::SurfaceAppearance
-        );
-        assert_eq!(
-            entry.observations[2].description,
-            "Slightly crystalline texture"
-        );
-        assert_eq!(entry.observations[2].confidence, ConfidenceLevel::Observed);
-        assert_eq!(entry.observations[2].recorded_at, 40);
-
-        assert_eq!(entry.observations[3].category, ObservationCategory::Weight);
-        assert_eq!(entry.observations[3].description, "Very heavy");
-        assert_eq!(entry.observations[3].confidence, ConfidenceLevel::Confident);
-        assert_eq!(entry.observations[3].recorded_at, 60);
-
-        assert_eq!(
-            entry.observations[4].category,
-            ObservationCategory::FabricationResult
-        );
-        assert_eq!(
-            entry.observations[4].description,
-            "Combined Volite + Silite -> Crystite"
-        );
-        assert_eq!(entry.observations[4].confidence, ConfidenceLevel::Confident);
-        assert_eq!(entry.observations[4].recorded_at, 80);
-
-        // Category filtering works across accumulated observations.
+        // Verify observations grouped by category.
         let surface = entry.observations_by_category(&ObservationCategory::SurfaceAppearance);
         assert_eq!(surface.len(), 2);
+        assert_eq!(surface[0].description, "Dark mineral grey");
+        assert_eq!(surface[0].confidence, ConfidenceLevel::Tentative);
+        assert_eq!(surface[0].recorded_at, 10);
+        assert_eq!(surface[1].description, "Slightly crystalline texture");
+        assert_eq!(surface[1].confidence, ConfidenceLevel::Observed);
+        assert_eq!(surface[1].recorded_at, 40);
+
         let thermal = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
         assert_eq!(thermal.len(), 1);
+        assert_eq!(thermal[0].description, "Glows faintly when heated");
+        assert_eq!(thermal[0].confidence, ConfidenceLevel::Observed);
+        assert_eq!(thermal[0].recorded_at, 25);
+
         let weight = entry.observations_by_category(&ObservationCategory::Weight);
         assert_eq!(weight.len(), 1);
+        assert_eq!(weight[0].description, "Very heavy");
+        assert_eq!(weight[0].confidence, ConfidenceLevel::Confident);
+        assert_eq!(weight[0].recorded_at, 60);
+
         let fab = entry.observations_by_category(&ObservationCategory::FabricationResult);
         assert_eq!(fab.len(), 1);
+        assert_eq!(fab[0].description, "Combined Volite + Silite -> Crystite");
+        assert_eq!(fab[0].confidence, ConfidenceLevel::Confident);
+        assert_eq!(fab[0].recorded_at, 80);
+
         let loc = entry.observations_by_category(&ObservationCategory::LocationNote);
         assert_eq!(loc.len(), 0);
     }
@@ -1353,14 +1350,19 @@ mod tests {
             serde_json::from_str(&json).expect("JournalEntry should deserialize");
         assert_eq!(rt.key, entry.key);
         assert_eq!(rt.name, entry.name);
-        assert_eq!(rt.observations.len(), 2);
+        assert_eq!(rt.observation_count(), 2);
         assert_eq!(rt.first_observed_at, entry.first_observed_at);
         assert_eq!(rt.last_updated_at, entry.last_updated_at);
         assert_eq!(
-            rt.observations[0].category,
-            ObservationCategory::SurfaceAppearance
+            rt.observations_by_category(&ObservationCategory::SurfaceAppearance)
+                .len(),
+            1
         );
-        assert_eq!(rt.observations[1].category, ObservationCategory::Weight);
+        assert_eq!(
+            rt.observations_by_category(&ObservationCategory::Weight)
+                .len(),
+            1
+        );
 
         // ── NewJournal with all key types and all categories ────────
         let mut journal = NewJournal::default();
@@ -1432,45 +1434,58 @@ mod tests {
             .get(&mat_key)
             .expect("Material entry should exist");
         assert_eq!(silite.name, "Silite");
-        assert_eq!(silite.observations.len(), 3);
+        assert_eq!(silite.observation_count(), 3);
         assert_eq!(silite.first_observed_at, 1);
         assert_eq!(silite.last_updated_at, 8);
         assert_eq!(
-            silite.observations[0].category,
-            ObservationCategory::SurfaceAppearance
+            silite
+                .observations_by_category(&ObservationCategory::SurfaceAppearance)
+                .len(),
+            1
         );
         assert_eq!(
-            silite.observations[0].confidence,
+            silite.observations_by_category(&ObservationCategory::SurfaceAppearance)[0].confidence,
             ConfidenceLevel::Tentative
         );
         assert_eq!(
-            silite.observations[1].category,
-            ObservationCategory::ThermalBehavior
+            silite
+                .observations_by_category(&ObservationCategory::ThermalBehavior)
+                .len(),
+            1
         );
-        assert_eq!(silite.observations[2].category, ObservationCategory::Weight);
+        assert_eq!(
+            silite
+                .observations_by_category(&ObservationCategory::Weight)
+                .len(),
+            1
+        );
 
         let neoite = rt
             .entries
             .get(&fab_key)
             .expect("Fabrication entry should exist");
         assert_eq!(neoite.name, "Neoite");
-        assert_eq!(neoite.observations.len(), 2);
+        assert_eq!(neoite.observation_count(), 2);
         assert_eq!(neoite.first_observed_at, 10);
         assert_eq!(neoite.last_updated_at, 15);
         assert_eq!(
-            neoite.observations[0].category,
-            ObservationCategory::FabricationResult
+            neoite
+                .observations_by_category(&ObservationCategory::FabricationResult)
+                .len(),
+            1
         );
         assert_eq!(
-            neoite.observations[0].confidence,
+            neoite.observations_by_category(&ObservationCategory::FabricationResult)[0].confidence,
             ConfidenceLevel::Confident
         );
         assert_eq!(
-            neoite.observations[1].category,
-            ObservationCategory::LocationNote
+            neoite
+                .observations_by_category(&ObservationCategory::LocationNote)
+                .len(),
+            1
         );
         assert_eq!(
-            neoite.observations[1].description,
+            neoite.observations_by_category(&ObservationCategory::LocationNote)[0].description,
             "Found near volcanic ridge"
         );
     }
@@ -1552,17 +1567,19 @@ mod tests {
             .get(&mat_a)
             .expect("mat_a entry should exist");
         assert_eq!(entry_a.name, "Ferrite");
-        assert_eq!(entry_a.observations.len(), 2);
+        assert_eq!(entry_a.observation_count(), 2);
         assert_eq!(entry_a.first_observed_at, 1);
         assert_eq!(entry_a.last_updated_at, 4);
         assert_eq!(
-            entry_a.observations[0].category,
-            ObservationCategory::SurfaceAppearance
+            entry_a.observations_by_category(&ObservationCategory::SurfaceAppearance)[0]
+                .description,
+            "Warm rust tone"
         );
-        assert_eq!(entry_a.observations[0].description, "Warm rust tone");
         assert_eq!(
-            entry_a.observations[1].category,
-            ObservationCategory::ThermalBehavior
+            entry_a
+                .observations_by_category(&ObservationCategory::ThermalBehavior)
+                .len(),
+            1
         );
 
         // ── Verify material B ───────────────────────────────────────
@@ -1571,10 +1588,14 @@ mod tests {
             .get(&mat_b)
             .expect("mat_b entry should exist");
         assert_eq!(entry_b.name, "Silite");
-        assert_eq!(entry_b.observations.len(), 1);
+        assert_eq!(entry_b.observation_count(), 1);
         assert_eq!(entry_b.first_observed_at, 2);
         assert_eq!(entry_b.last_updated_at, 2);
-        assert_eq!(entry_b.observations[0].description, "Cool blue tone");
+        assert_eq!(
+            entry_b.observations_by_category(&ObservationCategory::SurfaceAppearance)[0]
+                .description,
+            "Cool blue tone"
+        );
 
         // ── Verify fabrication A (same numeric id as mat_a) ─────────
         let entry_fab = journal
@@ -1582,20 +1603,21 @@ mod tests {
             .get(&fab_a)
             .expect("fab_a entry should exist");
         assert_eq!(entry_fab.name, "Neoite");
-        assert_eq!(entry_fab.observations.len(), 1);
+        assert_eq!(entry_fab.observation_count(), 1);
         assert_eq!(entry_fab.first_observed_at, 3);
         assert_eq!(entry_fab.last_updated_at, 3);
         assert_eq!(
-            entry_fab.observations[0].category,
-            ObservationCategory::FabricationResult
+            entry_fab
+                .observations_by_category(&ObservationCategory::FabricationResult)
+                .len(),
+            1
         );
 
         // ── Cross-contamination checks ──────────────────────────────
         // Material A must not contain material B's or fab_a's observations.
         assert!(
             entry_a
-                .observations
-                .iter()
+                .all_observations()
                 .all(|o| o.description != "Cool blue tone"
                     && o.description != "Combined Ferrite + Silite -> Neoite"),
             "mat_a must not contain observations from other keys"
@@ -1604,8 +1626,7 @@ mod tests {
         // Material B must not contain material A's or fab_a's observations.
         assert!(
             entry_b
-                .observations
-                .iter()
+                .all_observations()
                 .all(|o| o.description != "Warm rust tone"
                     && o.description != "Holds together under heat"
                     && o.description != "Combined Ferrite + Silite -> Neoite"),
@@ -1615,8 +1636,7 @@ mod tests {
         // Fabrication A must not contain either material's observations.
         assert!(
             entry_fab
-                .observations
-                .iter()
+                .all_observations()
                 .all(|o| o.description != "Warm rust tone"
                     && o.description != "Cool blue tone"
                     && o.description != "Holds together under heat"),

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -10,11 +10,40 @@ use std::collections::BTreeMap;
 
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::input::InputAction;
 use crate::materials::GameMaterial;
 use crate::observation::{ConfidenceLevel, describe_thermal_observation};
 use crate::player::{Player, cursor_is_captured, spawn_player};
+
+// ── Journal key ─────────────────────────────────────────────────────────
+
+/// Unique key identifying a journal subject.
+///
+/// Each variant encodes both the *type* of subject (material, fabrication
+/// output, etc.) and the identity that distinguishes one instance from
+/// another. The enum is intentionally non-exhaustive so future systems
+/// (navigation, trade, language) can add variants without breaking
+/// existing match arms.
+///
+/// `Ord` is derived so that `JournalKey` can serve as a `BTreeMap` key,
+/// giving the journal a stable, deterministic iteration order.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum JournalKey {
+    /// A raw or discovered material, keyed by its procedural seed.
+    Material {
+        /// The deterministic seed that uniquely identifies this material
+        /// within the world generation system.
+        seed: u64,
+    },
+    /// The output of a fabrication process, keyed by the resulting
+    /// material's seed.
+    Fabrication {
+        /// The deterministic seed of the fabricated output material.
+        output_seed: u64,
+    },
+}
 
 pub struct JournalPlugin;
 
@@ -426,6 +455,61 @@ mod tests {
 
         let text = build_journal_text(&journal);
         assert!(text.contains("Heat: Reliably hold together under heat"));
+    }
+
+    #[test]
+    fn journal_key_material_equality() {
+        let a = JournalKey::Material { seed: 42 };
+        let b = JournalKey::Material { seed: 42 };
+        let c = JournalKey::Material { seed: 99 };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn journal_key_fabrication_equality() {
+        let a = JournalKey::Fabrication { output_seed: 7 };
+        let b = JournalKey::Fabrication { output_seed: 7 };
+        let c = JournalKey::Fabrication { output_seed: 8 };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn journal_key_variants_are_distinct() {
+        let mat = JournalKey::Material { seed: 42 };
+        let fab = JournalKey::Fabrication { output_seed: 42 };
+        assert_ne!(mat, fab);
+    }
+
+    #[test]
+    fn journal_key_serde_round_trip() {
+        let keys = vec![
+            JournalKey::Material { seed: 123 },
+            JournalKey::Fabrication { output_seed: 456 },
+        ];
+        for key in &keys {
+            let json = serde_json::to_string(key).expect("JournalKey should serialize to JSON");
+            let deserialized: JournalKey =
+                serde_json::from_str(&json).expect("JournalKey should deserialize from JSON");
+            assert_eq!(*key, deserialized);
+        }
+    }
+
+    #[test]
+    fn journal_key_btreemap_ordering_is_stable() {
+        use std::collections::BTreeMap;
+        let mut map = BTreeMap::new();
+        map.insert(JournalKey::Fabrication { output_seed: 1 }, "fab");
+        map.insert(JournalKey::Material { seed: 99 }, "mat99");
+        map.insert(JournalKey::Material { seed: 1 }, "mat1");
+
+        let keys: Vec<_> = map.keys().collect();
+        // Derived Ord: enum variants ordered by declaration (Material < Fabrication),
+        // then by field values within each variant.
+        assert_eq!(*keys[0], JournalKey::Material { seed: 1 });
+        assert_eq!(*keys[1], JournalKey::Material { seed: 99 });
+        assert_eq!(*keys[2], JournalKey::Fabrication { output_seed: 1 });
     }
 
     #[test]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -13,8 +13,7 @@ use leafwing_input_manager::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::input::InputAction;
-use crate::materials::GameMaterial;
-use crate::observation::{ConfidenceLevel, describe_thermal_observation};
+use crate::observation::ConfidenceLevel;
 use crate::player::{Player, cursor_is_captured, spawn_player};
 
 // ── Observation data model ──────────────────────────────────────────────
@@ -91,10 +90,7 @@ pub struct JournalPlugin;
 
 impl Plugin for JournalPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<RecordEncounter>()
-            .add_message::<RecordFabrication>()
-            .add_message::<RecordThermalObservation>()
-            .add_message::<RecordWeightObservation>()
+        app.add_message::<RecordObservation>()
             .add_message::<ToggleJournalIntent>()
             .init_resource::<JournalUiState>()
             .add_systems(
@@ -109,15 +105,8 @@ impl Plugin for JournalPlugin {
                 (
                     emit_toggle_journal_intent,
                     toggle_journal_visibility.after(emit_toggle_journal_intent),
-                    apply_encounter_records,
-                    apply_fabrication_records,
-                    apply_thermal_records,
-                    apply_weight_records,
-                    render_journal
-                        .after(apply_encounter_records)
-                        .after(apply_fabrication_records)
-                        .after(apply_thermal_records)
-                        .after(apply_weight_records),
+                    apply_observations,
+                    render_journal.after(apply_observations),
                 ),
             );
     }
@@ -125,31 +114,23 @@ impl Plugin for JournalPlugin {
 
 // ── Messages ────────────────────────────────────────────────────────────
 
+/// Unified message for recording any observation in the player's journal.
+///
+/// Any game system (materials, heat, carry, fabrication, navigation, trade)
+/// sends this single message type instead of a per-category variant. The
+/// journal ingestion system routes based on the [`Observation::category`]
+/// field — callers only need to fill in the key, name, and observation.
 #[derive(Message, Clone)]
-pub struct RecordEncounter {
-    pub material: GameMaterial,
-}
-
-#[derive(Message, Clone)]
-pub struct RecordFabrication {
-    pub output_material: GameMaterial,
-    pub input_a: String,
-    pub input_b: String,
-}
-
-#[derive(Message, Clone)]
-pub struct RecordThermalObservation {
-    pub seed: u64,
+pub struct RecordObservation {
+    /// Which journal subject this observation belongs to.
+    pub key: JournalKey,
+    /// Player-facing display name for the subject (used to initialise the
+    /// entry on first encounter; ignored for subsequent observations of the
+    /// same key).
     pub name: String,
-    pub thermal_resistance: f32,
-    pub confidence: ConfidenceLevel,
-}
-
-#[derive(Message, Clone)]
-pub struct RecordWeightObservation {
-    pub seed: u64,
-    pub name: String,
-    pub description: String,
+    /// The observation payload including category, confidence, description,
+    /// and game-time tick.
+    pub observation: Observation,
 }
 
 // ── Player-owned journal data ───────────────────────────────────────────
@@ -385,8 +366,11 @@ fn toggle_journal_visibility(
 
 // ── Record ingestion ────────────────────────────────────────────────────
 
-fn apply_encounter_records(
-    mut reader: MessageReader<RecordEncounter>,
+/// Unified ingestion system — reads [`RecordObservation`] messages and
+/// writes them into the legacy journal for rendering (story 10.2 will
+/// migrate rendering to `NewJournal`).
+fn apply_observations(
+    mut reader: MessageReader<RecordObservation>,
     mut player_query: Query<&mut LegacyJournal, With<Player>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
@@ -394,77 +378,55 @@ fn apply_encounter_records(
     };
 
     for event in reader.read() {
-        let entry = journal.ensure_entry(event.material.seed, &event.material.name);
-        if entry.surface_observations.is_empty() {
-            entry.surface_observations = vec![
-                format!("Color: {}", describe_color(&event.material.color)),
-                format!("Weight: {}", describe_density(event.material.density.value)),
-            ];
+        match event.observation.category {
+            ObservationCategory::SurfaceAppearance => {
+                let entry = journal.ensure_entry(
+                    match &event.key {
+                        JournalKey::Material { seed } => *seed,
+                        JournalKey::Fabrication { output_seed } => *output_seed,
+                    },
+                    &event.name,
+                );
+                if entry.surface_observations.is_empty() {
+                    entry
+                        .surface_observations
+                        .push(event.observation.description.clone());
+                }
+            }
+            ObservationCategory::ThermalBehavior => {
+                let seed = match &event.key {
+                    JournalKey::Material { seed } => *seed,
+                    JournalKey::Fabrication { output_seed } => *output_seed,
+                };
+                let entry = journal.ensure_entry(seed, &event.name);
+                entry.thermal_observation = Some(event.observation.description.clone());
+            }
+            ObservationCategory::Weight => {
+                let seed = match &event.key {
+                    JournalKey::Material { seed } => *seed,
+                    JournalKey::Fabrication { output_seed } => *output_seed,
+                };
+                let entry = journal.ensure_entry(seed, &event.name);
+                entry.weight_observation = Some(event.observation.description.clone());
+            }
+            ObservationCategory::FabricationResult => {
+                let description = &event.observation.description;
+                if !journal.fabrication_log.contains(description) {
+                    journal.fabrication_log.push(description.clone());
+                }
+                let seed = match &event.key {
+                    JournalKey::Material { seed } => *seed,
+                    JournalKey::Fabrication { output_seed } => *output_seed,
+                };
+                let entry = journal.ensure_entry(seed, &event.name);
+                if !entry.fabrication_history.contains(description) {
+                    entry.fabrication_history.push(description.clone());
+                }
+            }
+            ObservationCategory::LocationNote => {
+                // Location notes are a future feature; no legacy rendering yet.
+            }
         }
-    }
-}
-
-fn apply_fabrication_records(
-    mut reader: MessageReader<RecordFabrication>,
-    mut player_query: Query<&mut LegacyJournal, With<Player>>,
-) {
-    let Ok(mut journal) = player_query.single_mut() else {
-        return;
-    };
-
-    for event in reader.read() {
-        let history = format!(
-            "Combined {} + {} -> {}",
-            event.input_a, event.input_b, event.output_material.name
-        );
-        if !journal.fabrication_log.contains(&history) {
-            journal.fabrication_log.push(history.clone());
-        }
-
-        let entry = journal.ensure_entry(event.output_material.seed, &event.output_material.name);
-        if entry.surface_observations.is_empty() {
-            entry.surface_observations = vec![
-                format!("Color: {}", describe_color(&event.output_material.color)),
-                format!(
-                    "Weight: {}",
-                    describe_density(event.output_material.density.value)
-                ),
-            ];
-        }
-        if !entry.fabrication_history.contains(&history) {
-            entry.fabrication_history.push(history);
-        }
-    }
-}
-
-fn apply_thermal_records(
-    mut reader: MessageReader<RecordThermalObservation>,
-    mut player_query: Query<&mut LegacyJournal, With<Player>>,
-) {
-    let Ok(mut journal) = player_query.single_mut() else {
-        return;
-    };
-
-    for event in reader.read() {
-        let entry = journal.ensure_entry(event.seed, &event.name);
-        entry.thermal_observation = Some(describe_thermal_observation(
-            event.thermal_resistance,
-            event.confidence,
-        ));
-    }
-}
-
-fn apply_weight_records(
-    mut reader: MessageReader<RecordWeightObservation>,
-    mut player_query: Query<&mut LegacyJournal, With<Player>>,
-) {
-    let Ok(mut journal) = player_query.single_mut() else {
-        return;
-    };
-
-    for event in reader.read() {
-        let entry = journal.ensure_entry(event.seed, &event.name);
-        entry.weight_observation = Some(event.description.clone());
     }
 }
 
@@ -541,7 +503,7 @@ fn build_journal_text(journal: &LegacyJournal) -> String {
 
 // ── Descriptive language ────────────────────────────────────────────────
 
-fn describe_density(value: f32) -> &'static str {
+pub fn describe_density(value: f32) -> &'static str {
     if value < 0.15 {
         "Almost weightless"
     } else if value < 0.3 {
@@ -559,7 +521,7 @@ fn describe_density(value: f32) -> &'static str {
     }
 }
 
-fn describe_color(color: &[f32; 3]) -> &'static str {
+pub fn describe_color(color: &[f32; 3]) -> &'static str {
     let [r, g, b] = *color;
     let max = r.max(g).max(b);
     let min = r.min(g).min(b);

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -240,7 +240,7 @@ impl JournalEntry {
 /// Keyed by [`JournalKey`] so lookups are O(log n) and iteration order is
 /// deterministic (important for save/load reproducibility and test stability).
 #[derive(Component, Default, Clone, Debug, Serialize, Deserialize)]
-pub struct NewJournal {
+pub struct Journal {
     /// All journal entries, keyed by subject identity.
     ///
     /// Serialized as a list of entries (not a JSON object) because
@@ -274,7 +274,7 @@ mod journal_entries_serde {
     }
 }
 
-impl NewJournal {
+impl Journal {
     /// Look up or create a journal entry for the given key.
     ///
     /// If no entry exists yet, one is created with the provided `name` and
@@ -298,35 +298,6 @@ impl NewJournal {
     }
 }
 
-// ── Legacy journal structs (POC — will be removed by migration stories) ─
-
-#[derive(Component, Default)]
-struct LegacyJournal {
-    fabrication_log: Vec<String>,
-    entries: BTreeMap<u64, LegacyJournalEntry>,
-}
-
-#[expect(dead_code)]
-#[derive(Clone, Debug, Default)]
-struct LegacyJournalEntry {
-    name: String,
-    surface_observations: Vec<String>,
-    thermal_observation: Option<String>,
-    weight_observation: Option<String>,
-    fabrication_history: Vec<String>,
-}
-
-impl LegacyJournal {
-    fn ensure_entry(&mut self, seed: u64, name: &str) -> &mut LegacyJournalEntry {
-        self.entries
-            .entry(seed)
-            .or_insert_with(|| LegacyJournalEntry {
-                name: name.to_string(),
-                ..default()
-            })
-    }
-}
-
 // ── UI state ────────────────────────────────────────────────────────────
 
 #[derive(Resource, Default)]
@@ -347,9 +318,7 @@ fn attach_journal_to_player(mut commands: Commands, player_query: Query<Entity, 
     let Ok(player) = player_query.single() else {
         return;
     };
-    commands
-        .entity(player)
-        .insert((LegacyJournal::default(), NewJournal::default()));
+    commands.entity(player).insert(Journal::default());
 }
 
 fn spawn_journal_ui(mut commands: Commands) {
@@ -412,71 +381,25 @@ fn toggle_journal_visibility(
 // ── Record ingestion ────────────────────────────────────────────────────
 
 /// Unified ingestion system — reads [`RecordObservation`] messages and
-/// writes them into the legacy journal for rendering (story 10.2 will
-/// migrate rendering to `NewJournal`).
+/// writes them into the player's [`Journal`].
+///
+/// Callers pass `recorded_at: 0` — this system overwrites with real
+/// elapsed time so caller signatures stay lean.
 fn apply_observations(
     mut reader: MessageReader<RecordObservation>,
-    mut player_query: Query<(&mut LegacyJournal, &mut NewJournal), With<Player>>,
+    mut player_query: Query<&mut Journal, With<Player>>,
+    time: Res<Time>,
 ) {
-    let Ok((mut journal, mut new_journal)) = player_query.single_mut() else {
+    let Ok(mut journal) = player_query.single_mut() else {
         return;
     };
 
-    for event in reader.read() {
-        // Write into the new typed journal for all categories.
-        new_journal.record(event.key.clone(), &event.name, event.observation.clone());
+    let tick = time.elapsed().as_millis() as u64;
 
-        // Also write into the legacy journal so the existing text overlay
-        // keeps working until story 10.2 migrates rendering.
-        match event.observation.category {
-            ObservationCategory::SurfaceAppearance => {
-                let entry = journal.ensure_entry(
-                    match &event.key {
-                        JournalKey::Material { seed } => *seed,
-                        JournalKey::Fabrication { output_seed } => *output_seed,
-                    },
-                    &event.name,
-                );
-                if entry.surface_observations.is_empty() {
-                    entry
-                        .surface_observations
-                        .push(event.observation.description.clone());
-                }
-            }
-            ObservationCategory::ThermalBehavior => {
-                let seed = match &event.key {
-                    JournalKey::Material { seed } => *seed,
-                    JournalKey::Fabrication { output_seed } => *output_seed,
-                };
-                let entry = journal.ensure_entry(seed, &event.name);
-                entry.thermal_observation = Some(event.observation.description.clone());
-            }
-            ObservationCategory::Weight => {
-                let seed = match &event.key {
-                    JournalKey::Material { seed } => *seed,
-                    JournalKey::Fabrication { output_seed } => *output_seed,
-                };
-                let entry = journal.ensure_entry(seed, &event.name);
-                entry.weight_observation = Some(event.observation.description.clone());
-            }
-            ObservationCategory::FabricationResult => {
-                let description = &event.observation.description;
-                if !journal.fabrication_log.contains(description) {
-                    journal.fabrication_log.push(description.clone());
-                }
-                let seed = match &event.key {
-                    JournalKey::Material { seed } => *seed,
-                    JournalKey::Fabrication { output_seed } => *output_seed,
-                };
-                let entry = journal.ensure_entry(seed, &event.name);
-                if !entry.fabrication_history.contains(description) {
-                    entry.fabrication_history.push(description.clone());
-                }
-            }
-            ObservationCategory::LocationNote => {
-                // Location notes are a future feature; no legacy rendering yet.
-            }
-        }
+    for event in reader.read() {
+        let mut obs = event.observation.clone();
+        obs.recorded_at = tick;
+        journal.record(event.key.clone(), &event.name, obs);
     }
 }
 
@@ -484,7 +407,7 @@ fn apply_observations(
 
 fn render_journal(
     state: Res<JournalUiState>,
-    player_query: Query<&NewJournal, With<Player>>,
+    player_query: Query<&Journal, With<Player>>,
     mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
     mut text_query: Query<&mut Text, With<JournalText>>,
 ) {
@@ -509,7 +432,7 @@ fn render_journal(
     text.0 = build_journal_text(journal);
 }
 
-fn build_journal_text(journal: &NewJournal) -> String {
+fn build_journal_text(journal: &Journal) -> String {
     if journal.entries.is_empty() {
         return "Journal\n\nNo observations yet.".to_string();
     }
@@ -577,48 +500,6 @@ fn build_journal_text(journal: &NewJournal) -> String {
     out.join("\n")
 }
 
-// ── Descriptive language ────────────────────────────────────────────────
-
-pub fn describe_density(value: f32) -> &'static str {
-    if value < 0.15 {
-        "Almost weightless"
-    } else if value < 0.3 {
-        "Very light"
-    } else if value < 0.45 {
-        "Light"
-    } else if value < 0.55 {
-        "Medium weight"
-    } else if value < 0.7 {
-        "Heavy"
-    } else if value < 0.85 {
-        "Very heavy"
-    } else {
-        "Extremely dense"
-    }
-}
-
-pub fn describe_color(color: &[f32; 3]) -> &'static str {
-    let [r, g, b] = *color;
-    let max = r.max(g).max(b);
-    let min = r.min(g).min(b);
-
-    if max - min < 0.08 {
-        if max < 0.25 {
-            "Dark mineral grey"
-        } else if max < 0.7 {
-            "Muted stone grey"
-        } else {
-            "Pale chalk grey"
-        }
-    } else if r >= g && r >= b {
-        "Warm rust tone"
-    } else if g >= r && g >= b {
-        "Verdant green tone"
-    } else {
-        "Cool blue tone"
-    }
-}
-
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -627,7 +508,7 @@ mod tests {
 
     #[test]
     fn journal_omits_unknown_properties() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         journal.record(
             JournalKey::Material { seed: 1 },
             "Ferrite",
@@ -646,7 +527,7 @@ mod tests {
 
     #[test]
     fn journal_includes_fabrication_history() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         journal.record(
             JournalKey::Fabrication { output_seed: 2 },
             "Neoite",
@@ -665,7 +546,7 @@ mod tests {
 
     #[test]
     fn journal_shows_thermal_observation_when_present() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         journal.record(
             JournalKey::Material { seed: 3 },
             "TestMat",
@@ -738,7 +619,7 @@ mod tests {
 
     #[test]
     fn journal_shows_weight_observation_only_when_present() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 4 };
         journal.record(
             key.clone(),
@@ -865,7 +746,7 @@ mod tests {
 
     #[test]
     fn new_journal_ensure_entry_creates_and_retrieves() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 42 };
 
         journal.ensure_entry(key.clone(), "Ferrite", 100);
@@ -881,7 +762,7 @@ mod tests {
 
     #[test]
     fn new_journal_record_accumulates_observations() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 42 };
 
         journal.record(
@@ -913,7 +794,7 @@ mod tests {
 
     #[test]
     fn new_journal_different_keys_coexist() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let mat_key = JournalKey::Material { seed: 1 };
         let fab_key = JournalKey::Fabrication { output_seed: 2 };
 
@@ -945,7 +826,7 @@ mod tests {
 
     #[test]
     fn new_journal_serde_round_trip() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         journal.record(
             JournalKey::Material { seed: 42 },
             "Ferrite",
@@ -967,9 +848,9 @@ mod tests {
             },
         );
 
-        let json = serde_json::to_string(&journal).expect("NewJournal should serialize to JSON");
-        let deserialized: NewJournal =
-            serde_json::from_str(&json).expect("NewJournal should deserialize from JSON");
+        let json = serde_json::to_string(&journal).expect("Journal should serialize to JSON");
+        let deserialized: Journal =
+            serde_json::from_str(&json).expect("Journal should deserialize from JSON");
 
         assert_eq!(deserialized.entries.len(), 2);
         let ferrite = deserialized
@@ -983,20 +864,20 @@ mod tests {
 
     #[test]
     fn new_journal_empty_default() {
-        let journal = NewJournal::default();
+        let journal = Journal::default();
         assert!(journal.entries.is_empty());
     }
 
     #[test]
     fn empty_journal_renders_no_observations_yet() {
-        let journal = NewJournal::default();
+        let journal = Journal::default();
         let text = build_journal_text(&journal);
         assert_eq!(text, "Journal\n\nNo observations yet.");
     }
 
     #[test]
     fn single_observation_recorded_correctly() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 55 };
 
         journal.record(
@@ -1114,7 +995,7 @@ mod tests {
     /// be preserved (or upgraded if the second look is stronger).
     #[test]
     fn examine_same_material_twice_does_not_duplicate() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 42 };
 
         let observation = Observation {
@@ -1153,7 +1034,7 @@ mod tests {
     /// confidence upgrades the stored observation without duplicating it.
     #[test]
     fn examine_same_material_twice_upgrades_confidence() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 42 };
 
         journal.record(
@@ -1242,13 +1123,13 @@ mod tests {
     }
 
     /// Multiple observations recorded against the same `JournalKey` via
-    /// `NewJournal::record` accumulate in chronological order. The entry is
+    /// `Journal::record` accumulate in chronological order. The entry is
     /// created once and subsequent observations append without replacing
     /// earlier ones, timestamps track the full observation window, and each
     /// observation preserves its own category, confidence, and description.
     #[test]
     fn multiple_observations_for_same_key_accumulate() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
         let key = JournalKey::Material { seed: 77 };
 
         // First observation — creates the entry.
@@ -1360,7 +1241,7 @@ mod tests {
     /// Every type in the journal data model serializes to JSON and deserializes
     /// back to an identical value. Covers all `JournalKey` variants, all
     /// `ObservationCategory` variants, all `ConfidenceLevel` variants, the
-    /// `Observation` struct, `JournalEntry`, and a `NewJournal` containing
+    /// `Observation` struct, `JournalEntry`, and a `Journal` containing
     /// entries of every key type with observations of every category.
     #[test]
     fn all_types_serde_round_trip() {
@@ -1453,8 +1334,8 @@ mod tests {
             1
         );
 
-        // ── NewJournal with all key types and all categories ────────
-        let mut journal = NewJournal::default();
+        // ── Journal with all key types and all categories ────────
+        let mut journal = Journal::default();
 
         // Material entry with surface, thermal, and weight observations.
         let mat_key = JournalKey::Material { seed: 100 };
@@ -1512,8 +1393,8 @@ mod tests {
             },
         );
 
-        let json = serde_json::to_string(&journal).expect("NewJournal should serialize");
-        let rt: NewJournal = serde_json::from_str(&json).expect("NewJournal should deserialize");
+        let json = serde_json::to_string(&journal).expect("Journal should serialize");
+        let rt: Journal = serde_json::from_str(&json).expect("Journal should deserialize");
 
         // Verify structure preserved.
         assert_eq!(rt.entries.len(), 2);
@@ -1585,7 +1466,7 @@ mod tests {
     /// the same observation category is used for multiple subjects.
     #[test]
     fn different_keys_stored_independently() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
 
         // Three keys: two Material keys with different seeds and one
         // Fabrication key whose output_seed numerically equals the first
@@ -1737,15 +1618,13 @@ mod tests {
     /// that the legacy POC journal displayed: material names, surface
     /// observations, thermal observations, weight observations, fabrication
     /// history, and the "Recent Fabrication" header. This test populates a
-    /// `NewJournal` with the same variety of data the legacy `LegacyJournal`
-    /// held and asserts every piece of information appears in the output.
+    /// `Journal` with the same variety of data and asserts every piece of
+    /// information appears in the output.
     #[test]
     fn rendered_text_contains_same_information_as_legacy_journal() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
 
         // ── Material entry with surface, thermal, and weight observations ──
-        // Legacy equivalent: LegacyJournalEntry with surface_observations,
-        // thermal_observation, and weight_observation populated.
         let mat_key = JournalKey::Material { seed: 42 };
 
         journal.record(
@@ -1805,8 +1684,6 @@ mod tests {
         );
 
         // ── Fabrication entry ───────────────────────────────────────────
-        // Legacy equivalent: fabrication_log entry + LegacyJournalEntry with
-        // fabrication_history.
         let fab_key = JournalKey::Fabrication { output_seed: 200 };
         journal.record(
             fab_key,
@@ -1899,7 +1776,7 @@ mod tests {
     /// journal simply displayed a header with no entries.
     #[test]
     fn empty_journal_renders_placeholder_text() {
-        let journal = NewJournal::default();
+        let journal = Journal::default();
         let text = build_journal_text(&journal);
         assert!(
             text.contains("Journal"),
@@ -1930,7 +1807,7 @@ mod tests {
             ConfidenceLevel::Confident,
         ];
 
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
 
         // Record 120 entries: 80 Material keys and 40 Fabrication keys,
         // each with between 1 and 3 observations across different categories.
@@ -2030,7 +1907,7 @@ mod tests {
 
         // Serde round-trip must not panic or lose entries.
         let serialized = serde_json::to_string(&journal).expect("journal must serialize");
-        let deserialized: NewJournal =
+        let deserialized: Journal =
             serde_json::from_str(&serialized).expect("journal must deserialize");
         assert_eq!(
             journal.entries.len(),
@@ -2045,7 +1922,7 @@ mod tests {
     /// own observations.
     #[test]
     fn multiple_materials_have_separate_entries_and_rendering() {
-        let mut journal = NewJournal::default();
+        let mut journal = Journal::default();
 
         // ── Material 1: Ferrite ─────────────────────────────────────
         let key_ferrite = JournalKey::Material { seed: 10 };

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1107,6 +1107,87 @@ mod tests {
         );
     }
 
+    /// Examining the same material twice with identical observations must not
+    /// duplicate the journal entry or its observations. The journal should
+    /// contain exactly one entry with one observation, and confidence should
+    /// be preserved (or upgraded if the second look is stronger).
+    #[test]
+    fn examine_same_material_twice_does_not_duplicate() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 42 };
+
+        let observation = Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        };
+
+        // First examination.
+        journal.record(key.clone(), "Ferrite", observation.clone());
+
+        // Second examination — identical observation at a later tick.
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 50,
+            },
+        );
+
+        assert_eq!(journal.entries.len(), 1, "only one entry for the material");
+        let entry = journal.entries.get(&key).expect("entry must exist");
+        assert_eq!(
+            entry.observation_count(),
+            1,
+            "duplicate observation must not be appended"
+        );
+        assert_eq!(entry.last_updated_at, 50, "timestamp should advance");
+    }
+
+    /// Examining the same material twice where the second look carries higher
+    /// confidence upgrades the stored observation without duplicating it.
+    #[test]
+    fn examine_same_material_twice_upgrades_confidence() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 42 };
+
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 10,
+            },
+        );
+
+        // Second examination — same description, higher confidence.
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Observed,
+                description: "Warm rust tone".into(),
+                recorded_at: 50,
+            },
+        );
+
+        assert_eq!(journal.entries.len(), 1);
+        let entry = journal.entries.get(&key).expect("entry must exist");
+        assert_eq!(entry.observation_count(), 1);
+        assert_eq!(
+            entry.observations_by_category(&ObservationCategory::SurfaceAppearance)[0].confidence,
+            ConfidenceLevel::Observed,
+            "confidence should upgrade on re-examination"
+        );
+    }
+
     #[test]
     fn same_category_different_description_is_not_duplicate() {
         let key = JournalKey::Material { seed: 1 };

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -154,14 +154,137 @@ pub struct RecordWeightObservation {
 
 // ── Player-owned journal data ───────────────────────────────────────────
 
+/// A journal entry that accumulates observations about a single subject over time.
+///
+/// Each entry is keyed by a [`JournalKey`] and holds a chronologically ordered
+/// vector of [`Observation`]s. The `first_observed_at` and `last_updated_at`
+/// timestamps track the game-time ticks bounding the observation window, which
+/// later systems (e.g., confidence decay, staleness indicators) can use without
+/// re-scanning all observations.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// The unique identifier for this journal subject.
+    pub key: JournalKey,
+    /// Player-facing display name for this subject.
+    pub name: String,
+    /// Chronologically ordered observations accumulated over time.
+    pub observations: Vec<Observation>,
+    /// Game-time tick when the player first recorded *any* observation about
+    /// this subject.
+    pub first_observed_at: u64,
+    /// Game-time tick of the most recent observation recorded for this subject.
+    pub last_updated_at: u64,
+}
+
+impl JournalEntry {
+    /// Create a new journal entry with no observations yet recorded.
+    ///
+    /// The `tick` parameter sets both `first_observed_at` and `last_updated_at`
+    /// to the same initial value; they diverge once additional observations
+    /// arrive.
+    pub fn new(key: JournalKey, name: String, tick: u64) -> Self {
+        Self {
+            key,
+            name,
+            observations: Vec::new(),
+            first_observed_at: tick,
+            last_updated_at: tick,
+        }
+    }
+
+    /// Append an observation and update the `last_updated_at` timestamp.
+    ///
+    /// The observation's `recorded_at` tick is used as the new
+    /// `last_updated_at` value, so callers must ensure observations are
+    /// appended in monotonically non-decreasing tick order.
+    pub fn add_observation(&mut self, observation: Observation) {
+        self.last_updated_at = observation.recorded_at;
+        self.observations.push(observation);
+    }
+
+    /// Return all observations matching a given category, in recorded order.
+    pub fn observations_by_category(&self, category: &ObservationCategory) -> Vec<&Observation> {
+        self.observations
+            .iter()
+            .filter(|o| &o.category == category)
+            .collect()
+    }
+}
+
+/// The player's journal — accumulates all observations about every subject
+/// the player has investigated.
+///
+/// Keyed by [`JournalKey`] so lookups are O(log n) and iteration order is
+/// deterministic (important for save/load reproducibility and test stability).
+#[derive(Component, Default, Clone, Debug, Serialize, Deserialize)]
+pub struct NewJournal {
+    /// All journal entries, keyed by subject identity.
+    ///
+    /// Serialized as a list of entries (not a JSON object) because
+    /// [`JournalKey`] is an enum and cannot serve as a JSON map key.
+    #[serde(with = "journal_entries_serde")]
+    pub entries: BTreeMap<JournalKey, JournalEntry>,
+}
+
+/// Serialize/deserialize a `BTreeMap<JournalKey, JournalEntry>` as a
+/// `Vec<JournalEntry>`. Each entry already carries its key, so the vec
+/// representation is lossless and avoids the JSON "keys must be strings"
+/// limitation.
+mod journal_entries_serde {
+    use super::*;
+    use serde::de::Deserializer;
+    use serde::ser::Serializer;
+
+    pub fn serialize<S: Serializer>(
+        map: &BTreeMap<JournalKey, JournalEntry>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let entries: Vec<&JournalEntry> = map.values().collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<BTreeMap<JournalKey, JournalEntry>, D::Error> {
+        let entries: Vec<JournalEntry> = Vec::deserialize(deserializer)?;
+        Ok(entries.into_iter().map(|e| (e.key.clone(), e)).collect())
+    }
+}
+
+impl NewJournal {
+    /// Look up or create a journal entry for the given key.
+    ///
+    /// If no entry exists yet, one is created with the provided `name` and
+    /// `tick` as the initial observation timestamp. If an entry already exists,
+    /// the existing entry is returned unchanged (name is *not* overwritten —
+    /// the first observer wins).
+    pub fn ensure_entry(&mut self, key: JournalKey, name: &str, tick: u64) -> &mut JournalEntry {
+        self.entries
+            .entry(key.clone())
+            .or_insert_with(|| JournalEntry::new(key, name.to_string(), tick))
+    }
+
+    /// Record an observation against a subject, creating the entry if needed.
+    ///
+    /// This is the primary write path that future systems (materials, heat,
+    /// fabrication, navigation, trade, language) use to push knowledge into
+    /// the journal.
+    pub fn record(&mut self, key: JournalKey, name: &str, observation: Observation) {
+        let entry = self.ensure_entry(key, name, observation.recorded_at);
+        entry.add_observation(observation);
+    }
+}
+
+// ── Legacy journal structs (POC — will be removed by migration stories) ─
+
 #[derive(Component, Default)]
-struct Journal {
+struct LegacyJournal {
     fabrication_log: Vec<String>,
-    entries: BTreeMap<u64, JournalEntry>,
+    entries: BTreeMap<u64, LegacyJournalEntry>,
 }
 
 #[derive(Clone, Debug, Default)]
-struct JournalEntry {
+struct LegacyJournalEntry {
     name: String,
     surface_observations: Vec<String>,
     thermal_observation: Option<String>,
@@ -169,12 +292,14 @@ struct JournalEntry {
     fabrication_history: Vec<String>,
 }
 
-impl Journal {
-    fn ensure_entry(&mut self, seed: u64, name: &str) -> &mut JournalEntry {
-        self.entries.entry(seed).or_insert_with(|| JournalEntry {
-            name: name.to_string(),
-            ..default()
-        })
+impl LegacyJournal {
+    fn ensure_entry(&mut self, seed: u64, name: &str) -> &mut LegacyJournalEntry {
+        self.entries
+            .entry(seed)
+            .or_insert_with(|| LegacyJournalEntry {
+                name: name.to_string(),
+                ..default()
+            })
     }
 }
 
@@ -198,7 +323,7 @@ fn attach_journal_to_player(mut commands: Commands, player_query: Query<Entity, 
     let Ok(player) = player_query.single() else {
         return;
     };
-    commands.entity(player).insert(Journal::default());
+    commands.entity(player).insert(LegacyJournal::default());
 }
 
 fn spawn_journal_ui(mut commands: Commands) {
@@ -262,7 +387,7 @@ fn toggle_journal_visibility(
 
 fn apply_encounter_records(
     mut reader: MessageReader<RecordEncounter>,
-    mut player_query: Query<&mut Journal, With<Player>>,
+    mut player_query: Query<&mut LegacyJournal, With<Player>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
         return;
@@ -281,7 +406,7 @@ fn apply_encounter_records(
 
 fn apply_fabrication_records(
     mut reader: MessageReader<RecordFabrication>,
-    mut player_query: Query<&mut Journal, With<Player>>,
+    mut player_query: Query<&mut LegacyJournal, With<Player>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
         return;
@@ -314,7 +439,7 @@ fn apply_fabrication_records(
 
 fn apply_thermal_records(
     mut reader: MessageReader<RecordThermalObservation>,
-    mut player_query: Query<&mut Journal, With<Player>>,
+    mut player_query: Query<&mut LegacyJournal, With<Player>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
         return;
@@ -331,7 +456,7 @@ fn apply_thermal_records(
 
 fn apply_weight_records(
     mut reader: MessageReader<RecordWeightObservation>,
-    mut player_query: Query<&mut Journal, With<Player>>,
+    mut player_query: Query<&mut LegacyJournal, With<Player>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
         return;
@@ -347,7 +472,7 @@ fn apply_weight_records(
 
 fn render_journal(
     state: Res<JournalUiState>,
-    player_query: Query<&Journal, With<Player>>,
+    player_query: Query<&LegacyJournal, With<Player>>,
     mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
     mut text_query: Query<&mut Text, With<JournalText>>,
 ) {
@@ -372,7 +497,7 @@ fn render_journal(
     text.0 = build_journal_text(journal);
 }
 
-fn build_journal_text(journal: &Journal) -> String {
+fn build_journal_text(journal: &LegacyJournal) -> String {
     if journal.entries.is_empty() {
         return "Journal\n\nNo observations yet.".to_string();
     }
@@ -387,7 +512,7 @@ fn build_journal_text(journal: &Journal) -> String {
         }
     }
 
-    let mut entries: Vec<&JournalEntry> = journal.entries.values().collect();
+    let mut entries: Vec<&LegacyJournalEntry> = journal.entries.values().collect();
     entries.sort_by(|a, b| a.name.cmp(&b.name));
 
     for entry in entries {
@@ -464,7 +589,7 @@ mod tests {
 
     #[test]
     fn journal_omits_unknown_properties() {
-        let mut journal = Journal::default();
+        let mut journal = LegacyJournal::default();
         let entry = journal.ensure_entry(1, "Ferrite");
         entry.surface_observations.push("Weight: Heavy".into());
 
@@ -475,7 +600,7 @@ mod tests {
 
     #[test]
     fn journal_includes_fabrication_history() {
-        let mut journal = Journal::default();
+        let mut journal = LegacyJournal::default();
         journal
             .fabrication_log
             .push("Combined Ferrite + Silite -> Neoite".into());
@@ -491,7 +616,7 @@ mod tests {
 
     #[test]
     fn journal_shows_thermal_observation_when_present() {
-        let mut journal = Journal::default();
+        let mut journal = LegacyJournal::default();
         let entry = journal.ensure_entry(3, "TestMat");
         entry.thermal_observation = Some("Reliably hold together under heat".into());
 
@@ -556,7 +681,7 @@ mod tests {
 
     #[test]
     fn journal_shows_weight_observation_only_when_present() {
-        let mut journal = Journal::default();
+        let mut journal = LegacyJournal::default();
         let entry = journal.ensure_entry(4, "Ferrite");
         entry
             .surface_observations
@@ -570,5 +695,223 @@ mod tests {
 
         let with_weight = build_journal_text(&journal);
         assert!(with_weight.contains("Carried: Heavy but manageable"));
+    }
+
+    // ── New data model tests ────────────────────────────────────────────
+
+    #[test]
+    fn journal_entry_new_sets_timestamps() {
+        let key = JournalKey::Material { seed: 1 };
+        let entry = JournalEntry::new(key.clone(), "Ferrite".into(), 100);
+        assert_eq!(entry.key, key);
+        assert_eq!(entry.name, "Ferrite");
+        assert!(entry.observations.is_empty());
+        assert_eq!(entry.first_observed_at, 100);
+        assert_eq!(entry.last_updated_at, 100);
+    }
+
+    #[test]
+    fn journal_entry_add_observation_updates_timestamp() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 20,
+        });
+
+        assert_eq!(entry.observations.len(), 1);
+        assert_eq!(entry.first_observed_at, 10);
+        assert_eq!(entry.last_updated_at, 20);
+    }
+
+    #[test]
+    fn journal_entry_accumulates_multiple_observations() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::ThermalBehavior,
+            confidence: ConfidenceLevel::Observed,
+            description: "Holds together under heat".into(),
+            recorded_at: 50,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::Weight,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Heavy".into(),
+            recorded_at: 55,
+        });
+
+        assert_eq!(entry.observations.len(), 3);
+        assert_eq!(entry.last_updated_at, 55);
+    }
+
+    #[test]
+    fn journal_entry_observations_by_category() {
+        let key = JournalKey::Material { seed: 1 };
+        let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Tentative,
+            description: "Warm rust tone".into(),
+            recorded_at: 10,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::ThermalBehavior,
+            confidence: ConfidenceLevel::Observed,
+            description: "Holds together under heat".into(),
+            recorded_at: 20,
+        });
+        entry.add_observation(Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: ConfidenceLevel::Observed,
+            description: "Slightly rough texture".into(),
+            recorded_at: 30,
+        });
+
+        let surface = entry.observations_by_category(&ObservationCategory::SurfaceAppearance);
+        assert_eq!(surface.len(), 2);
+        assert_eq!(surface[0].description, "Warm rust tone");
+        assert_eq!(surface[1].description, "Slightly rough texture");
+
+        let thermal = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
+        assert_eq!(thermal.len(), 1);
+
+        let weight = entry.observations_by_category(&ObservationCategory::Weight);
+        assert!(weight.is_empty());
+    }
+
+    #[test]
+    fn new_journal_ensure_entry_creates_and_retrieves() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 42 };
+
+        journal.ensure_entry(key.clone(), "Ferrite", 100);
+        journal.ensure_entry(key.clone(), "Ignored Name", 200);
+
+        assert_eq!(journal.entries.len(), 1);
+        let entry = journal.entries.get(&key).expect("entry should exist");
+        // First name wins.
+        assert_eq!(entry.name, "Ferrite");
+        // Timestamps unchanged by second ensure_entry call.
+        assert_eq!(entry.first_observed_at, 100);
+    }
+
+    #[test]
+    fn new_journal_record_accumulates_observations() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 42 };
+
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 10,
+            },
+        );
+        journal.record(
+            key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Holds together under heat".into(),
+                recorded_at: 50,
+            },
+        );
+
+        let entry = journal.entries.get(&key).expect("entry should exist");
+        assert_eq!(entry.observations.len(), 2);
+        assert_eq!(entry.first_observed_at, 10);
+        assert_eq!(entry.last_updated_at, 50);
+    }
+
+    #[test]
+    fn new_journal_different_keys_coexist() {
+        let mut journal = NewJournal::default();
+        let mat_key = JournalKey::Material { seed: 1 };
+        let fab_key = JournalKey::Fabrication { output_seed: 2 };
+
+        journal.record(
+            mat_key.clone(),
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 10,
+            },
+        );
+        journal.record(
+            fab_key.clone(),
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Ferrite + Silite -> Neoite".into(),
+                recorded_at: 20,
+            },
+        );
+
+        assert_eq!(journal.entries.len(), 2);
+        assert!(journal.entries.contains_key(&mat_key));
+        assert!(journal.entries.contains_key(&fab_key));
+    }
+
+    #[test]
+    fn new_journal_serde_round_trip() {
+        let mut journal = NewJournal::default();
+        journal.record(
+            JournalKey::Material { seed: 42 },
+            "Ferrite",
+            Observation {
+                category: ObservationCategory::SurfaceAppearance,
+                confidence: ConfidenceLevel::Tentative,
+                description: "Warm rust tone".into(),
+                recorded_at: 10,
+            },
+        );
+        journal.record(
+            JournalKey::Fabrication { output_seed: 99 },
+            "Neoite",
+            Observation {
+                category: ObservationCategory::FabricationResult,
+                confidence: ConfidenceLevel::Confident,
+                description: "Combined Ferrite + Silite -> Neoite".into(),
+                recorded_at: 50,
+            },
+        );
+
+        let json = serde_json::to_string(&journal).expect("NewJournal should serialize to JSON");
+        let deserialized: NewJournal =
+            serde_json::from_str(&json).expect("NewJournal should deserialize from JSON");
+
+        assert_eq!(deserialized.entries.len(), 2);
+        let ferrite = deserialized
+            .entries
+            .get(&JournalKey::Material { seed: 42 })
+            .expect("Ferrite entry should exist");
+        assert_eq!(ferrite.name, "Ferrite");
+        assert_eq!(ferrite.observations.len(), 1);
+        assert_eq!(ferrite.first_observed_at, 10);
+    }
+
+    #[test]
+    fn new_journal_empty_default() {
+        let journal = NewJournal::default();
+        assert!(journal.entries.is_empty());
     }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -903,6 +903,41 @@ mod tests {
     }
 
     #[test]
+    fn single_observation_recorded_correctly() {
+        let mut journal = NewJournal::default();
+        let key = JournalKey::Material { seed: 55 };
+
+        journal.record(
+            key.clone(),
+            "Quarite",
+            Observation {
+                category: ObservationCategory::ThermalBehavior,
+                confidence: ConfidenceLevel::Observed,
+                description: "Cracks under rapid heating".into(),
+                recorded_at: 42,
+            },
+        );
+
+        // Exactly one entry created for the key.
+        assert_eq!(journal.entries.len(), 1);
+        let entry = journal.entries.get(&key).expect("entry should exist");
+
+        // Entry metadata is correct.
+        assert_eq!(entry.key, key);
+        assert_eq!(entry.name, "Quarite");
+        assert_eq!(entry.first_observed_at, 42);
+        assert_eq!(entry.last_updated_at, 42);
+
+        // Exactly one observation stored.
+        assert_eq!(entry.observations.len(), 1);
+        let obs = &entry.observations[0];
+        assert_eq!(obs.category, ObservationCategory::ThermalBehavior);
+        assert_eq!(obs.confidence, ConfidenceLevel::Observed);
+        assert_eq!(obs.description, "Cracks under rapid heating");
+        assert_eq!(obs.recorded_at, 42);
+    }
+
+    #[test]
     fn duplicate_observation_same_category_and_description_is_skipped() {
         let key = JournalKey::Material { seed: 1 };
         let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod carry_feedback;
 pub mod combination;
 #[allow(missing_docs)]
 pub mod debug_overlay;
+pub mod descriptions;
 #[allow(missing_docs)]
 pub mod fabricator;
 #[allow(missing_docs)]

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub struct ObservationPlugin;
 
@@ -30,7 +31,7 @@ impl Plugin for ObservationPlugin {
 /// Qualitative confidence level derived from observation count.
 /// Used by the examine panel in the next PR to select descriptor language.
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfidenceLevel {
     /// One observation — tentative language.
     Tentative,

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -31,7 +31,7 @@ impl Plugin for ObservationPlugin {
 /// Qualitative confidence level derived from observation count.
 /// Used by the examine panel in the next PR to select descriptor language.
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ConfidenceLevel {
     /// One observation — tentative language.
     Tentative,

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -54,33 +54,6 @@ impl ConfidenceLevel {
     }
 }
 
-fn describe_thermal_behavior(value: f32) -> &'static str {
-    if value < 0.25 {
-        "soften quickly under heat"
-    } else if value < 0.5 {
-        "change noticeably under heat"
-    } else if value < 0.75 {
-        "hold together under heat"
-    } else {
-        "barely react to heat"
-    }
-}
-
-pub fn describe_thermal_observation(value: f32, confidence: ConfidenceLevel) -> String {
-    let behavior = describe_thermal_behavior(value);
-    match confidence {
-        ConfidenceLevel::Tentative => format!("Seemed to {behavior}"),
-        ConfidenceLevel::Observed => {
-            let mut chars = behavior.chars();
-            let Some(first) = chars.next() else {
-                return String::new();
-            };
-            format!("{}{}", first.to_uppercase(), chars.as_str())
-        }
-        ConfidenceLevel::Confident => format!("Reliably {behavior}"),
-    }
-}
-
 // ── Tracker resource ─────────────────────────────────────────────────────
 
 /// Canonical key: (material seed, property name).

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -766,7 +766,9 @@ pub struct PlanetSeed(pub u64);
 /// project these coordinates differently, but the first useful model is simply
 /// "infinite signed grid on X/Z" rather than "special-case only positive
 /// chunks near the room."
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct ChunkCoord {
     pub x: i32,
     pub z: i32,

--- a/tests/carry_scenarios.rs
+++ b/tests/carry_scenarios.rs
@@ -6,7 +6,7 @@
 mod scenarios;
 
 use apeiron_cipher::carry::{CarryPlugin, CarryState, CarryStrength};
-use apeiron_cipher::journal::RecordWeightObservation;
+use apeiron_cipher::journal::RecordObservation;
 use apeiron_cipher::observation::ConfidenceTracker;
 use apeiron_cipher::player::Player;
 use bevy::prelude::*;
@@ -21,7 +21,7 @@ use scenarios::{Scenario, Step, run_scenarios};
 /// resources/messages that `CarryPlugin`'s systems expect at runtime.
 fn carry_shared_setup(app: &mut App) {
     app.add_plugins(MinimalPlugins);
-    app.add_message::<RecordWeightObservation>();
+    app.add_message::<RecordObservation>();
     app.init_resource::<ConfidenceTracker>();
     app.add_plugins(CarryPlugin);
 }


### PR DESCRIPTION
## Summary

Implements Story 10.1 (#163) — the new typed journal data model — plus architectural review fixes.

### Task-runner work (21 commits)
- New `JournalKey`, `Observation`, `ObservationCategory`, `JournalEntry` data model with BTreeMap storage and serde support
- Unified `RecordObservation` message replacing per-category message types
- Updated carry, fabricator, heat, and interaction systems to use the new message
- 30 new journal tests (501 total, all passing)

### Architectural review fixes (1 commit)
- **F10.3**: Renamed `NewJournal` → `Journal`, removed `LegacyJournal` struct and dual-write path entirely
- **F10.2+F10.5**: Created `src/descriptions.rs` centralising all `describe_*` functions from journal.rs, interaction.rs, and observation.rs — eliminates duplicate `describe_density`
- **F10.1**: `apply_observations` now takes `Res<Time>` and stamps `recorded_at` with real elapsed millis (callers pass 0, ingestion overwrites)

Closes #163