### PR TITLE
refactor: privatize SurfaceOverrideRegistry and CarryState stash with accessor methods

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -233,7 +233,7 @@ pub struct CarryState {
     /// Whether stashing is rejected when weight exceeds capacity.
     pub hard_limit_enabled: bool,
     /// Ordered list of items currently stashed in carry.
-    pub carried_items: Vec<CarriedItem>,
+    carried_items: Vec<CarriedItem>,
 }
 
 impl CarryState {
@@ -247,12 +247,63 @@ impl CarryState {
         }
     }
 
+    /// Push an item into the carry container using the configured order.
+    /// 
+    /// For both FIFO and LIFO, items are added to the end of the internal storage.
+    /// The difference is in retrieval order via `pop()` and `cycle()`.
+    pub fn push(&mut self, item: CarriedItem) {
+        self.carried_items.push(item);
+    }
+
+    /// Pop an item from the carry container using the configured order.
+    /// 
+    /// FIFO: removes the oldest item (first in the list).
+    /// LIFO: removes the newest item (last in the list).
+    pub fn pop(&mut self, cycle_order: CarryCycleOrder) -> Option<CarriedItem> {
+        match cycle_order {
+            CarryCycleOrder::Fifo => {
+                if self.carried_items.is_empty() {
+                    None
+                } else {
+                    Some(self.carried_items.remove(0))
+                }
+            }
+            CarryCycleOrder::Lifo => self.carried_items.pop(),
+        }
+    }
+
+    /// Get the next item that would be returned by `pop()` without removing it.
+    /// 
+    /// This is used for cycle operations where we need to check the item before
+    /// deciding whether to actually remove it.
+    pub fn cycle(&self, cycle_order: CarryCycleOrder) -> Option<&CarriedItem> {
+        match cycle_order {
+            CarryCycleOrder::Fifo => self.carried_items.first(),
+            CarryCycleOrder::Lifo => self.carried_items.last(),
+        }
+    }
+
+    /// Returns true if the carry container is empty.
+    pub fn is_empty(&self) -> bool {
+        self.carried_items.is_empty()
+    }
+
+    /// Returns the number of items in the carry container.
+    pub fn len(&self) -> usize {
+        self.carried_items.len()
+    }
+
+    /// Iterate over all carried items.
+    pub fn iter(&self) -> impl Iterator<Item = &CarriedItem> {
+        self.carried_items.iter()
+    }
+
     /// Adds a material into carry using that material's density as its weight cost.
     ///
     /// Story 4.1 does not wire the stash interaction yet, but this method is the
     /// server-side accounting rule that later intent-processing systems will call.
     pub fn add_material(&mut self, entity: Entity, material: &GameMaterial) {
-        self.carried_items.push(CarriedItem::new(entity));
+        self.push(CarriedItem::new(entity));
         self.current_weight += material.density.value;
     }
 
@@ -298,10 +349,7 @@ impl CarryState {
     /// systems can decide the order of multi-step operations like "stash current
     /// hand item, then retrieve an older carried item."
     pub fn next_carried_entity(&self, cycle_order: CarryCycleOrder) -> Option<Entity> {
-        match cycle_order {
-            CarryCycleOrder::Fifo => self.carried_items.first().map(|item| item.entity),
-            CarryCycleOrder::Lifo => self.carried_items.last().map(|item| item.entity),
-        }
+        self.cycle(cycle_order).map(|item| item.entity)
     }
 
     /// Returns true when the carry container can accept an item of the given weight.
@@ -1775,7 +1823,8 @@ exponent = 1.0
         state.add_material(entity, &material);
 
         assert_eq!(state.current_weight, 0.8);
-        assert_eq!(state.carried_items, vec![CarriedItem::new(entity)]);
+        assert_eq!(state.len(), 1);
+        assert_eq!(state.iter().next().unwrap(), &CarriedItem::new(entity));
     }
 
     #[test]
@@ -1792,7 +1841,8 @@ exponent = 1.0
 
         assert_eq!(removed, Some(CarriedItem::new(second)));
         assert!((state.current_weight - 0.2).abs() < f32::EPSILON);
-        assert_eq!(state.carried_items, vec![CarriedItem::new(first)]);
+        assert_eq!(state.len(), 1);
+        assert_eq!(state.iter().next().unwrap(), &CarriedItem::new(first));
     }
 
     #[test]
@@ -1818,7 +1868,8 @@ exponent = 1.0
         let first = Entity::from_bits(1);
         let second = Entity::from_bits(2);
         let mut state = CarryState::new(5.0, true);
-        state.carried_items = vec![CarriedItem::new(first), CarriedItem::new(second)];
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
 
         assert_eq!(
             state.next_carried_entity(CarryCycleOrder::Fifo),
@@ -1831,7 +1882,8 @@ exponent = 1.0
         let first = Entity::from_bits(1);
         let second = Entity::from_bits(2);
         let mut state = CarryState::new(5.0, true);
-        state.carried_items = vec![CarriedItem::new(first), CarriedItem::new(second)];
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
 
         assert_eq!(
             state.next_carried_entity(CarryCycleOrder::Lifo),
@@ -1869,16 +1921,90 @@ exponent = 1.0
         let first = Entity::from_bits(1);
         let second = Entity::from_bits(2);
         let mut state = CarryState::new(5.0, true);
-        state.carried_items = vec![CarriedItem::new(first), CarriedItem::new(second)];
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
 
         assert!(state.evict_stale_entity(first));
-        assert_eq!(state.carried_items, vec![CarriedItem::new(second)]);
+        assert_eq!(state.len(), 1);
+        assert_eq!(state.iter().next().unwrap(), &CarriedItem::new(second));
     }
 
     #[test]
     fn evict_stale_entity_returns_false_for_unknown() {
         let mut state = CarryState::new(5.0, true);
         assert!(!state.evict_stale_entity(Entity::from_bits(999)));
+    }
+
+    #[test]
+    fn push_and_pop_fifo_order() {
+        let first = Entity::from_bits(1);
+        let second = Entity::from_bits(2);
+        let mut state = CarryState::new(5.0, true);
+        
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
+        
+        // FIFO: first in, first out
+        assert_eq!(state.pop(CarryCycleOrder::Fifo), Some(CarriedItem::new(first)));
+        assert_eq!(state.pop(CarryCycleOrder::Fifo), Some(CarriedItem::new(second)));
+        assert_eq!(state.pop(CarryCycleOrder::Fifo), None);
+    }
+
+    #[test]
+    fn push_and_pop_lifo_order() {
+        let first = Entity::from_bits(1);
+        let second = Entity::from_bits(2);
+        let mut state = CarryState::new(5.0, true);
+        
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
+        
+        // LIFO: last in, first out
+        assert_eq!(state.pop(CarryCycleOrder::Lifo), Some(CarriedItem::new(second)));
+        assert_eq!(state.pop(CarryCycleOrder::Lifo), Some(CarriedItem::new(first)));
+        assert_eq!(state.pop(CarryCycleOrder::Lifo), None);
+    }
+
+    #[test]
+    fn cycle_returns_next_without_removing() {
+        let first = Entity::from_bits(1);
+        let second = Entity::from_bits(2);
+        let mut state = CarryState::new(5.0, true);
+        
+        state.push(CarriedItem::new(first));
+        state.push(CarriedItem::new(second));
+        
+        // FIFO: cycle returns first, but doesn't remove it
+        assert_eq!(state.cycle(CarryCycleOrder::Fifo), Some(&CarriedItem::new(first)));
+        assert_eq!(state.len(), 2);
+        
+        // LIFO: cycle returns last, but doesn't remove it
+        assert_eq!(state.cycle(CarryCycleOrder::Lifo), Some(&CarriedItem::new(second)));
+        assert_eq!(state.len(), 2);
+    }
+
+    #[test]
+    fn is_empty_and_len_work_correctly() {
+        let mut state = CarryState::new(5.0, true);
+        
+        assert!(state.is_empty());
+        assert_eq!(state.len(), 0);
+        
+        state.push(CarriedItem::new(Entity::from_bits(1)));
+        assert!(!state.is_empty());
+        assert_eq!(state.len(), 1);
+        
+        state.push(CarriedItem::new(Entity::from_bits(2)));
+        assert!(!state.is_empty());
+        assert_eq!(state.len(), 2);
+        
+        state.pop(CarryCycleOrder::Fifo);
+        assert!(!state.is_empty());
+        assert_eq!(state.len(), 1);
+        
+        state.pop(CarryCycleOrder::Fifo);
+        assert!(state.is_empty());
+        assert_eq!(state.len(), 0);
     }
 
     #[test]

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -61,17 +61,29 @@ pub struct SurfaceOverrideRegistry {
 }
 
 impl SurfaceOverrideRegistry {
-    /// Register a new surface override. Returns the index for debugging.
-    pub fn register(&mut self, surface: SurfaceOverride) -> usize {
+    /// Add a new surface override. Returns the index for debugging.
+    pub fn add_override(&mut self, surface: SurfaceOverride) -> usize {
         let idx = self.overrides.len();
         self.overrides.push(surface);
         idx
+    }
+
+    /// Register a new surface override. Returns the index for debugging.
+    /// 
+    /// Deprecated: Use `add_override` instead. Kept for backward compatibility.
+    pub fn register(&mut self, surface: SurfaceOverride) -> usize {
+        self.add_override(surface)
     }
 
     /// Remove all overrides owned by the given entity.
     #[allow(dead_code)] // API for future structure removal
     pub fn remove_by_owner(&mut self, owner: Entity) {
         self.overrides.retain(|s| s.owner != owner);
+    }
+
+    /// Query for overrides that contain the given XZ point.
+    pub fn query(&self, x: f32, z: f32) -> impl Iterator<Item = &SurfaceOverride> {
+        self.overrides.iter().filter(move |s| s.contains_xz(x, z))
     }
 
     /// Iterate all overrides (for queries).
@@ -138,7 +150,7 @@ mod tests {
     fn sample_registry() -> SurfaceOverrideRegistry {
         let mut reg = SurfaceOverrideRegistry::default();
         // Room floor at y=2.0, covering -4..4 on both axes.
-        reg.register(SurfaceOverride {
+        reg.add_override(SurfaceOverride {
             owner: Entity::from_bits(1),
             min_x: -4.0,
             max_x: 4.0,
@@ -147,7 +159,7 @@ mod tests {
             surface_y: 2.0,
         });
         // Table at y=2.8, smaller footprint.
-        reg.register(SurfaceOverride {
+        reg.add_override(SurfaceOverride {
             owner: Entity::from_bits(2),
             min_x: -1.0,
             max_x: 1.0,
@@ -230,7 +242,7 @@ mod tests {
     fn cave_override_below_terrain_is_found() {
         let mut reg = SurfaceOverrideRegistry::default();
         // Cave floor at y=-2, terrain at y=5. Player is in the cave at y=-1.
-        reg.register(SurfaceOverride {
+        reg.add_override(SurfaceOverride {
             owner: Entity::from_bits(10),
             min_x: -10.0,
             max_x: 10.0,
@@ -241,5 +253,40 @@ mod tests {
         // max_y = -1 + 0.5 = -0.5. Cave floor at -2 is below -0.5. Terrain at 5 is above.
         let result = resolve_standing_surface(0.0, 0.0, -0.5, 5.0, &reg);
         assert!((result - (-2.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn query_returns_matching_overrides() {
+        let reg = sample_registry();
+        
+        // Query inside table bounds (0.0, 0.0) - should return both room and table
+        let matches: Vec<_> = reg.query(0.0, 0.0).collect();
+        assert_eq!(matches.len(), 2);
+        
+        // Query inside room but outside table (3.0, 3.0) - should return only room
+        let matches: Vec<_> = reg.query(3.0, 3.0).collect();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].surface_y, 2.0); // room floor
+        
+        // Query outside everything (10.0, 10.0) - should return nothing
+        let matches: Vec<_> = reg.query(10.0, 10.0).collect();
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn register_method_still_works_for_backward_compatibility() {
+        let mut reg = SurfaceOverrideRegistry::default();
+        let surface = SurfaceOverride {
+            owner: Entity::from_bits(1),
+            min_x: 0.0,
+            max_x: 1.0,
+            min_z: 0.0,
+            max_z: 1.0,
+            surface_y: 1.0,
+        };
+        
+        let idx = reg.register(surface);
+        assert_eq!(idx, 0);
+        assert_eq!(reg.iter().count(), 1);
     }
 }

--- a/tests/scenarios/helpers.rs
+++ b/tests/scenarios/helpers.rs
@@ -62,6 +62,5 @@ pub fn carry_item_count(world: &mut World) -> usize {
         .iter(world)
         .next()
         .expect("no entity with CarryState found")
-        .carried_items
         .len()
 }


### PR DESCRIPTION
Closes #346

Generated by task-runner from issue #346.

Final task branch: `enhancement/346-refactor-privatize-surfaceoverrideregistry-and-carrystate-stash-with-accessor-methods`