### PR TITLE
fix(ci): use macos-latest for x86_64-apple-darwin and fix aarch64 cross-compile libs

### DIFF
--- a/.github/workflows/release-game.yml
+++ b/.github/workflows/release-game.yml
@@ -59,7 +59,7 @@ jobs:
             os: windows-latest
             ext: .exe
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             ext: ""
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -86,7 +86,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && !matrix.cross
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,4 @@
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
-    "apt-get update && apt-get install -y --no-install-recommends libwayland-dev libxkbcommon-dev libudev-dev libasound2-dev",
+    "dpkg --add-architecture arm64 && apt-get update && apt-get install -y --no-install-recommends libwayland-dev:arm64 libxkbcommon-dev:arm64 libudev-dev:arm64 libasound2-dev:arm64",
 ]


### PR DESCRIPTION
## Summary
- Switch `x86_64-apple-darwin` runner from `macos-13` (deprecated/removed) to `macos-latest` — jobs were queuing indefinitely with no runner available
- Skip host `apt-get install` for `cross` builds (the Docker container handles its own deps)
- Fix `Cross.toml` to install `arm64` architecture packages instead of x86_64 ones for the `aarch64-unknown-linux-gnu` target

These two issues prevented the `upload-assets` job from ever running, so releases v1.0.4 and v1.0.5 have no compiled binaries attached.