### PR TITLE
fix: add Cross.toml for aarch64 Linux wayland dependencies

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y --no-install-recommends libwayland-dev libxkbcommon-dev libudev-dev libasound2-dev",
+]


### PR DESCRIPTION
## Summary
- Adds `Cross.toml` to install `libwayland-dev` and other required system libraries inside the `cross` Docker container for `aarch64-unknown-linux-gnu` builds
- Fixes the CI failure where `wayland-client` was not found because host-installed x86_64 libs aren't visible inside the cross container