### PR TITLE
refactor: data-driven carry profiles and CarryMovementState as Component

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -43,7 +43,6 @@ impl Plugin for CarryPlugin {
             .add_message::<ObserveWeight>()
             .init_resource::<CarryConfig>()
             .init_resource::<ActiveCarryProfile>()
-            .init_resource::<CarryMovementState>()
             .add_systems(PreStartup, load_carry_config)
             .add_systems(
                 Startup,
@@ -136,7 +135,7 @@ struct CarryWeightChanged {
 /// source of truth for *how that mass affects locomotion right now*. Keeping the
 /// two separated lets later stories change the feedback model without rewriting
 /// how carry contents are tracked.
-#[derive(Clone, Debug, Resource, PartialEq)]
+#[derive(Clone, Debug, Component, PartialEq)]
 pub struct CarryMovementState {
     pub speed_modifier: f32,
     pub stamina_drain_multiplier: f32,
@@ -397,7 +396,7 @@ pub struct CarryConfig {
     pub weight_descriptions: Vec<WeightDescriptionBand>,
     #[serde(default)]
     pub weight_cues: CarryCueConfig,
-    #[serde(default)]
+    #[serde(default = "default_profiles")]
     pub profiles: CarryProfilesConfig,
 }
 
@@ -415,7 +414,7 @@ impl Default for CarryConfig {
             cycle_order: CarryCycleOrder::default(),
             weight_descriptions: default_weight_descriptions(),
             weight_cues: CarryCueConfig::default(),
-            profiles: CarryProfilesConfig::default(),
+            profiles: default_profiles(),
         }
     }
 }
@@ -689,24 +688,26 @@ pub enum CarryCycleOrder {
     Lifo,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CarryProfilesConfig {
-    #[serde(default = "default_profile_config")]
-    pub default: CarryProfileConfig,
-    #[serde(default = "relaxed_profile_config")]
-    pub relaxed: CarryProfileConfig,
-    #[serde(default = "creative_profile_config")]
-    pub creative: CarryProfileConfig,
-}
+/// Profile name for the creative (no-consequence) carry mode.
+///
+/// Used as the key in [`CarryConfig::profiles`] and for string comparisons
+/// elsewhere — centralised here to avoid scattered string literals.
+pub const CREATIVE_PROFILE: &str = "creative";
 
-impl Default for CarryProfilesConfig {
-    fn default() -> Self {
-        Self {
-            default: default_profile_config(),
-            relaxed: relaxed_profile_config(),
-            creative: creative_profile_config(),
-        }
-    }
+/// Map of named carry profiles keyed by profile name.
+///
+/// The TOML `[profiles.<name>]` tables deserialize directly into this map.
+/// Adding a new profile requires only a new TOML section — no code changes.
+pub type CarryProfilesConfig = std::collections::HashMap<String, CarryProfileConfig>;
+
+/// Build the default set of three carry profiles: `"default"`, `"relaxed"`,
+/// and `"creative"`.
+fn default_profiles() -> CarryProfilesConfig {
+    let mut map = CarryProfilesConfig::new();
+    map.insert("default".into(), default_profile_config());
+    map.insert("relaxed".into(), relaxed_profile_config());
+    map.insert(CREATIVE_PROFILE.into(), creative_profile_config());
+    map
 }
 
 /// One difficulty/mode profile's carry consequences.
@@ -859,10 +860,18 @@ impl Default for ActiveCarryProfile {
 
 impl ActiveCarryProfile {
     fn from_config(config: &CarryConfig) -> Self {
-        let tuning = match config.active_profile.as_str() {
-            "relaxed" => config.profiles.relaxed.clone(),
-            "creative" => config.profiles.creative.clone(),
-            _ => config.profiles.default.clone(),
+        let tuning = if let Some(profile) = config.profiles.get(&config.active_profile) {
+            profile.clone()
+        } else {
+            warn!(
+                "Carry profile '{}' not found in config; falling back to 'default'",
+                config.active_profile
+            );
+            config
+                .profiles
+                .get("default")
+                .cloned()
+                .unwrap_or_else(default_profile_config)
         };
 
         Self {
@@ -935,6 +944,7 @@ fn attach_carry_state_to_player(
             current: config.starting_strength,
         },
         device_state,
+        CarryMovementState::default(),
     ));
 }
 
@@ -944,10 +954,9 @@ fn attach_carry_state_to_player(
 /// actually change, avoiding redundant writes on idle frames.
 fn update_carry_movement_state(
     active_profile: Res<ActiveCarryProfile>,
-    mut movement_state: ResMut<CarryMovementState>,
-    player_query: Query<(Ref<CarryState>,), With<Player>>,
+    mut player_query: Query<(Ref<CarryState>, &mut CarryMovementState), With<Player>>,
 ) {
-    let Ok((carry_ref,)) = player_query.single() else {
+    let Ok((carry_ref, mut movement_state)) = player_query.single_mut() else {
         return;
     };
 
@@ -1015,7 +1024,7 @@ fn update_carry_strength(
     config: Res<CarryConfig>,
     mut player_query: Query<(&CarryState, &mut CarryStrength), With<Player>>,
 ) {
-    if active_profile.profile_name == "creative" {
+    if active_profile.profile_name == CREATIVE_PROFILE {
         return;
     }
 
@@ -1560,7 +1569,7 @@ exponent = 1.0
         assert!(config.grant_starting_device);
         assert_eq!(config.cycle_order, CarryCycleOrder::Lifo);
         assert_eq!(
-            config.profiles.relaxed.speed_curve.kind,
+            config.profiles["relaxed"].speed_curve.kind,
             CarryCurveKind::Exponential
         );
     }
@@ -2017,5 +2026,131 @@ exponent = 1.0
         );
 
         assert_eq!(text, "Straining under the weight");
+    }
+
+    // ── Tests added by #282 ─────────────────────────────────────────────
+
+    #[test]
+    fn remove_from_empty_carry_is_harmless() {
+        let mat = material_with_density(0.5);
+        let mut state = CarryState::new(10.0, true);
+        // Removing a material that was never added should not panic or
+        // corrupt state.
+        assert!(
+            state
+                .remove_material(Entity::from_bits(999), &mat)
+                .is_none()
+        );
+        assert_eq!(state.current_weight, 0.0);
+        assert!(state.carried_items.is_empty());
+    }
+
+    #[test]
+    fn remove_nonexistent_entity_leaves_state_unchanged() {
+        let mat = material_with_density(0.5);
+        let entity = Entity::from_bits(1);
+        let mut state = CarryState::new(10.0, true);
+        state.add_material(entity, &mat);
+
+        let other = Entity::from_bits(42);
+        assert!(state.remove_material(other, &mat).is_none());
+        assert_eq!(state.carried_items.len(), 1);
+        assert!((state.current_weight - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn device_state_no_requirement_always_ready() {
+        let config = CarryConfig {
+            carry_device_item_key: None,
+            ..CarryConfig::default()
+        };
+        let device = CarryDeviceState::from_config(&config);
+        assert!(device.has_required_device());
+    }
+
+    #[test]
+    fn device_state_requirement_without_grant_is_missing() {
+        let config = CarryConfig {
+            carry_device_item_key: Some("satchel".into()),
+            grant_starting_device: false,
+            ..CarryConfig::default()
+        };
+        let device = CarryDeviceState::from_config(&config);
+        assert!(!device.has_required_device());
+    }
+
+    #[test]
+    fn device_state_requirement_with_grant_is_present() {
+        let config = CarryConfig {
+            carry_device_item_key: Some("satchel".into()),
+            grant_starting_device: true,
+            ..CarryConfig::default()
+        };
+        let device = CarryDeviceState::from_config(&config);
+        assert!(device.has_required_device());
+    }
+
+    #[test]
+    fn exponential_speed_curve_degrades_at_full_load() {
+        let curve = CarryCurveConfig {
+            kind: CarryCurveKind::Exponential,
+            min_multiplier: 0.3,
+            exponent: 2.0,
+        };
+        let speed = evaluate_speed_curve(&curve, 1.0, true);
+        // Exponential curve asymptotically approaches min_multiplier but
+        // never quite reaches it at ratio 1.0. Verify it's well below 1.0
+        // and clamped above min_multiplier.
+        assert!(speed < 0.5, "expected significant degradation, got {speed}");
+        assert!(
+            speed >= 0.3,
+            "expected speed >= min_multiplier 0.3, got {speed}"
+        );
+    }
+
+    #[test]
+    fn exponential_speed_curve_full_speed_at_zero_load() {
+        let curve = CarryCurveConfig {
+            kind: CarryCurveKind::Exponential,
+            min_multiplier: 0.3,
+            exponent: 2.0,
+        };
+        let speed = evaluate_speed_curve(&curve, 0.0, true);
+        assert!(
+            (speed - 1.0).abs() < f32::EPSILON,
+            "expected 1.0 at zero load, got {speed}"
+        );
+    }
+
+    #[test]
+    fn hashmap_profiles_parse_from_toml() {
+        let toml = r#"
+active_profile = "custom"
+
+[profiles.custom]
+creative_mode = true
+
+[profiles.custom.speed_curve]
+kind = "linear"
+min_multiplier = 1.0
+exponent = 1.0
+"#;
+        let config: CarryConfig = toml::from_str(toml).expect("should parse custom profile");
+        assert!(config.profiles.contains_key("custom"));
+        assert!(config.profiles["custom"].creative_mode);
+        // Default profiles are NOT auto-injected — only what's in the TOML.
+        assert!(!config.profiles.contains_key("default"));
+    }
+
+    #[test]
+    fn unknown_active_profile_falls_back_with_warning() {
+        let config = CarryConfig {
+            active_profile: "nonexistent".into(),
+            ..CarryConfig::default()
+        };
+        let active = ActiveCarryProfile::from_config(&config);
+        // Should fall back to the "default" profile's tuning.
+        assert_eq!(active.tuning, default_profile_config());
+        assert_eq!(active.profile_name, "nonexistent");
     }
 }

--- a/src/carry_feedback.rs
+++ b/src/carry_feedback.rs
@@ -163,21 +163,20 @@ fn attach_carry_feedback_state(
 fn update_carry_camera_bob(
     time: Res<Time>,
     config: Res<CarryConfig>,
-    carry_movement: Res<CarryMovementState>,
     cursor_options: Single<&bevy::window::CursorOptions>,
-    player_query: Query<&ActionState<InputAction>, With<Player>>,
+    player_query: Query<(&ActionState<InputAction>, &CarryMovementState), With<Player>>,
     mut camera_query: Query<(&mut Transform, &mut CameraBobState), With<PlayerCamera>>,
 ) {
     let Ok((mut camera_transform, mut bob_state)) = camera_query.single_mut() else {
         return;
     };
 
-    let Ok(action_state) = player_query.single() else {
+    let Ok((action_state, carry_movement)) = player_query.single() else {
         camera_transform.translation = Vec3::ZERO;
         return;
     };
 
-    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, &carry_movement);
+    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, carry_movement);
 
     if !is_moving {
         bob_state.phase_radians = 0.0;
@@ -219,15 +218,21 @@ fn emit_weighted_footsteps(
     time: Res<Time>,
     config: Res<CarryConfig>,
     cue_assets: Res<CarryCueAssets>,
-    carry_movement: Res<CarryMovementState>,
     cursor_options: Single<&bevy::window::CursorOptions>,
-    mut player_query: Query<(&ActionState<InputAction>, &mut FootstepCueState), With<Player>>,
+    mut player_query: Query<
+        (
+            &ActionState<InputAction>,
+            &mut FootstepCueState,
+            &CarryMovementState,
+        ),
+        With<Player>,
+    >,
 ) {
-    let Ok((action_state, mut footstep_state)) = player_query.single_mut() else {
+    let Ok((action_state, mut footstep_state, carry_movement)) = player_query.single_mut() else {
         return;
     };
 
-    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, &carry_movement);
+    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, carry_movement);
 
     if !is_moving {
         // Reset to half the interval so the first step after resuming movement
@@ -278,19 +283,18 @@ fn emit_weighted_footsteps(
 /// entities right at the threshold.
 fn update_breathing_cue(
     config: Res<CarryConfig>,
-    carry_movement: Res<CarryMovementState>,
     cursor_options: Single<&bevy::window::CursorOptions>,
-    player_query: Query<&ActionState<InputAction>, With<Player>>,
+    player_query: Query<(&ActionState<InputAction>, &CarryMovementState), With<Player>>,
     mut sink_query: Query<&mut AudioSink, With<BreathingCue>>,
 ) {
     let Ok(mut sink) = sink_query.single_mut() else {
         return;
     };
-    let Ok(action_state) = player_query.single() else {
+    let Ok((action_state, carry_movement)) = player_query.single() else {
         return;
     };
 
-    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, &carry_movement);
+    let is_moving = is_player_moving(cursor_options.grab_mode, action_state, carry_movement);
 
     if !is_moving {
         sink.set_volume(Volume::Linear(0.0));

--- a/src/player.rs
+++ b/src/player.rs
@@ -14,7 +14,7 @@ use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, CursorOptions};
 use leafwing_input_manager::prelude::*;
 
-use crate::carry::CarryMovementState;
+use crate::carry::{CarryConfig, CarryMovementState};
 use crate::input::InputAction;
 use crate::scene::{PlayerSceneConfig, PositionXZ, RoomShellCollision};
 use crate::world_generation::{PlanetSurface, WorldGenerationConfig, WorldProfile};
@@ -113,7 +113,7 @@ struct CameraPitch(f32);
 pub fn spawn_player(
     mut commands: Commands,
     scene: Res<PlayerSceneConfig>,
-    carry_movement: Res<CarryMovementState>,
+    carry_config: Res<CarryConfig>,
     world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
@@ -133,6 +133,14 @@ pub fn spawn_player(
         terrain_y,
         &surface_registry,
     );
+    // Read base_stamina from the active profile in config. CarryMovementState
+    // is a Component attached later by CarryPlugin — it doesn't exist yet at
+    // spawn time, and we only need the profile's starting stamina here.
+    let base_stamina = carry_config
+        .profiles
+        .get(&carry_config.active_profile)
+        .map(|p| p.base_stamina)
+        .unwrap_or(100.0);
     commands
         .spawn((
             Player,
@@ -142,8 +150,8 @@ pub fn spawn_player(
             // The InputMap is attached separately by InputPlugin after spawn.
             ActionState::<InputAction>::default(),
             StaminaState {
-                current: carry_movement.base_stamina,
-                max: carry_movement.base_stamina,
+                current: base_stamina,
+                max: base_stamina,
             },
         ))
         .with_children(|parent| {
@@ -221,12 +229,16 @@ fn player_move(
     cursor_options: Single<&CursorOptions>,
     scene: Res<PlayerSceneConfig>,
     room_shell: Res<RoomShellCollision>,
-    carry_movement: Res<CarryMovementState>,
     world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     surface_registry: Res<crate::surface::SurfaceOverrideRegistry>,
     mut player_query: Query<
-        (&ActionState<InputAction>, &mut Transform, &mut StaminaState),
+        (
+            &ActionState<InputAction>,
+            &mut Transform,
+            &mut StaminaState,
+            &CarryMovementState,
+        ),
         With<Player>,
     >,
 ) {
@@ -237,7 +249,8 @@ fn player_move(
         return;
     };
 
-    let Ok((action_state, mut transform, mut stamina)) = player_query.single_mut() else {
+    let Ok((action_state, mut transform, mut stamina, carry_movement)) = player_query.single_mut()
+    else {
         return;
     };
 

--- a/tests/scenarios/helpers.rs
+++ b/tests/scenarios/helpers.rs
@@ -47,7 +47,11 @@ pub fn assert_carry_weight(world: &mut World, expected: f32) {
 
 /// Assert the speed modifier on [`CarryMovementState`] is within a range.
 pub fn assert_speed_in_range(world: &mut World, min: f32, max: f32) {
-    let state = world.resource::<CarryMovementState>();
+    let state = world
+        .query::<&CarryMovementState>()
+        .iter(world)
+        .next()
+        .expect("no entity with CarryMovementState found");
     assert!(
         state.speed_modifier >= min && state.speed_modifier <= max,
         "expected speed_modifier in [{min}, {max}], got {}",


### PR DESCRIPTION
## Summary
- Replace fixed `CarryProfilesConfig` struct with `HashMap<String, CarryProfileConfig>` — adding a new profile now requires only a TOML section, no code changes
- Move `CarryMovementState` from `Resource` to `Component` on the player entity, since it describes per-entity movement consequences not a global singleton
- `spawn_player` reads `base_stamina` from `CarryConfig` profiles directly instead of from `CarryMovementState` (which doesn't exist until the carry system attaches it)
- Add `warn!` log when `active_profile` doesn't match any configured profile name
- Extract `CREATIVE_PROFILE` const to eliminate scattered `"creative"` string literals
- 9 new tests: empty/nonexistent remove, device state edge cases, exponential speed curve behavior, HashMap profile TOML parsing, unknown profile fallback

Closes #282