### PR TITLE
refactor: replace string-keyed enums with proper Rust enums (ObsKey, StarType, BiomeType, seed channels)

### DIFF
--- a/.plan/test-extraction-plan.md
+++ b/.plan/test-extraction-plan.md
@@ -1,0 +1,54 @@
+# Test Extraction Plan
+
+Move all test code from production `.rs` files into sibling `_tests.rs` files using Rust's `#[path]` attribute. No tests deleted — purely structural.
+
+## File Layout After
+
+```
+src/
+  lib.rs                         # add: #[cfg(test)] mod test_support;
+  test_support.rs                # NEW — shared test structs
+  world_generation.rs            # ~150 lines (was 5275)
+  world_generation_tests.rs      # NEW — ~2938 lines
+  world_generation/
+    exterior.rs                  # ~1648 lines (was 5796)
+    exterior_tests.rs            # NEW — ~4148 lines
+  journal.rs                     # ~1166 lines (was 5054)
+  journal_tests.rs               # NEW — ~3703 lines
+  solar_system.rs                # ~1538 lines (was 4624)
+  solar_system_tests.rs          # NEW — ~3086 lines
+```
+
+## Approach
+
+Each production file gets:
+```rust
+#[cfg(test)]
+#[path = "foo_tests.rs"]
+mod tests;
+```
+This keeps `use super::*` access to private items while physically separating test code.
+
+## Phases (make check after each)
+
+### Phase 1: Create `src/test_support.rs`
+- Move `FlatSurface`, `SteppedSurface`, `TiltedSurface` + their `SurfaceProvider` impls from `world_generation.rs` (lines 153–432ish, the `#[cfg(test)]` blocks before `mod tests`)
+- Add `#[cfg(test)] mod test_support;` to `src/lib.rs`
+
+### Phase 2: Extract `world_generation.rs` tests
+- Create `src/world_generation_tests.rs` with body of `mod tests` (lines 2337–5275)
+- Replace `mod tests` block with `#[path]` declaration
+- Update imports: `use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};`
+
+### Phase 3: Extract `world_generation/exterior.rs` tests
+- Create `src/world_generation/exterior_tests.rs` (lines 1649–5796)
+- Update imports to use `crate::test_support` instead of `crate::world_generation`
+
+### Phase 4: Extract `solar_system.rs` tests
+- Create `src/solar_system_tests.rs` (lines 1539–4624)
+
+### Phase 5: Extract `journal.rs` tests
+- Create `src/journal_tests.rs` — includes test helpers (lines 1167–1350) + mod tests body (lines 1351–5054)
+
+## Verification
+- `make check` after each phase (fmt, clippy, test, build)

--- a/assets/config/biomes.toml
+++ b/assets/config/biomes.toml
@@ -7,7 +7,7 @@
 #
 # Ranges are allowed to overlap — the first matching biome in file order wins.
 # Any (temperature, moisture) pair that falls outside all defined ranges
-# resolves to the `fallback_biome_key`.
+# resolves to the `fallback_biome_type`.
 
 # ── Global noise parameters ──────────────────────────────────────────────
 
@@ -21,14 +21,14 @@ noise_scale_chunks = 12.0
 temperature_noise_channel = 0xB10E_0001_0000_0001
 moisture_noise_channel    = 0xB10E_0001_0000_0002
 
-# Key of the biome used when a chunk's (temperature, moisture) pair does not
+# Biome type used when a chunk's (temperature, moisture) pair does not
 # match any defined biome range.
-fallback_biome_key = "mineral_steppe"
+fallback_biome_type = "mineral_steppe"
 
 # ── Biome definitions ────────────────────────────────────────────────────
 
 [[biomes]]
-key = "scorched_flats"
+biome_type = "scorched_flats"
 temperature_min = 0.6
 temperature_max = 1.0
 temperature_abs_min_k = 350.0
@@ -71,7 +71,7 @@ material_seed = 1009  # Silite — rare in hot regions
 selection_weight = 0.3
 
 [[biomes]]
-key = "mineral_steppe"
+biome_type = "mineral_steppe"
 temperature_min = 0.3
 temperature_max = 0.7
 temperature_abs_min_k = 220.0
@@ -116,7 +116,7 @@ material_seed = 1010  # Phosphite — occasional find
 selection_weight = 0.8
 
 [[biomes]]
-key = "frost_shelf"
+biome_type = "frost_shelf"
 temperature_min = 0.0
 temperature_max = 0.4
 temperature_abs_min_k = 50.0

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use crate::observation::PropertyName;
+
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -1367,8 +1369,8 @@ pub fn record_weight_observation(
     journal_writer: &mut MessageWriter<RecordObservation>,
     planet_seed: Option<u64>,
 ) {
-    tracker.record(material.seed, "weight");
-    let confidence = tracker.level(material.seed, "weight");
+    tracker.record(material.seed, PropertyName::Density);
+    let confidence = tracker.level(material.seed, PropertyName::Density);
     let description = describe_weight_observation(
         material.density.value,
         carry_strength,

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -20,6 +20,7 @@ use crate::descriptions::describe_thermal_observation;
 use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::ConfidenceTracker;
+use crate::observation::PropertyName;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
 use crate::world_generation::WorldProfile;
 
@@ -304,7 +305,7 @@ fn reveal_thermal_property(
         revealed_seeds.push(mat.seed);
 
         if recorded.is_none() {
-            let count = tracker.record(mat.seed, "thermal_resistance");
+            let count = tracker.record(mat.seed, PropertyName::ThermalResistance);
             commands
                 .entity(entity)
                 .insert(ThermalObservationRecordedThisCycle);
@@ -325,10 +326,10 @@ fn reveal_thermal_property(
                 name: mat.name.clone(),
                 observation: Observation {
                     category: ObservationCategory::ThermalBehavior,
-                    confidence: tracker.level(mat.seed, "thermal_resistance"),
+                    confidence: tracker.level(mat.seed, PropertyName::ThermalResistance),
                     description: describe_thermal_observation(
                         mat.thermal_resistance.value,
-                        tracker.level(mat.seed, "thermal_resistance"),
+                        tracker.level(mat.seed, PropertyName::ThermalResistance),
                     ),
                     recorded_at: 0,
                 },
@@ -497,7 +498,7 @@ mod tests {
         assert_eq!(
             app.world()
                 .resource::<ConfidenceTracker>()
-                .count(7, "thermal_resistance"),
+                .count(7, PropertyName::ThermalResistance),
             1
         );
 
@@ -518,7 +519,7 @@ mod tests {
         assert_eq!(
             app.world()
                 .resource::<ConfidenceTracker>()
-                .count(7, "thermal_resistance"),
+                .count(7, PropertyName::ThermalResistance),
             2
         );
     }

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -28,7 +28,7 @@ use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
 use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
 use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
-use crate::observation::{ConfidenceLevel, ConfidenceTracker};
+use crate::observation::{ConfidenceLevel, ConfidenceTracker, PropertyName};
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
 use crate::world_generation::{PlanetSurface, WorldGenerationConfig, WorldProfile};
@@ -880,7 +880,7 @@ fn append_prop(
 }
 
 fn append_thermal_prop(lines: &mut Vec<String>, mat: &GameMaterial, tracker: &ConfidenceTracker) {
-    let seed_has_thermal_knowledge = tracker.count(mat.seed, "thermal_resistance") > 0;
+    let seed_has_thermal_knowledge = tracker.count(mat.seed, PropertyName::ThermalResistance) > 0;
     match mat.thermal_resistance.visibility {
         PropertyVisibility::Hidden if !seed_has_thermal_knowledge => {
             lines.push("Heat response: ???".to_string())
@@ -888,7 +888,7 @@ fn append_thermal_prop(lines: &mut Vec<String>, mat: &GameMaterial, tracker: &Co
         PropertyVisibility::Hidden
         | PropertyVisibility::Observable
         | PropertyVisibility::Revealed => {
-            let confidence = tracker.level(mat.seed, "thermal_resistance");
+            let confidence = tracker.level(mat.seed, PropertyName::ThermalResistance);
             let description =
                 describe_thermal_observation(mat.thermal_resistance.value, confidence);
             lines.push(format!("Heat response: {description}"));
@@ -981,13 +981,13 @@ mod tests {
         let tentative = build_examine_text(&mat, &tracker);
         assert!(tentative.contains("Heat response: Seemed to hold together under heat"));
 
-        tracker.record(mat.seed, "thermal_resistance");
-        tracker.record(mat.seed, "thermal_resistance");
+        tracker.record(mat.seed, PropertyName::ThermalResistance);
+        tracker.record(mat.seed, PropertyName::ThermalResistance);
         let observed = build_examine_text(&mat, &tracker);
         assert!(observed.contains("Heat response: Hold together under heat"));
 
-        tracker.record(mat.seed, "thermal_resistance");
-        tracker.record(mat.seed, "thermal_resistance");
+        tracker.record(mat.seed, PropertyName::ThermalResistance);
+        tracker.record(mat.seed, PropertyName::ThermalResistance);
         let confident = build_examine_text(&mat, &tracker);
         assert!(confident.contains("Heat response: Reliably hold together under heat"));
     }
@@ -996,7 +996,7 @@ mod tests {
     fn examine_text_uses_seed_level_thermal_knowledge_even_if_entity_is_hidden() {
         let mat = test_material();
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(mat.seed, "thermal_resistance");
+        tracker.record(mat.seed, PropertyName::ThermalResistance);
 
         let text = build_examine_text(&mat, &tracker);
         assert!(!text.contains("Heat response: ???"));

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -68,8 +68,28 @@ impl ConfidenceLevel {
 
 // ── Tracker resource ─────────────────────────────────────────────────────
 
+/// Property names that can be observed through environmental testing.
+///
+/// This enum replaces string literals to provide compile-time safety.
+/// A typo in property names would create silently separate trackers;
+/// the enum prevents this by making invalid property names a compile error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PropertyName {
+    /// Material density — how much mass per unit volume.
+    Density,
+    /// Resistance to heat transfer — thermal insulation properties.
+    ThermalResistance,
+    /// Chemical reactivity — tendency to undergo reactions.
+    Reactivity,
+    /// Electrical conductivity — ability to conduct electric current.
+    Conductivity,
+    /// Toxicity level — harmful effects on biological systems.
+    Toxicity,
+}
+
 /// Canonical key: (material seed, property name).
-type ObsKey = (u64, String);
+type ObsKey = (u64, PropertyName);
 
 /// Stores how many times the player has observed each (material, property)
 /// combination through environmental testing.
@@ -83,8 +103,8 @@ pub struct ConfidenceTracker {
 impl ConfidenceTracker {
     /// Record one observation. Returns the new count.
     #[allow(dead_code)]
-    pub fn record(&mut self, seed: u64, property: &str) -> u32 {
-        let key = (seed, property.to_string());
+    pub fn record(&mut self, seed: u64, property: PropertyName) -> u32 {
+        let key = (seed, property);
         let count = self.counts.entry(key).or_insert(0);
         *count += 1;
         *count
@@ -92,16 +112,13 @@ impl ConfidenceTracker {
 
     /// Current observation count (0 if never observed).
     #[allow(dead_code)]
-    pub fn count(&self, seed: u64, property: &str) -> u32 {
-        self.counts
-            .get(&(seed, property.to_string()))
-            .copied()
-            .unwrap_or(0)
+    pub fn count(&self, seed: u64, property: PropertyName) -> u32 {
+        self.counts.get(&(seed, property)).copied().unwrap_or(0)
     }
 
     /// Confidence level for a specific (material, property) pair.
     #[allow(dead_code)]
-    pub fn level(&self, seed: u64, property: &str) -> ConfidenceLevel {
+    pub fn level(&self, seed: u64, property: PropertyName) -> ConfidenceLevel {
         ConfidenceLevel::from_count(self.count(seed, property))
     }
 }
@@ -115,33 +132,33 @@ mod tests {
     #[test]
     fn fresh_tracker_has_zero_count() {
         let tracker = ConfidenceTracker::default();
-        assert_eq!(tracker.count(42, "thermal_resistance"), 0);
+        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 0);
     }
 
     #[test]
     fn record_increments_count() {
         let mut tracker = ConfidenceTracker::default();
-        assert_eq!(tracker.record(42, "thermal_resistance"), 1);
-        assert_eq!(tracker.record(42, "thermal_resistance"), 2);
-        assert_eq!(tracker.count(42, "thermal_resistance"), 2);
+        assert_eq!(tracker.record(42, PropertyName::ThermalResistance), 1);
+        assert_eq!(tracker.record(42, PropertyName::ThermalResistance), 2);
+        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 2);
     }
 
     #[test]
     fn different_seeds_tracked_independently() {
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(42, "thermal_resistance");
-        tracker.record(99, "thermal_resistance");
-        assert_eq!(tracker.count(42, "thermal_resistance"), 1);
-        assert_eq!(tracker.count(99, "thermal_resistance"), 1);
+        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(99, PropertyName::ThermalResistance);
+        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 1);
+        assert_eq!(tracker.count(99, PropertyName::ThermalResistance), 1);
     }
 
     #[test]
     fn different_properties_tracked_independently() {
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(42, "thermal_resistance");
-        tracker.record(42, "density");
-        assert_eq!(tracker.count(42, "thermal_resistance"), 1);
-        assert_eq!(tracker.count(42, "density"), 1);
+        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(42, PropertyName::Density);
+        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 1);
+        assert_eq!(tracker.count(42, PropertyName::Density), 1);
     }
 
     #[test]
@@ -158,27 +175,27 @@ mod tests {
     fn level_method_uses_internal_count() {
         let mut tracker = ConfidenceTracker::default();
         assert_eq!(
-            tracker.level(42, "thermal_resistance"),
+            tracker.level(42, PropertyName::ThermalResistance),
             ConfidenceLevel::Tentative
         );
-        tracker.record(42, "thermal_resistance");
+        tracker.record(42, PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, "thermal_resistance"),
+            tracker.level(42, PropertyName::ThermalResistance),
             ConfidenceLevel::Tentative
         );
-        tracker.record(42, "thermal_resistance");
+        tracker.record(42, PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, "thermal_resistance"),
+            tracker.level(42, PropertyName::ThermalResistance),
             ConfidenceLevel::Observed
         );
-        tracker.record(42, "thermal_resistance");
+        tracker.record(42, PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, "thermal_resistance"),
+            tracker.level(42, PropertyName::ThermalResistance),
             ConfidenceLevel::Observed
         );
-        tracker.record(42, "thermal_resistance");
+        tracker.record(42, PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, "thermal_resistance"),
+            tracker.level(42, PropertyName::ThermalResistance),
             ConfidenceLevel::Confident
         );
     }

--- a/src/seed_util.rs
+++ b/src/seed_util.rs
@@ -15,8 +15,8 @@
 //!   - `0xE1EF_0001` — elevation
 //!   - `0xA7E1_0001` — material properties
 //!   - `0xE1E7_0001` — planet environment
-//! - Adding a new channel? Add it here, not in the consuming module.
-//! - The uniqueness test at the bottom of this file catches collisions at compile time.
+//! - Adding a new channel? Add it to the `SeedChannel` enum, not as a separate constant.
+//! - The compiler enforces unique discriminants automatically.
 
 // ── Core Mixing Functions ────────────────────────────────────────────────
 
@@ -31,6 +31,113 @@ pub fn mix_seed(base: u64, channel: u64) -> u64 {
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
     z ^ (z >> 31)
+}
+
+/// Seed channel constants for deterministic generation.
+///
+/// Each variant has a unique discriminant value that serves as the channel
+/// constant for `mix_seed`. The compiler enforces uniqueness automatically,
+/// eliminating the need for manual collision checking.
+///
+/// ## Usage
+///
+/// ```rust
+/// use apeiron_cipher::seed_util::{mix_seed, SeedChannel};
+/// let base_seed: u64 = 42;
+/// let mixed = mix_seed(base_seed, SeedChannel::StarType as u64);
+/// ```
+///
+/// ## Adding new channels
+///
+/// Add a new variant with an explicit discriminant in the appropriate family
+/// prefix space. The discriminant values follow the same prefix organization
+/// as the old constants to maintain deterministic compatibility.
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SeedChannel {
+    // ── Star Generation Channels (prefix 0x57A2_0001) ───────────────────────
+    /// Channel for selecting the star type via weighted random.
+    StarType = 0x57A2_0001_0000_0001,
+    /// Channel for interpolating luminosity within the selected type's range.
+    StarLuminosity = 0x57A2_0001_0000_0002,
+    /// Channel for interpolating surface temperature within the selected type's range.
+    StarTemperature = 0x57A2_0001_0000_0003,
+    /// Channel for interpolating stellar mass within the selected type's range.
+    StarMass = 0x57A2_0001_0000_0004,
+
+    // ── Orbital Layout Channels (prefix 0x02B1_0001) ────────────────────────
+    /// Channel for deriving planet count from a system seed.
+    PlanetCount = 0x02B1_0001_0000_0001,
+    /// Channel for seeding the orbital distance RNG.
+    OrbitalLayout = 0x02B1_0001_0000_0002,
+
+    // ── World Generation Channels (prefix 0xD3E5_17A1) ─────────────────────
+    /// Channel for deriving placement density seed from planet seed.
+    PlacementDensity = 0xD3E5_17A1_0000_0001,
+    /// Channel for deriving placement variation seed from planet seed.
+    PlacementVariation = 0xD3E5_17A1_0000_0002,
+    /// Channel for deriving object identity seed from planet seed.
+    ObjectIdentity = 0xD3E5_17A1_0000_0003,
+    /// Channel for deriving the planet surface radius from the planet seed.
+    ///
+    /// The planet surface radius (measured in chunks) determines how large the
+    /// planet is. It is derived deterministically from the planet seed so that
+    /// each planet has a consistent, reproducible size.
+    PlanetSurfaceRadius = 0xD3E5_17A1_0000_0004,
+    /// Channel for deriving the biome climate seed from the planet seed.
+    ///
+    /// The biome climate seed is mixed with sub-channel constants (temperature and
+    /// moisture) to produce two independent coherent noise fields that together
+    /// determine the biome at each chunk position.
+    BiomeClimate = 0xD3E5_17A1_0000_0005,
+
+    // ── Elevation Channels (prefix 0xE1EF_0001) ─────────────────────────────
+    /// Channel for deriving the elevation seed from the planet seed.
+    ///
+    /// The elevation seed drives multi-octave value noise that produces terrain
+    /// height variation across the planet surface.
+    Elevation = 0xE1EF_0001_0000_0001,
+    /// Sub-channel for chunk-level detail noise layered on top of the base
+    /// elevation field. Derived from the elevation seed (not the planet seed)
+    /// so it is guaranteed independent of the base octaves.
+    ElevationDetail = 0xE1EF_0001_0000_0002,
+
+    // ── Material Property Channels (prefix 0xA7E1_0001) ────────────────────
+    /// Channel for deriving material density from a seed.
+    MaterialDensity = 0xA7E1_0001_0000_0001,
+    /// Channel for deriving material thermal resistance from a seed.
+    MaterialThermalResistance = 0xA7E1_0001_0000_0002,
+    /// Channel for deriving material reactivity from a seed.
+    MaterialReactivity = 0xA7E1_0001_0000_0003,
+    /// Channel for deriving material conductivity from a seed.
+    MaterialConductivity = 0xA7E1_0001_0000_0004,
+    /// Channel for deriving material toxicity from a seed.
+    MaterialToxicity = 0xA7E1_0001_0000_0005,
+    /// Channel for deriving the red component of material color from a seed.
+    MaterialColorR = 0xA7E1_0001_0000_0006,
+    /// Channel for deriving the green component of material color from a seed.
+    MaterialColorG = 0xA7E1_0001_0000_0007,
+    /// Channel for deriving the blue component of material color from a seed.
+    MaterialColorB = 0xA7E1_0001_0000_0008,
+
+    // ── Planet Environment Channels (prefix 0xE1E7_0001) ───────────────────
+    /// Channel for deriving planet surface temperature variation from planet seed.
+    PlanetTempVariation = 0xE1E7_0001_0000_0001,
+    /// Channel for deriving planet atmosphere density variation from planet seed.
+    PlanetAtmosphere = 0xE1E7_0001_0000_0002,
+    /// Channel for deriving planet surface gravity from planet seed.
+    PlanetGravity = 0xE1E7_0001_0000_0003,
+}
+
+impl SeedChannel {
+    /// Mix a base seed with this channel to produce a deterministic derived seed.
+    ///
+    /// This is a convenience method that calls `mix_seed(base, self as u64)`.
+    /// It provides a more ergonomic API while maintaining the same deterministic
+    /// behavior as the original constant-based approach.
+    pub fn mix_seed(self, base: u64) -> u64 {
+        mix_seed(base, self as u64)
+    }
 }
 
 /// Convert a mixed `u64` into a `f32` in `[0.0, 1.0)`.
@@ -93,146 +200,138 @@ pub fn f32_next_up(value: f32) -> f32 {
     f32::from_bits(next_bits)
 }
 
-// ── Star Generation Channels (prefix 0x57A2_0001) ───────────────────────
+// ── Backward Compatibility Constants ────────────────────────────────────
+//
+// These constants maintain API compatibility with existing code that uses
+// the old constant-based approach. They map directly to the enum discriminants
+// to ensure identical deterministic behavior.
 
 /// Channel for selecting the star type via weighted random.
-pub const STAR_TYPE_CHANNEL: u64 = 0x57A2_0001_0000_0001;
+pub const STAR_TYPE_CHANNEL: u64 = SeedChannel::StarType as u64;
 /// Channel for interpolating luminosity within the selected type's range.
-pub const STAR_LUMINOSITY_CHANNEL: u64 = 0x57A2_0001_0000_0002;
+pub const STAR_LUMINOSITY_CHANNEL: u64 = SeedChannel::StarLuminosity as u64;
 /// Channel for interpolating surface temperature within the selected type's range.
-pub const STAR_TEMPERATURE_CHANNEL: u64 = 0x57A2_0001_0000_0003;
+pub const STAR_TEMPERATURE_CHANNEL: u64 = SeedChannel::StarTemperature as u64;
 /// Channel for interpolating stellar mass within the selected type's range.
-pub const STAR_MASS_CHANNEL: u64 = 0x57A2_0001_0000_0004;
-
-// ── Orbital Layout Channels (prefix 0x02B1_0001) ────────────────────────
+pub const STAR_MASS_CHANNEL: u64 = SeedChannel::StarMass as u64;
 
 /// Channel for deriving planet count from a system seed.
-pub const PLANET_COUNT_CHANNEL: u64 = 0x02B1_0001_0000_0001;
+pub const PLANET_COUNT_CHANNEL: u64 = SeedChannel::PlanetCount as u64;
 /// Channel for seeding the orbital distance RNG.
-pub const ORBITAL_LAYOUT_CHANNEL: u64 = 0x02B1_0001_0000_0002;
-
-// ── World Generation Channels (prefix 0xD3E5_17A1) ─────────────────────
+pub const ORBITAL_LAYOUT_CHANNEL: u64 = SeedChannel::OrbitalLayout as u64;
 
 /// Channel for deriving placement density seed from planet seed.
-pub const PLACEMENT_DENSITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0001;
+pub const PLACEMENT_DENSITY_CHANNEL: u64 = SeedChannel::PlacementDensity as u64;
 /// Channel for deriving placement variation seed from planet seed.
-pub const PLACEMENT_VARIATION_CHANNEL: u64 = 0xD3E5_17A1_0000_0002;
+pub const PLACEMENT_VARIATION_CHANNEL: u64 = SeedChannel::PlacementVariation as u64;
 /// Channel for deriving object identity seed from planet seed.
-pub const OBJECT_IDENTITY_CHANNEL: u64 = 0xD3E5_17A1_0000_0003;
+pub const OBJECT_IDENTITY_CHANNEL: u64 = SeedChannel::ObjectIdentity as u64;
 /// Channel for deriving the planet surface radius from the planet seed.
-///
-/// The planet surface radius (measured in chunks) determines how large the
-/// planet is. It is derived deterministically from the planet seed so that
-/// each planet has a consistent, reproducible size.
-pub const PLANET_SURFACE_RADIUS_CHANNEL: u64 = 0xD3E5_17A1_0000_0004;
+pub const PLANET_SURFACE_RADIUS_CHANNEL: u64 = SeedChannel::PlanetSurfaceRadius as u64;
 /// Channel for deriving the biome climate seed from the planet seed.
-///
-/// The biome climate seed is mixed with sub-channel constants (temperature and
-/// moisture) to produce two independent coherent noise fields that together
-/// determine the biome at each chunk position.
-pub const BIOME_CLIMATE_CHANNEL: u64 = 0xD3E5_17A1_0000_0005;
-
-// ── Elevation Channels (prefix 0xE1EF_0001) ─────────────────────────────
+pub const BIOME_CLIMATE_CHANNEL: u64 = SeedChannel::BiomeClimate as u64;
 
 /// Channel for deriving the elevation seed from the planet seed.
-///
-/// The elevation seed drives multi-octave value noise that produces terrain
-/// height variation across the planet surface.
-pub const ELEVATION_CHANNEL: u64 = 0xE1EF_0001_0000_0001;
-/// Sub-channel for chunk-level detail noise layered on top of the base
-/// elevation field. Derived from the elevation seed (not the planet seed)
-/// so it is guaranteed independent of the base octaves.
-pub const ELEVATION_DETAIL_CHANNEL: u64 = 0xE1EF_0001_0000_0002;
-
-// ── Material Property Channels (prefix 0xA7E1_0001) ────────────────────
+pub const ELEVATION_CHANNEL: u64 = SeedChannel::Elevation as u64;
+/// Sub-channel for chunk-level detail noise layered on top of the base elevation field.
+pub const ELEVATION_DETAIL_CHANNEL: u64 = SeedChannel::ElevationDetail as u64;
 
 /// Channel for deriving material density from a seed.
-pub const MAT_DENSITY_CHANNEL: u64 = 0xA7E1_0001_0000_0001;
+pub const MAT_DENSITY_CHANNEL: u64 = SeedChannel::MaterialDensity as u64;
 /// Channel for deriving material thermal resistance from a seed.
-pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = 0xA7E1_0001_0000_0002;
+pub const MAT_THERMAL_RESISTANCE_CHANNEL: u64 = SeedChannel::MaterialThermalResistance as u64;
 /// Channel for deriving material reactivity from a seed.
-pub const MAT_REACTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0003;
+pub const MAT_REACTIVITY_CHANNEL: u64 = SeedChannel::MaterialReactivity as u64;
 /// Channel for deriving material conductivity from a seed.
-pub const MAT_CONDUCTIVITY_CHANNEL: u64 = 0xA7E1_0001_0000_0004;
+pub const MAT_CONDUCTIVITY_CHANNEL: u64 = SeedChannel::MaterialConductivity as u64;
 /// Channel for deriving material toxicity from a seed.
-pub const MAT_TOXICITY_CHANNEL: u64 = 0xA7E1_0001_0000_0005;
+pub const MAT_TOXICITY_CHANNEL: u64 = SeedChannel::MaterialToxicity as u64;
 /// Channel for deriving the red component of material color from a seed.
-pub const MAT_COLOR_R_CHANNEL: u64 = 0xA7E1_0001_0000_0006;
+pub const MAT_COLOR_R_CHANNEL: u64 = SeedChannel::MaterialColorR as u64;
 /// Channel for deriving the green component of material color from a seed.
-pub const MAT_COLOR_G_CHANNEL: u64 = 0xA7E1_0001_0000_0007;
+pub const MAT_COLOR_G_CHANNEL: u64 = SeedChannel::MaterialColorG as u64;
 /// Channel for deriving the blue component of material color from a seed.
-pub const MAT_COLOR_B_CHANNEL: u64 = 0xA7E1_0001_0000_0008;
-
-// ── Planet Environment Channels (prefix 0xE1E7_0001) ───────────────────
+pub const MAT_COLOR_B_CHANNEL: u64 = SeedChannel::MaterialColorB as u64;
 
 /// Channel for deriving planet surface temperature variation from planet seed.
-pub const PLANET_TEMP_VARIATION_CHANNEL: u64 = 0xE1E7_0001_0000_0001;
+pub const PLANET_TEMP_VARIATION_CHANNEL: u64 = SeedChannel::PlanetTempVariation as u64;
 /// Channel for deriving planet atmosphere density variation from planet seed.
-pub const PLANET_ATMOSPHERE_CHANNEL: u64 = 0xE1E7_0001_0000_0002;
+pub const PLANET_ATMOSPHERE_CHANNEL: u64 = SeedChannel::PlanetAtmosphere as u64;
 /// Channel for deriving planet surface gravity from planet seed.
-pub const PLANET_GRAVITY_CHANNEL: u64 = 0xE1E7_0001_0000_0003;
-
-// ── Tests ────────────────────────────────────────────────────────────────
+pub const PLANET_GRAVITY_CHANNEL: u64 = SeedChannel::PlanetGravity as u64;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Every channel constant in the codebase must be unique. If this test
-    /// fails, two channels have the same value and seed derivation will
-    /// produce identical outputs for different parameters.
+    /// The enum-based approach automatically ensures unique discriminants.
+    /// This test verifies that the backward compatibility constants match
+    /// their corresponding enum values.
     #[test]
-    fn all_channel_constants_are_unique() {
-        let channels: &[(&str, u64)] = &[
-            // Star generation
-            ("STAR_TYPE_CHANNEL", STAR_TYPE_CHANNEL),
-            ("STAR_LUMINOSITY_CHANNEL", STAR_LUMINOSITY_CHANNEL),
-            ("STAR_TEMPERATURE_CHANNEL", STAR_TEMPERATURE_CHANNEL),
-            ("STAR_MASS_CHANNEL", STAR_MASS_CHANNEL),
-            // Orbital layout
-            ("PLANET_COUNT_CHANNEL", PLANET_COUNT_CHANNEL),
-            ("ORBITAL_LAYOUT_CHANNEL", ORBITAL_LAYOUT_CHANNEL),
-            // World generation
-            ("PLACEMENT_DENSITY_CHANNEL", PLACEMENT_DENSITY_CHANNEL),
-            ("PLACEMENT_VARIATION_CHANNEL", PLACEMENT_VARIATION_CHANNEL),
-            ("OBJECT_IDENTITY_CHANNEL", OBJECT_IDENTITY_CHANNEL),
-            (
-                "PLANET_SURFACE_RADIUS_CHANNEL",
-                PLANET_SURFACE_RADIUS_CHANNEL,
-            ),
-            ("BIOME_CLIMATE_CHANNEL", BIOME_CLIMATE_CHANNEL),
-            // Elevation
-            ("ELEVATION_CHANNEL", ELEVATION_CHANNEL),
-            ("ELEVATION_DETAIL_CHANNEL", ELEVATION_DETAIL_CHANNEL),
-            // Material properties
-            ("MAT_DENSITY_CHANNEL", MAT_DENSITY_CHANNEL),
-            (
-                "MAT_THERMAL_RESISTANCE_CHANNEL",
-                MAT_THERMAL_RESISTANCE_CHANNEL,
-            ),
-            ("MAT_REACTIVITY_CHANNEL", MAT_REACTIVITY_CHANNEL),
-            ("MAT_CONDUCTIVITY_CHANNEL", MAT_CONDUCTIVITY_CHANNEL),
-            ("MAT_TOXICITY_CHANNEL", MAT_TOXICITY_CHANNEL),
-            ("MAT_COLOR_R_CHANNEL", MAT_COLOR_R_CHANNEL),
-            ("MAT_COLOR_G_CHANNEL", MAT_COLOR_G_CHANNEL),
-            ("MAT_COLOR_B_CHANNEL", MAT_COLOR_B_CHANNEL),
-            // Planet environment
-            (
-                "PLANET_TEMP_VARIATION_CHANNEL",
-                PLANET_TEMP_VARIATION_CHANNEL,
-            ),
-            ("PLANET_ATMOSPHERE_CHANNEL", PLANET_ATMOSPHERE_CHANNEL),
-            ("PLANET_GRAVITY_CHANNEL", PLANET_GRAVITY_CHANNEL),
-        ];
+    fn backward_compatibility_constants_match_enum() {
+        assert_eq!(STAR_TYPE_CHANNEL, SeedChannel::StarType as u64);
+        assert_eq!(STAR_LUMINOSITY_CHANNEL, SeedChannel::StarLuminosity as u64);
+        assert_eq!(
+            STAR_TEMPERATURE_CHANNEL,
+            SeedChannel::StarTemperature as u64
+        );
+        assert_eq!(STAR_MASS_CHANNEL, SeedChannel::StarMass as u64);
+        assert_eq!(PLANET_COUNT_CHANNEL, SeedChannel::PlanetCount as u64);
+        assert_eq!(ORBITAL_LAYOUT_CHANNEL, SeedChannel::OrbitalLayout as u64);
+        assert_eq!(
+            PLACEMENT_DENSITY_CHANNEL,
+            SeedChannel::PlacementDensity as u64
+        );
+        assert_eq!(
+            PLACEMENT_VARIATION_CHANNEL,
+            SeedChannel::PlacementVariation as u64
+        );
+        assert_eq!(OBJECT_IDENTITY_CHANNEL, SeedChannel::ObjectIdentity as u64);
+        assert_eq!(
+            PLANET_SURFACE_RADIUS_CHANNEL,
+            SeedChannel::PlanetSurfaceRadius as u64
+        );
+        assert_eq!(BIOME_CLIMATE_CHANNEL, SeedChannel::BiomeClimate as u64);
+        assert_eq!(ELEVATION_CHANNEL, SeedChannel::Elevation as u64);
+        assert_eq!(
+            ELEVATION_DETAIL_CHANNEL,
+            SeedChannel::ElevationDetail as u64
+        );
+        assert_eq!(MAT_DENSITY_CHANNEL, SeedChannel::MaterialDensity as u64);
+        assert_eq!(
+            MAT_THERMAL_RESISTANCE_CHANNEL,
+            SeedChannel::MaterialThermalResistance as u64
+        );
+        assert_eq!(
+            MAT_REACTIVITY_CHANNEL,
+            SeedChannel::MaterialReactivity as u64
+        );
+        assert_eq!(
+            MAT_CONDUCTIVITY_CHANNEL,
+            SeedChannel::MaterialConductivity as u64
+        );
+        assert_eq!(MAT_TOXICITY_CHANNEL, SeedChannel::MaterialToxicity as u64);
+        assert_eq!(MAT_COLOR_R_CHANNEL, SeedChannel::MaterialColorR as u64);
+        assert_eq!(MAT_COLOR_G_CHANNEL, SeedChannel::MaterialColorG as u64);
+        assert_eq!(MAT_COLOR_B_CHANNEL, SeedChannel::MaterialColorB as u64);
+        assert_eq!(
+            PLANET_TEMP_VARIATION_CHANNEL,
+            SeedChannel::PlanetTempVariation as u64
+        );
+        assert_eq!(
+            PLANET_ATMOSPHERE_CHANNEL,
+            SeedChannel::PlanetAtmosphere as u64
+        );
+        assert_eq!(PLANET_GRAVITY_CHANNEL, SeedChannel::PlanetGravity as u64);
+    }
 
-        for (i, (name_a, val_a)) in channels.iter().enumerate() {
-            for (name_b, val_b) in channels.iter().skip(i + 1) {
-                assert_ne!(
-                    val_a, val_b,
-                    "channel collision: {name_a} ({val_a:#018X}) == {name_b} ({val_b:#018X})"
-                );
-            }
-        }
+    #[test]
+    fn seed_channel_mix_seed_method_works() {
+        let base = 12345_u64;
+        let channel = SeedChannel::StarType;
+
+        // The method should produce the same result as the function
+        assert_eq!(channel.mix_seed(base), mix_seed(base, channel as u64));
     }
 
     #[test]

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -51,6 +51,24 @@ use crate::solar_system::{
     derive_planet_environment, derive_star_profile,
 };
 
+/// Canonical biome identities.
+///
+/// Each variant corresponds to a biome definition in `biomes.toml` and
+/// serializes as snake_case strings for TOML/JSON compatibility.
+///
+/// Adding a new biome type requires both a new variant here and a corresponding
+/// entry in `biomes.toml` with a matching key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BiomeType {
+    /// Hot, arid desert with exposed mineral veins. High ferrite content.
+    ScorchedFlats,
+    /// Temperate grassland with balanced mineral distribution. The default biome.
+    MineralSteppe,
+    /// Cold, icy regions with crystalline deposits. High prismate content.
+    FrostShelf,
+}
+
 // ── Surface Query Abstraction (Story 5.3) ────────────────────────────────
 //
 // WHY THIS IS PURE RUST AND NOT AN ECS QUERY:
@@ -1703,8 +1721,8 @@ pub struct BiomeRegistry {
     pub moisture_noise_channel: u64,
     /// Key of the biome used when a chunk's (temperature, moisture) pair does
     /// not fall within any defined biome's range.
-    #[serde(default = "default_fallback_biome_key")]
-    pub fallback_biome_key: String,
+    #[serde(default = "default_fallback_biome_type")]
+    pub fallback_biome_type: BiomeType,
     /// Ordered list of biome definitions. The first matching biome wins when
     /// ranges overlap.
     #[serde(default)]
@@ -1720,8 +1738,8 @@ fn default_temperature_noise_channel() -> u64 {
 fn default_moisture_noise_channel() -> u64 {
     0xB10E_0001_0000_0002
 }
-fn default_fallback_biome_key() -> String {
-    "mineral_steppe".to_string()
+fn default_fallback_biome_type() -> BiomeType {
+    BiomeType::MineralSteppe
 }
 
 /// Reasonable default material palette for the hardcoded neutral fallback biome.
@@ -1769,7 +1787,7 @@ impl Default for BiomeRegistry {
             noise_scale_chunks: default_biome_noise_scale_chunks(),
             temperature_noise_channel: default_temperature_noise_channel(),
             moisture_noise_channel: default_moisture_noise_channel(),
-            fallback_biome_key: default_fallback_biome_key(),
+            fallback_biome_type: default_fallback_biome_type(),
             biomes: default_biome_definitions(),
         }
     }
@@ -1807,8 +1825,8 @@ pub struct PaletteMaterial {
 /// moisture ranges contain the chunk's sampled values.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BiomeDefinition {
-    /// Unique key identifying this biome (e.g., `"scorched_flats"`).
-    pub key: String,
+    /// Canonical biome type identifying this biome.
+    pub biome_type: BiomeType,
     /// Minimum temperature value (0.0–1.0) for this biome's range.
     pub temperature_min: f32,
     /// Maximum temperature value (0.0–1.0) for this biome's range.
@@ -1871,7 +1889,7 @@ fn one_f32() -> f32 {
 fn default_biome_definitions() -> Vec<BiomeDefinition> {
     vec![
         BiomeDefinition {
-            key: "scorched_flats".to_string(),
+            biome_type: BiomeType::ScorchedFlats,
             temperature_min: 0.6,
             temperature_max: 1.0,
             temperature_abs_min_k: Some(350.0),
@@ -1913,7 +1931,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             ],
         },
         BiomeDefinition {
-            key: "mineral_steppe".to_string(),
+            biome_type: BiomeType::MineralSteppe,
             temperature_min: 0.3,
             temperature_max: 0.7,
             temperature_abs_min_k: Some(220.0),
@@ -1926,7 +1944,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             material_palette: default_fallback_material_palette(),
         },
         BiomeDefinition {
-            key: "frost_shelf".to_string(),
+            biome_type: BiomeType::FrostShelf,
             temperature_min: 0.0,
             temperature_max: 0.4,
             temperature_abs_min_k: Some(50.0),
@@ -1978,8 +1996,8 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
 /// Component or Resource.
 #[derive(Clone, Debug)]
 pub struct ChunkBiome {
-    /// The biome key (e.g., `"scorched_flats"`).
-    pub biome_key: String,
+    /// The biome type for this chunk.
+    pub biome_type: BiomeType,
     /// RGB ground color for this chunk's ground tile.
     pub ground_color: [f32; 3],
     /// Density modifier applied to the deposit spawn threshold.
@@ -2084,7 +2102,7 @@ pub fn derive_chunk_biome(
         }
 
         return ChunkBiome {
-            biome_key: biome_def.key.clone(),
+            biome_type: biome_def.biome_type,
             ground_color: biome_def.ground_color,
             density_modifier: biome_def.density_modifier,
             deposit_weight_modifiers: biome_def.deposit_weight_modifiers.clone(),
@@ -2096,10 +2114,10 @@ pub fn derive_chunk_biome(
     if let Some(fallback) = registry
         .biomes
         .iter()
-        .find(|b| b.key == registry.fallback_biome_key)
+        .find(|b| b.biome_type == registry.fallback_biome_type)
     {
         return ChunkBiome {
-            biome_key: fallback.key.clone(),
+            biome_type: fallback.biome_type,
             ground_color: fallback.ground_color,
             density_modifier: fallback.density_modifier,
             deposit_weight_modifiers: fallback.deposit_weight_modifiers.clone(),
@@ -2111,11 +2129,11 @@ pub fn derive_chunk_biome(
     // This should never happen with a well-formed biomes.toml, but we must
     // not panic in generation code.
     warn!(
-        "Biome fallback key '{}' not found in registry; using hardcoded neutral default",
-        registry.fallback_biome_key
+        "Biome fallback type '{:?}' not found in registry; using hardcoded neutral default",
+        registry.fallback_biome_type
     );
     ChunkBiome {
-        biome_key: registry.fallback_biome_key.clone(),
+        biome_type: registry.fallback_biome_type,
         ground_color: [0.26, 0.3, 0.22],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -560,7 +560,7 @@ fn sync_active_exterior_chunks(
         );
         trace!(
             chunk = ?chunk,
-            biome = %chunk_biome.biome_key,
+            biome = ?chunk_biome.biome_type,
             "derived biome for chunk"
         );
 

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
-use crate::world_generation::{PlanetSeed, WorldGenerationConfig};
+use crate::world_generation::{BiomeType, PlanetSeed, WorldGenerationConfig};
 
 fn sample_profile() -> WorldProfile {
     WorldProfile::from_config(&WorldGenerationConfig {
@@ -29,7 +29,7 @@ fn sample_catalog() -> SurfaceMineralDepositCatalog {
 /// exercise the same generation logic without biome influence.
 fn sample_biome() -> ChunkBiome {
     ChunkBiome {
-        biome_key: "mineral_steppe".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.42, 0.45, 0.30],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -1819,14 +1819,14 @@ fn density_modifier_increases_deposit_count() {
     let chunk = ChunkCoord::new(0, -1);
 
     let neutral_biome = ChunkBiome {
-        biome_key: "neutral".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
         material_palette: Vec::new(),
     };
     let dense_biome = ChunkBiome {
-        biome_key: "dense".to_string(),
+        biome_type: BiomeType::ScorchedFlats,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 3.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -1896,7 +1896,7 @@ fn density_modifier_zero_does_not_panic() {
     };
     let surface = sample_flat_surface();
     let biome = ChunkBiome {
-        biome_key: "zero_density".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 0.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2039,7 +2039,7 @@ fn all_deposits_zeroed_in_generation_produces_no_placements() {
     }
 
     let biome = ChunkBiome {
-        biome_key: "dead_zone".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.1, 0.1, 0.1],
         density_modifier: 1.0,
         deposit_weight_modifiers: modifiers,
@@ -2310,7 +2310,7 @@ fn deposit_sites_carry_material_seed_from_palette() {
     let seed_a: u64 = 0xFE00_0000_0000_0001;
     let seed_b: u64 = 0xFE00_0000_0000_0002;
     let biome = ChunkBiome {
-        biome_key: "test_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2357,7 +2357,7 @@ fn deposit_placements_inherit_material_seed_from_site() {
 
     let seed: u64 = 0xAB00_0000_0000_0099;
     let biome = ChunkBiome {
-        biome_key: "single_mat_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.3, 0.3, 0.3],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2401,7 +2401,7 @@ fn empty_palette_produces_zero_material_seed() {
 
     // Biome with no material palette entries.
     let biome = ChunkBiome {
-        biome_key: "barren_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.2, 0.2, 0.2],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2443,7 +2443,7 @@ fn empty_palette_baseline_placements_exist_but_all_have_zero_seed() {
     let surface = sample_flat_surface();
 
     let biome = ChunkBiome {
-        biome_key: "barren_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.2, 0.2, 0.2],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2488,7 +2488,7 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
     let surface = sample_flat_surface();
 
     let biome = ChunkBiome {
-        biome_key: "zero_weight_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.3, 0.3, 0.3],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2546,7 +2546,7 @@ fn single_palette_entry_always_selected() {
 
     let sole_seed: u64 = 0xAA00_0000_0000_0042;
     let biome = ChunkBiome {
-        biome_key: "mono_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.4, 0.4, 0.4],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2650,7 +2650,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
 
     let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
     let biome = ChunkBiome {
-        biome_key: "test_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2743,7 +2743,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
     let biome = ChunkBiome {
-        biome_key: "test_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -2898,14 +2898,14 @@ fn palette_swap_does_not_change_deposit_count() {
     ];
 
     let biome_a = ChunkBiome {
-        biome_key: "test_a".to_string(),
+        biome_type: BiomeType::ScorchedFlats,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
         material_palette: palette_a,
     };
     let biome_b = ChunkBiome {
-        biome_key: "test_b".to_string(),
+        biome_type: BiomeType::FrostShelf,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),
@@ -3032,12 +3032,12 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
         ChunkCoord::new(diameter / 4, diameter / 6),
     ];
 
-    let mut observed_biome_keys: HashSet<String> = HashSet::new();
+    let mut observed_biome_types: HashSet<BiomeType> = HashSet::new();
     let mut total_deposits = 0_usize;
 
     for &chunk in &chunks {
         let biome = derive_chunk_biome(&profile, &biome_registry, chunk, None);
-        observed_biome_keys.insert(biome.biome_key.clone());
+        observed_biome_types.insert(biome.biome_type);
 
         let palette_seeds: HashSet<u64> = biome
             .material_palette
@@ -3068,10 +3068,10 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
             if !palette_seeds.is_empty() && placement.material_seed != 0 {
                 assert!(
                     palette_seeds.contains(&placement.material_seed),
-                    "deposit material_seed {:#018X} not in biome '{}' palette \
+                    "deposit material_seed {:#018X} not in biome '{:?}' palette \
                          (chunk {chunk:?})",
                     placement.material_seed,
-                    biome.biome_key,
+                    biome.biome_type,
                 );
 
                 // Material must register without panicking.
@@ -3088,8 +3088,8 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
 
     // Sanity: the test exercised at least two distinct biome keys.
     assert!(
-        observed_biome_keys.len() >= 2,
-        "expected at least 2 distinct biomes but only saw: {observed_biome_keys:?}"
+        observed_biome_types.len() >= 2,
+        "expected at least 2 distinct biomes but only saw: {observed_biome_types:?}"
     );
 
     // Sanity: we actually generated some deposits across all those chunks.
@@ -3114,7 +3114,7 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
 
     // Scorched-style biome: only seeds 1001, 1003, 1007.
     let scorched_biome = ChunkBiome {
-        biome_key: "scorched_flats".to_string(),
+        biome_type: BiomeType::ScorchedFlats,
         ground_color: [0.55, 0.38, 0.22],
         density_modifier: 1.15,
         deposit_weight_modifiers: HashMap::new(),
@@ -3136,7 +3136,7 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
 
     // Frost-style biome: only seeds 1004, 1010, 1008 — completely disjoint.
     let frost_biome = ChunkBiome {
-        biome_key: "frost_shelf".to_string(),
+        biome_type: BiomeType::FrostShelf,
         ground_color: [0.42, 0.48, 0.56],
         density_modifier: 0.7,
         deposit_weight_modifiers: HashMap::new(),
@@ -3394,7 +3394,7 @@ fn every_deposit_material_is_pickup_ready() {
     let surface = PlanetSurface::new_from_profile(&profile, &config);
 
     let biome = ChunkBiome {
-        biome_key: "scorched_flats".to_string(),
+        biome_type: BiomeType::ScorchedFlats,
         ground_color: [0.55, 0.38, 0.22],
         density_modifier: 1.15,
         deposit_weight_modifiers: HashMap::new(),
@@ -3498,7 +3498,7 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
     // Three distinct biomes with overlapping and unique palette entries.
     let biomes = [
         ChunkBiome {
-            biome_key: "scorched_flats".to_string(),
+            biome_type: BiomeType::ScorchedFlats,
             ground_color: [0.6, 0.3, 0.1],
             density_modifier: 0.8,
             deposit_weight_modifiers: HashMap::new(),
@@ -3518,7 +3518,7 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             ],
         },
         ChunkBiome {
-            biome_key: "mineral_steppe".to_string(),
+            biome_type: BiomeType::MineralSteppe,
             ground_color: [0.42, 0.45, 0.30],
             density_modifier: 1.0,
             deposit_weight_modifiers: HashMap::new(),
@@ -3542,7 +3542,7 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             ],
         },
         ChunkBiome {
-            biome_key: "frost_shelf".to_string(),
+            biome_type: BiomeType::FrostShelf,
             ground_color: [0.7, 0.75, 0.85],
             density_modifier: 1.2,
             deposit_weight_modifiers: HashMap::new(),
@@ -3752,8 +3752,8 @@ fn restart_system_seed_chain_yields_identical_world() {
     #[derive(Debug)]
     struct SessionResult {
         profile: WorldProfile,
-        /// (chunk, biome_key) pairs in insertion order.
-        biome_keys: Vec<(ChunkCoord, String)>,
+        /// (chunk, biome_type) pairs in insertion order.
+        biome_types: Vec<(ChunkCoord, BiomeType)>,
         /// (chunk, elevation_at_origin) pairs for terrain comparison.
         elevations: Vec<(ChunkCoord, f32)>,
         materials: MaterialCatalog,
@@ -3782,14 +3782,14 @@ fn restart_system_seed_chain_yields_identical_world() {
             .as_ref()
             .map(|ctx| &ctx.planet_environment);
 
-        let mut biome_keys = Vec::new();
+        let mut biome_types = Vec::new();
         let mut elevations = Vec::new();
         let mut mat_catalog = MaterialCatalog::default();
 
         for &chunk in chunks {
             // Derive biome using planet environment from the system context.
             let biome = derive_chunk_biome(&profile, biome_registry, chunk, planet_env);
-            biome_keys.push((chunk, biome.biome_key.clone()));
+            biome_types.push((chunk, biome.biome_type));
 
             // Sample elevation at chunk origin to verify terrain identity.
             let origin = chunk_origin_xz(chunk, profile.chunk_size_world_units);
@@ -3813,7 +3813,7 @@ fn restart_system_seed_chain_yields_identical_world() {
 
         SessionResult {
             profile,
-            biome_keys,
+            biome_types,
             elevations,
             materials: mat_catalog,
         }
@@ -3869,15 +3869,19 @@ fn restart_system_seed_chain_yields_identical_world() {
 
     // Biomes must be identical at every chunk.
     assert_eq!(
-        session_a.biome_keys.len(),
-        session_b.biome_keys.len(),
-        "biome key count must match"
+        session_a.biome_types.len(),
+        session_b.biome_types.len(),
+        "biome type count must match"
     );
-    for (a, b) in session_a.biome_keys.iter().zip(session_b.biome_keys.iter()) {
+    for (a, b) in session_a
+        .biome_types
+        .iter()
+        .zip(session_b.biome_types.iter())
+    {
         assert_eq!(a.0, b.0, "chunk coordinates must be in the same order");
         assert_eq!(
             a.1, b.1,
-            "biome key at chunk ({}, {}) must be identical across restarts",
+            "biome type at chunk ({}, {}) must be identical across restarts",
             a.0.x, a.0.z,
         );
     }
@@ -3983,7 +3987,7 @@ fn restart_system_seed_chain_yields_identical_world() {
 /// Build a biome with a real material palette for deposit tests.
 fn sample_biome_with_palette() -> ChunkBiome {
     ChunkBiome {
-        biome_key: "test_biome".to_string(),
+        biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
         density_modifier: 1.0,
         deposit_weight_modifiers: HashMap::new(),

--- a/src/world_generation_tests.rs
+++ b/src/world_generation_tests.rs
@@ -649,24 +649,24 @@ fn biome_derivation_is_deterministic() {
     let a = derive_chunk_biome(&profile, &registry, coord, None);
     let b = derive_chunk_biome(&profile, &registry, coord, None);
 
-    assert_eq!(a.biome_key, b.biome_key);
+    assert_eq!(a.biome_type, b.biome_type);
     assert_eq!(a.ground_color, b.ground_color);
     assert_eq!(a.density_modifier, b.density_modifier);
 }
 
 #[test]
 fn all_three_biomes_reachable() {
-    // Scan a large set of coords and verify all three biome keys appear.
+    // Scan a large set of coords and verify all three biome types appear.
     // The noise field is coherent, so with enough samples we should hit
     // all defined ranges.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
     let registry = BiomeRegistry::default();
 
-    let mut found: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut found: std::collections::HashSet<BiomeType> = std::collections::HashSet::new();
     for x in -50..50 {
         for z in -50..50 {
             let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, z), None);
-            found.insert(biome.biome_key.clone());
+            found.insert(biome.biome_type);
             if found.len() == 3 {
                 break;
             }
@@ -677,16 +677,16 @@ fn all_three_biomes_reachable() {
     }
 
     assert!(
-        found.contains("scorched_flats"),
-        "scorched_flats not found in 100×100 scan, found: {found:?}"
+        found.contains(&BiomeType::ScorchedFlats),
+        "ScorchedFlats not found in 100×100 scan, found: {found:?}"
     );
     assert!(
-        found.contains("mineral_steppe"),
-        "mineral_steppe not found in 100×100 scan, found: {found:?}"
+        found.contains(&BiomeType::MineralSteppe),
+        "MineralSteppe not found in 100×100 scan, found: {found:?}"
     );
     assert!(
-        found.contains("frost_shelf"),
-        "frost_shelf not found in 100×100 scan, found: {found:?}"
+        found.contains(&BiomeType::FrostShelf),
+        "FrostShelf not found in 100×100 scan, found: {found:?}"
     );
 }
 
@@ -699,11 +699,11 @@ fn fallback_biome_used_when_no_range_matches() {
         noise_scale_chunks: 12.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
         moisture_noise_channel: 0xB10E_0001_0000_0002,
-        fallback_biome_key: "fallback_test".to_string(),
+        fallback_biome_type: BiomeType::MineralSteppe,
         biomes: vec![
             // Impossibly narrow range — almost nothing will match.
             BiomeDefinition {
-                key: "narrow".to_string(),
+                biome_type: BiomeType::ScorchedFlats,
                 temperature_min: 0.999,
                 temperature_max: 1.0,
                 temperature_abs_min_k: None,
@@ -717,7 +717,7 @@ fn fallback_biome_used_when_no_range_matches() {
             },
             // Fallback biome.
             BiomeDefinition {
-                key: "fallback_test".to_string(),
+                biome_type: BiomeType::MineralSteppe,
                 temperature_min: 0.0,
                 temperature_max: 0.0,
                 temperature_abs_min_k: None,
@@ -736,7 +736,7 @@ fn fallback_biome_used_when_no_range_matches() {
     let mut found_fallback = false;
     for x in 0..20 {
         let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, 0), None);
-        if biome.biome_key == "fallback_test" {
+        if biome.biome_type == BiomeType::MineralSteppe {
             found_fallback = true;
             assert_eq!(
                 biome.density_modifier, 0.5,
@@ -784,10 +784,10 @@ fn biome_registry_toml_round_trip() {
         toml::from_str(&toml_str).expect("BiomeRegistry should parse from TOML");
 
     assert_eq!(parsed.biomes.len(), registry.biomes.len());
-    assert_eq!(parsed.fallback_biome_key, registry.fallback_biome_key);
+    assert_eq!(parsed.fallback_biome_type, registry.fallback_biome_type);
     assert_eq!(parsed.noise_scale_chunks, registry.noise_scale_chunks);
     for (a, b) in registry.biomes.iter().zip(parsed.biomes.iter()) {
-        assert_eq!(a.key, b.key);
+        assert_eq!(a.biome_type, b.biome_type);
         assert_eq!(a.temperature_min, b.temperature_min);
         assert_eq!(a.temperature_max, b.temperature_max);
         assert_eq!(a.density_modifier, b.density_modifier);
@@ -809,7 +809,7 @@ fn biome_registry_toml_round_trip_with_palette_entries() {
     // Inject palette entries into the first biome (or add a biome if none exist).
     if registry.biomes.is_empty() {
         registry.biomes.push(BiomeDefinition {
-            key: "test_biome".to_string(),
+            biome_type: BiomeType::MineralSteppe,
             temperature_min: 0.0,
             temperature_max: 1.0,
             temperature_abs_min_k: None,
@@ -873,8 +873,8 @@ fn biome_toml_round_trip_empty_palette() {
     for (a, b) in registry.biomes.iter().zip(parsed.biomes.iter()) {
         assert!(
             b.material_palette.is_empty(),
-            "biome '{}' palette should be empty after round-trip",
-            a.key,
+            "biome '{:?}' palette should be empty after round-trip",
+            a.biome_type,
         );
     }
 }
@@ -887,8 +887,13 @@ fn biome_toml_round_trip_shared_seed_across_biomes() {
 
     // Ensure at least two biomes exist.
     while registry.biomes.len() < 2 {
+        let bt = if registry.biomes.is_empty() {
+            BiomeType::ScorchedFlats
+        } else {
+            BiomeType::MineralSteppe
+        };
         registry.biomes.push(BiomeDefinition {
-            key: format!("synth_biome_{}", registry.biomes.len()),
+            biome_type: bt,
             temperature_min: 0.0,
             temperature_max: 1.0,
             temperature_abs_min_k: None,
@@ -946,8 +951,8 @@ fn biome_toml_parses_shipped_asset_file() {
         for entry in &biome.material_palette {
             assert!(
                 entry.selection_weight > 0.0,
-                "biome '{}' has palette entry with non-positive weight {}",
-                biome.key,
+                "biome '{:?}' has palette entry with non-positive weight {}",
+                biome.biome_type,
                 entry.selection_weight,
             );
         }
@@ -976,7 +981,7 @@ fn biome_derivation_wraps_torus_correctly() {
     let a = derive_chunk_biome(&profile, &registry, raw, None);
     let b = derive_chunk_biome(&profile, &registry, wrapped, None);
 
-    assert_eq!(a.biome_key, b.biome_key);
+    assert_eq!(a.biome_type, b.biome_type);
     assert_eq!(a.ground_color, b.ground_color);
 }
 
@@ -991,7 +996,7 @@ fn empty_registry_returns_hardcoded_neutral_default() {
     let profile = WorldProfile::from_config(&config).unwrap();
     let registry = BiomeRegistry {
         biomes: vec![],
-        fallback_biome_key: "nonexistent".to_string(),
+        fallback_biome_type: BiomeType::FrostShelf,
         noise_scale_chunks: 10.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
         moisture_noise_channel: 0xB10E_0001_0000_0002,
@@ -1000,7 +1005,7 @@ fn empty_registry_returns_hardcoded_neutral_default() {
     let result = derive_chunk_biome(&profile, &registry, ChunkCoord::new(0, 0), None);
 
     // Should get the hardcoded neutral default values.
-    assert_eq!(result.biome_key, "nonexistent");
+    assert_eq!(result.biome_type, BiomeType::FrostShelf);
     assert_eq!(result.ground_color, [0.26, 0.3, 0.22]);
     assert_eq!(result.density_modifier, 1.0);
     assert!(result.deposit_weight_modifiers.is_empty());
@@ -1018,7 +1023,7 @@ fn fallback_key_missing_from_registry_returns_hardcoded_default() {
     // will match any real noise sample.
     let registry = BiomeRegistry {
         biomes: vec![BiomeDefinition {
-            key: "impossible".to_string(),
+            biome_type: BiomeType::ScorchedFlats,
             temperature_min: -999.0,
             temperature_max: -998.0,
             temperature_abs_min_k: None,
@@ -1030,7 +1035,7 @@ fn fallback_key_missing_from_registry_returns_hardcoded_default() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: Vec::new(),
         }],
-        fallback_biome_key: "does_not_exist".to_string(),
+        fallback_biome_type: BiomeType::FrostShelf,
         noise_scale_chunks: 10.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
         moisture_noise_channel: 0xB10E_0001_0000_0002,
@@ -1039,7 +1044,7 @@ fn fallback_key_missing_from_registry_returns_hardcoded_default() {
     let result = derive_chunk_biome(&profile, &registry, ChunkCoord::new(5, 5), None);
 
     // Must get the hardcoded neutral, not panic.
-    assert_eq!(result.biome_key, "does_not_exist");
+    assert_eq!(result.biome_type, BiomeType::FrostShelf);
     assert_eq!(result.ground_color, [0.26, 0.3, 0.22]);
     assert_eq!(result.density_modifier, 1.0);
 }
@@ -1054,8 +1059,8 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
     let registry = BiomeRegistry::default();
 
-    // Build expected palettes from the registry, keyed by biome key.
-    let expected: HashMap<String, Vec<(u64, f32)>> = registry
+    // Build expected palettes from the registry, keyed by biome type.
+    let expected: HashMap<BiomeType, Vec<(u64, f32)>> = registry
         .biomes
         .iter()
         .map(|b| {
@@ -1064,21 +1069,21 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
                 .iter()
                 .map(|p| (p.material_seed, p.selection_weight))
                 .collect::<Vec<_>>();
-            (b.key.clone(), palette)
+            (b.biome_type, palette)
         })
         .collect();
 
     // Track which biomes we have verified so we can assert full coverage.
-    let mut verified: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut verified: std::collections::HashSet<BiomeType> = std::collections::HashSet::new();
 
     for x in -50..50 {
         for z in -50..50 {
             let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, z), None);
 
-            let Some(expected_palette) = expected.get(&biome.biome_key) else {
+            let Some(expected_palette) = expected.get(&biome.biome_type) else {
                 panic!(
-                    "derive_chunk_biome returned unknown biome key '{}'",
-                    biome.biome_key
+                    "derive_chunk_biome returned unknown biome type '{:?}'",
+                    biome.biome_type
                 );
             };
 
@@ -1090,11 +1095,11 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
 
             assert_eq!(
                 &actual, expected_palette,
-                "palette mismatch for biome '{}' at chunk ({}, {})",
-                biome.biome_key, x, z
+                "palette mismatch for biome '{:?}' at chunk ({}, {})",
+                biome.biome_type, x, z
             );
 
-            verified.insert(biome.biome_key);
+            verified.insert(biome.biome_type);
             if verified.len() == expected.len() {
                 break;
             }
@@ -1108,7 +1113,7 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
     for key in expected.keys() {
         assert!(
             verified.contains(key),
-            "biome '{key}' was never reached in 100×100 scan — cannot verify its palette"
+            "biome '{key:?}' was never reached in 100×100 scan — cannot verify its palette"
         );
     }
 }
@@ -1132,11 +1137,11 @@ fn chunk_biome_fallback_carries_fallback_palette() {
         noise_scale_chunks: 12.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
         moisture_noise_channel: 0xB10E_0001_0000_0002,
-        fallback_biome_key: "fb".to_string(),
+        fallback_biome_type: BiomeType::MineralSteppe,
         biomes: vec![
             // Impossibly narrow range — almost nothing will match.
             BiomeDefinition {
-                key: "narrow".to_string(),
+                biome_type: BiomeType::ScorchedFlats,
                 temperature_min: 0.999,
                 temperature_max: 1.0,
                 temperature_abs_min_k: None,
@@ -1149,7 +1154,7 @@ fn chunk_biome_fallback_carries_fallback_palette() {
                 material_palette: Vec::new(),
             },
             BiomeDefinition {
-                key: "fb".to_string(),
+                biome_type: BiomeType::MineralSteppe,
                 temperature_min: 0.0,
                 temperature_max: 0.0,
                 temperature_abs_min_k: None,
@@ -1168,7 +1173,7 @@ fn chunk_biome_fallback_carries_fallback_palette() {
     let mut found = false;
     for x in 0..20 {
         let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, 0), None);
-        if biome.biome_key == "fb" {
+        if biome.biome_type == BiomeType::MineralSteppe {
             assert_eq!(
                 biome.material_palette.len(),
                 fallback_palette.len(),
@@ -1195,7 +1200,7 @@ fn chunk_biome_hardcoded_default_has_reasonable_palette() {
     // palette so that deposits can be generated even without biomes.toml.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
     let registry = BiomeRegistry {
-        fallback_biome_key: "does_not_exist".to_string(),
+        fallback_biome_type: BiomeType::FrostShelf,
         biomes: Vec::new(),
         noise_scale_chunks: 12.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
@@ -1224,13 +1229,13 @@ fn chunk_biome_hardcoded_default_has_reasonable_palette() {
 /// for testing planet environment integration.
 fn abs_temp_registry() -> BiomeRegistry {
     BiomeRegistry {
-        fallback_biome_key: "neutral_biome".to_string(),
+        fallback_biome_type: BiomeType::MineralSteppe,
         noise_scale_chunks: 12.0,
         temperature_noise_channel: 0xB10E_0001_0000_0001,
         moisture_noise_channel: 0xB10E_0001_0000_0002,
         biomes: vec![
             BiomeDefinition {
-                key: "hot_biome".to_string(),
+                biome_type: BiomeType::ScorchedFlats,
                 temperature_min: 0.6,
                 temperature_max: 1.0,
                 temperature_abs_min_k: Some(350.0),
@@ -1243,7 +1248,7 @@ fn abs_temp_registry() -> BiomeRegistry {
                 material_palette: Vec::new(),
             },
             BiomeDefinition {
-                key: "cold_biome".to_string(),
+                biome_type: BiomeType::FrostShelf,
                 temperature_min: 0.0,
                 temperature_max: 0.5,
                 temperature_abs_min_k: Some(50.0),
@@ -1259,7 +1264,7 @@ fn abs_temp_registry() -> BiomeRegistry {
             // full normalized range so it catches anything filtered out by
             // absolute temperature checks on the other biomes.
             BiomeDefinition {
-                key: "neutral_biome".to_string(),
+                biome_type: BiomeType::MineralSteppe,
                 temperature_min: 0.0,
                 temperature_max: 1.0,
                 temperature_abs_min_k: None,
@@ -1287,9 +1292,10 @@ fn planet_env_none_uses_normalized_matching_only() {
     for x in 0..20 {
         let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, 0), None);
         assert!(
-            biome.biome_key == "hot_biome" || biome.biome_key == "cold_biome",
-            "unexpected biome: {}",
-            biome.biome_key,
+            biome.biome_type == BiomeType::ScorchedFlats
+                || biome.biome_type == BiomeType::FrostShelf,
+            "unexpected biome: {:?}",
+            biome.biome_type,
         );
     }
 }
@@ -1315,7 +1321,8 @@ fn planet_env_hot_planet_filters_cold_biome() {
         // On a 400–700 K planet, the absolute temp is always >= 400 K.
         // The cold biome requires abs <= 220 K, so it must never appear.
         assert_ne!(
-            biome.biome_key, "cold_biome",
+            biome.biome_type,
+            BiomeType::FrostShelf,
             "cold biome should not appear on a 400–700 K planet (chunk x={x})",
         );
     }
@@ -1339,7 +1346,8 @@ fn planet_env_cold_planet_filters_hot_biome() {
     for x in 0..50 {
         let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, x), Some(&cold_env));
         assert_ne!(
-            biome.biome_key, "hot_biome",
+            biome.biome_type,
+            BiomeType::ScorchedFlats,
             "hot biome should not appear on a 30–100 K planet (chunk x={x})",
         );
     }
@@ -1361,7 +1369,7 @@ fn planet_env_deterministic() {
     let a = derive_chunk_biome(&profile, &registry, coord, Some(&env));
     let b = derive_chunk_biome(&profile, &registry, coord, Some(&env));
     assert_eq!(
-        a.biome_key, b.biome_key,
+        a.biome_type, b.biome_type,
         "same inputs must produce same biome"
     );
 }
@@ -1390,24 +1398,25 @@ fn hot_planet_biomes_differ_from_cold_planet_biomes() {
         in_habitable_zone: false,
     };
 
-    let mut hot_biomes: Vec<String> = Vec::new();
-    let mut cold_biomes: Vec<String> = Vec::new();
+    let mut hot_biomes: Vec<BiomeType> = Vec::new();
+    let mut cold_biomes: Vec<BiomeType> = Vec::new();
 
     for x in 0..100 {
         let coord = ChunkCoord::new(x, x * 3);
-        hot_biomes.push(derive_chunk_biome(&profile, &registry, coord, Some(&hot_env)).biome_key);
-        cold_biomes.push(derive_chunk_biome(&profile, &registry, coord, Some(&cold_env)).biome_key);
+        hot_biomes.push(derive_chunk_biome(&profile, &registry, coord, Some(&hot_env)).biome_type);
+        cold_biomes
+            .push(derive_chunk_biome(&profile, &registry, coord, Some(&cold_env)).biome_type);
     }
 
     // The hot planet must never produce the cold biome (abs max 220 K)
     // and the cold planet must never produce the hot biome (abs min 350 K).
     assert!(
-        !hot_biomes.contains(&"cold_biome".to_string()),
-        "hot planet should not contain cold_biome",
+        !hot_biomes.contains(&BiomeType::FrostShelf),
+        "hot planet should not contain FrostShelf",
     );
     assert!(
-        !cold_biomes.contains(&"hot_biome".to_string()),
-        "cold planet should not contain hot_biome",
+        !cold_biomes.contains(&BiomeType::ScorchedFlats),
+        "cold planet should not contain ScorchedFlats",
     );
 
     // The distributions must actually differ — at least one coordinate
@@ -1465,17 +1474,17 @@ fn hot_planet_skews_toward_scorched_flats_over_frost_shelf() {
     for x in 0..sample_count {
         let coord = ChunkCoord::new(x, x * 7 + 3);
 
-        let hot_biome = derive_chunk_biome(&profile, &registry, coord, Some(&hot_env)).biome_key;
-        if hot_biome == "scorched_flats" {
+        let hot_biome = derive_chunk_biome(&profile, &registry, coord, Some(&hot_env)).biome_type;
+        if hot_biome == BiomeType::ScorchedFlats {
             hot_scorched += 1;
-        } else if hot_biome == "frost_shelf" {
+        } else if hot_biome == BiomeType::FrostShelf {
             hot_frost += 1;
         }
 
-        let cold_biome = derive_chunk_biome(&profile, &registry, coord, Some(&cold_env)).biome_key;
-        if cold_biome == "scorched_flats" {
+        let cold_biome = derive_chunk_biome(&profile, &registry, coord, Some(&cold_env)).biome_type;
+        if cold_biome == BiomeType::ScorchedFlats {
             cold_scorched += 1;
-        } else if cold_biome == "frost_shelf" {
+        } else if cold_biome == BiomeType::FrostShelf {
             cold_frost += 1;
         }
     }
@@ -2413,8 +2422,8 @@ fn full_chain_determinism_system_seed_to_biome_at_origin() {
     );
 
     assert_eq!(
-        biome_a.biome_key, biome_b.biome_key,
-        "biome key at origin must be deterministic"
+        biome_a.biome_type, biome_b.biome_type,
+        "biome type at origin must be deterministic"
     );
     assert_eq!(
         biome_a.ground_color, biome_b.ground_color,
@@ -2425,13 +2434,11 @@ fn full_chain_determinism_system_seed_to_biome_at_origin() {
         "biome density modifier at origin must be deterministic"
     );
 
-    // Verify the biome key is a non-empty string — a truly exercised
-    // pipeline must resolve to a concrete biome, not silently fall through
-    // to an empty default.
-    assert!(
-        !biome_a.biome_key.is_empty(),
-        "biome at origin must resolve to a named biome"
-    );
+    // Verify the biome key is a concrete biome — a truly exercised
+    // pipeline must resolve to a concrete biome, not silently fall through.
+    // (BiomeType is an enum, so this is always satisfied — kept for
+    // documentation value.)
+    let _ = biome_a.biome_type;
 
     // Verify the chunk generation key is also deterministic through
     // the full chain.
@@ -2737,21 +2744,21 @@ fn system_derived_world_generates_biomes_influenced_by_planet_temperature() {
 
     // Collect biome keys across a grid of chunks using the system-derived
     // planet environment (the full-chain path).
-    let mut biomes_with_env: Vec<String> = Vec::new();
+    let mut biomes_with_env: Vec<BiomeType> = Vec::new();
     for x in 0..100_i32 {
         let coord = ChunkCoord::new(x, x.wrapping_mul(7));
         let biome = derive_chunk_biome(&profile, &registry, coord, Some(env));
-        biomes_with_env.push(biome.biome_key);
+        biomes_with_env.push(biome.biome_type);
     }
 
-    // Collect biome keys for the same chunks without a planet environment
+    // Collect biome types for the same chunks without a planet environment
     // (override / no-context mode). Without absolute Kelvin filtering,
     // all biomes that match normalized ranges can appear.
-    let mut biomes_without_env: Vec<String> = Vec::new();
+    let mut biomes_without_env: Vec<BiomeType> = Vec::new();
     for x in 0..100_i32 {
         let coord = ChunkCoord::new(x, x.wrapping_mul(7));
         let biome = derive_chunk_biome(&profile, &registry, coord, None);
-        biomes_without_env.push(biome.biome_key);
+        biomes_without_env.push(biome.biome_type);
     }
 
     // The planet temperature must actually influence biome selection:
@@ -2793,7 +2800,7 @@ fn system_derived_world_generates_biomes_influenced_by_planet_temperature() {
             Some(&ctx_again.planet_environment),
         );
         assert_eq!(
-            biome_a.biome_key, biome_b.biome_key,
+            biome_a.biome_type, biome_b.biome_type,
             "biome at chunk ({}, {}) must be deterministic across identical derivations",
             coord.x, coord.z,
         );
@@ -2861,7 +2868,7 @@ fn override_mode_biome_generation_no_regression() {
     );
 
     let registry = BiomeRegistry::default();
-    let mut found_biomes: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut found_biomes: std::collections::HashSet<BiomeType> = std::collections::HashSet::new();
 
     // Scan a wide grid and assert byte-identical biome results between
     // the two independently-constructed profiles.
@@ -2875,8 +2882,8 @@ fn override_mode_biome_generation_no_regression() {
             let biome_b = derive_chunk_biome(&profile_b, &registry, coord, None);
 
             assert_eq!(
-                biome_a.biome_key, biome_b.biome_key,
-                "biome key mismatch at chunk ({x}, {z})"
+                biome_a.biome_type, biome_b.biome_type,
+                "biome type mismatch at chunk ({x}, {z})"
             );
             assert_eq!(
                 biome_a.ground_color, biome_b.ground_color,
@@ -2887,22 +2894,22 @@ fn override_mode_biome_generation_no_regression() {
                 "density_modifier mismatch at chunk ({x}, {z})"
             );
 
-            found_biomes.insert(biome_a.biome_key);
+            found_biomes.insert(biome_a.biome_type);
         }
     }
 
     // All three default biomes must still be reachable — a regression
     // that silently shifted noise offsets would collapse biome variety.
     assert!(
-        found_biomes.contains("scorched_flats"),
-        "scorched_flats must be reachable in override mode, found: {found_biomes:?}"
+        found_biomes.contains(&BiomeType::ScorchedFlats),
+        "ScorchedFlats must be reachable in override mode, found: {found_biomes:?}"
     );
     assert!(
-        found_biomes.contains("mineral_steppe"),
-        "mineral_steppe must be reachable in override mode, found: {found_biomes:?}"
+        found_biomes.contains(&BiomeType::MineralSteppe),
+        "MineralSteppe must be reachable in override mode, found: {found_biomes:?}"
     );
     assert!(
-        found_biomes.contains("frost_shelf"),
-        "frost_shelf must be reachable in override mode, found: {found_biomes:?}"
+        found_biomes.contains(&BiomeType::FrostShelf),
+        "FrostShelf must be reachable in override mode, found: {found_biomes:?}"
     );
 }

--- a/tests/material_regression.rs
+++ b/tests/material_regression.rs
@@ -8,7 +8,7 @@ mod scenarios;
 
 use apeiron_cipher::materials::{MaterialCatalog, derive_material_from_seed};
 use apeiron_cipher::world_generation::{
-    BiomeRegistry, ChunkCoord, PaletteMaterial, WorldGenerationConfig, WorldProfile,
+    BiomeRegistry, BiomeType, ChunkCoord, PaletteMaterial, WorldGenerationConfig, WorldProfile,
     derive_chunk_biome,
 };
 use std::collections::{HashMap, HashSet};
@@ -174,7 +174,7 @@ fn different_biomes_produce_different_material_sets() {
     let registry = BiomeRegistry::default();
 
     // Sample many chunks and collect material palettes per biome.
-    let mut biome_seeds: HashMap<String, HashSet<u64>> = HashMap::new();
+    let mut biome_seeds: HashMap<BiomeType, HashSet<u64>> = HashMap::new();
 
     for x in -50..50 {
         for z in -50..50 {
@@ -185,7 +185,7 @@ fn different_biomes_produce_different_material_sets() {
                 .map(|p| p.material_seed)
                 .collect();
             biome_seeds
-                .entry(biome.biome_key.clone())
+                .entry(biome.biome_type)
                 .or_default()
                 .extend(seeds);
         }
@@ -224,16 +224,14 @@ fn all_palette_entries_appear_across_many_chunks() {
     let registry = BiomeRegistry::default();
 
     // For each biome, track which palette seeds we actually see.
-    let mut seen_per_biome: HashMap<String, HashSet<u64>> = HashMap::new();
-    let mut expected_per_biome: HashMap<String, HashSet<u64>> = HashMap::new();
+    let mut seen_per_biome: HashMap<BiomeType, HashSet<u64>> = HashMap::new();
+    let mut expected_per_biome: HashMap<BiomeType, HashSet<u64>> = HashMap::new();
 
     for x in -50..50 {
         for z in -50..50 {
             let biome = derive_chunk_biome(&profile, &registry, ChunkCoord::new(x, z), None);
-            let expected = expected_per_biome
-                .entry(biome.biome_key.clone())
-                .or_default();
-            let seen = seen_per_biome.entry(biome.biome_key.clone()).or_default();
+            let expected = expected_per_biome.entry(biome.biome_type).or_default();
+            let seen = seen_per_biome.entry(biome.biome_type).or_default();
 
             for p in &biome.material_palette {
                 expected.insert(p.material_seed);
@@ -251,7 +249,7 @@ fn all_palette_entries_appear_across_many_chunks() {
         for seed in expected {
             assert!(
                 seen.contains(seed),
-                "biome '{biome_key}': palette seed {seed:#x} never appeared \
+                "biome '{biome_key:?}': palette seed {seed:#x} never appeared \
                  across 10,000 chunks"
             );
         }
@@ -371,13 +369,13 @@ fn biome_ground_colors_are_valid_and_distinct_across_biome_types() {
     let registry = BiomeRegistry::default();
 
     // Sample a large grid of chunks to collect biome→color mappings.
-    let mut biome_colors: HashMap<String, Vec<[f32; 3]>> = HashMap::new();
+    let mut biome_colors: HashMap<BiomeType, Vec<[f32; 3]>> = HashMap::new();
 
     for x in -50..50 {
         for z in -50..50 {
             let biome = derive_chunk_biome(&profile, &registry, ChunkCoord { x, z }, None);
             biome_colors
-                .entry(biome.biome_key.clone())
+                .entry(biome.biome_type)
                 .or_default()
                 .push(biome.ground_color);
         }
@@ -394,7 +392,7 @@ fn biome_ground_colors_are_valid_and_distinct_across_biome_types() {
             for (i, &c) in color.iter().enumerate() {
                 assert!(
                     (0.0..=1.0).contains(&c),
-                    "biome '{}' has invalid color component [{}] = {} (must be 0.0..=1.0)",
+                    "biome '{:?}' has invalid color component [{}] = {} (must be 0.0..=1.0)",
                     key,
                     i,
                     c
@@ -410,7 +408,7 @@ fn biome_ground_colors_are_valid_and_distinct_across_biome_types() {
         for color in &colors[1..] {
             assert_eq!(
                 &first, color,
-                "biome '{}' has inconsistent ground colors across chunks",
+                "biome '{:?}' has inconsistent ground colors across chunks",
                 key
             );
         }


### PR DESCRIPTION
Closes #343

Generated by task-runner (enhancement mode) from issue #343.

Branch: `enhancement/343-refactor-replace-string-keyed-enums-with-proper-rust-enums-obskey-startype-biometype-seed-channels`