### PR TITLE
fix: enforce MaterialObject/HeldItem exclusivity in pickup, place, and unstash

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -1392,10 +1392,10 @@ pub fn record_weight_observation(
 
 /// Convert a stashed carry item back into the player's hand.
 ///
-/// We restore the entity into the world-facing material state because the hand
-/// interaction loop already understands `HeldItem + MaterialObject`. Reusing that
-/// path keeps Epic 4 from inventing a second representation for "the material in
-/// front of the camera."
+/// We restore the entity into the held state (`HeldItem` only, not
+/// `MaterialObject`) because the hand is not "in the world" — it is
+/// attached to the camera. `MaterialObject` is re-added when the player
+/// places the item back onto a surface or slot.
 fn move_entity_from_carry_to_hand(
     commands: &mut Commands,
     camera_entity: Entity,
@@ -1405,7 +1405,6 @@ fn move_entity_from_carry_to_hand(
     commands
         .entity(entity)
         .remove::<InCarry>()
-        .insert(MaterialObject)
         .insert(HeldItem)
         .insert(Visibility::Inherited)
         .set_parent_in_place(camera_entity)

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -389,6 +389,7 @@ fn process_pickup(
 
         commands
             .entity(target_entity)
+            .remove::<MaterialObject>()
             .insert(HeldItem)
             .set_parent_in_place(camera_entity)
             .insert(Transform::from_translation(carry_config.hold_offset_vec3()));
@@ -456,6 +457,7 @@ fn process_place(
             commands
                 .entity(held_entity)
                 .remove::<HeldItem>()
+                .insert(MaterialObject)
                 .remove_parent_in_place()
                 .insert(Transform::from_xyz(
                     slot_pos.x,
@@ -478,6 +480,7 @@ fn process_place(
         commands
             .entity(held_entity)
             .remove::<HeldItem>()
+            .insert(MaterialObject)
             .remove_parent_in_place();
 
         let drop_position = if let Some((_entity, surface_gtf, surface)) =


### PR DESCRIPTION
## Summary
- `process_pickup` added `HeldItem` without removing `MaterialObject`, causing the debug assertion to panic on first pickup
- `process_place` (both slot and surface paths) removed `HeldItem` without re-adding `MaterialObject`, leaving placed entities invisible to heat/examine/chunk queries
- `move_entity_from_carry_to_hand` inserted both `MaterialObject` and `HeldItem`, which would also trigger the assertion on unstash

The three markers (`MaterialObject`, `HeldItem`, `InCarry`) are mutually exclusive location states, not type markers.

Closes #358