### PR TITLE
Bug: Stringly-typed biome_key in JournalContext creates silent filter failures

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -22,28 +22,8 @@ use crate::world_generation::BiomeType;
 
 /// Type-safe wrapper for biome identifiers used in journal filtering.
 ///
-/// This newtype ensures that biome keys used in [`JournalContext::CurrentBiome`]
-/// are always valid biome registry identifiers, preventing silent filter
-/// failures caused by typos or mismatched strings (e.g., "basalt_flat" vs
-/// "basalt_flats").
-///
-/// The key is constructed only from a [`BiomeType`] enum value, which is the
-/// single source of truth for biome identity in the registry. This eliminates
-/// the possibility of constructing an invalid biome key that would silently
-/// match nothing during filtering.
-///
-/// # Example
-///
-/// ```rust
-/// use apeiron_cipher::journal::{BiomeKey, JournalContext};
-/// use apeiron_cipher::world_generation::BiomeType;
-///
-/// // Type-safe construction from registry enum
-/// let key = BiomeKey::from(BiomeType::ScorchedFlats);
-/// 
-/// // Use in journal context
-/// let context = JournalContext::CurrentBiome { biome_key: key };
-/// ```
+/// Prevents silent filter failures from string typos by ensuring biome keys
+/// are always constructed from valid [`BiomeType`] enum values.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BiomeKey(BiomeType);
 
@@ -65,6 +45,11 @@ impl BiomeKey {
     ///
     /// This returns the snake_case string that matches the biome registry's
     /// text key format (e.g., "scorched_flats", "mineral_steppe", "frost_shelf").
+    ///
+    /// Note: These strings must match BiomeType's serde serialization format
+    /// (snake_case). The match is exhaustive, so adding a new BiomeType variant
+    /// will cause a compile error here, prompting the developer to add the
+    /// corresponding snake_case string.
     pub fn as_str(&self) -> &'static str {
         match self.0 {
             BiomeType::ScorchedFlats => "scorched_flats",
@@ -1640,7 +1625,11 @@ fn build_filter_bar_text(filter: &JournalFilter) -> String {
             format!("Filter: {} | Current Planet", category.display_label())
         }
         (Some(category), Some(JournalContext::CurrentBiome { biome_key })) => {
-            format!("Filter: {} | Current Biome ({})", category.display_label(), biome_key)
+            format!(
+                "Filter: {} | Current Biome ({})",
+                category.display_label(),
+                biome_key
+            )
         }
     }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -16,6 +16,75 @@ use strum::IntoEnumIterator;
 use crate::input::InputAction;
 use crate::observation::ConfidenceLevel;
 use crate::player::{Player, cursor_is_captured, spawn_player};
+use crate::world_generation::BiomeType;
+
+// ── Biome key type safety ──────────────────────────────────────────────
+
+/// Type-safe wrapper for biome identifiers used in journal filtering.
+///
+/// This newtype ensures that biome keys used in [`JournalContext::CurrentBiome`]
+/// are always valid biome registry identifiers, preventing silent filter
+/// failures caused by typos or mismatched strings (e.g., "basalt_flat" vs
+/// "basalt_flats").
+///
+/// The key is constructed only from a [`BiomeType`] enum value, which is the
+/// single source of truth for biome identity in the registry. This eliminates
+/// the possibility of constructing an invalid biome key that would silently
+/// match nothing during filtering.
+///
+/// # Example
+///
+/// ```rust
+/// use apeiron_cipher::journal::{BiomeKey, JournalContext};
+/// use apeiron_cipher::world_generation::BiomeType;
+///
+/// // Type-safe construction from registry enum
+/// let key = BiomeKey::from(BiomeType::ScorchedFlats);
+/// 
+/// // Use in journal context
+/// let context = JournalContext::CurrentBiome { biome_key: key };
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BiomeKey(BiomeType);
+
+impl BiomeKey {
+    /// Create a new biome key from a biome type.
+    ///
+    /// This is the only way to construct a `BiomeKey`, ensuring all instances
+    /// correspond to valid biome registry entries.
+    pub fn new(biome_type: BiomeType) -> Self {
+        Self(biome_type)
+    }
+
+    /// Get the underlying biome type.
+    pub fn biome_type(&self) -> BiomeType {
+        self.0
+    }
+
+    /// Get the string representation used for serialization and display.
+    ///
+    /// This returns the snake_case string that matches the biome registry's
+    /// text key format (e.g., "scorched_flats", "mineral_steppe", "frost_shelf").
+    pub fn as_str(&self) -> &'static str {
+        match self.0 {
+            BiomeType::ScorchedFlats => "scorched_flats",
+            BiomeType::MineralSteppe => "mineral_steppe",
+            BiomeType::FrostShelf => "frost_shelf",
+        }
+    }
+}
+
+impl From<BiomeType> for BiomeKey {
+    fn from(biome_type: BiomeType) -> Self {
+        Self::new(biome_type)
+    }
+}
+
+impl std::fmt::Display for BiomeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
 
 // ── Observation data model ──────────────────────────────────────────────
 
@@ -240,13 +309,13 @@ pub enum JournalContext {
         planet_seed: u64,
     },
     /// Restrict to entries that were observed within the named biome.
-    /// The key matches the biome registry's text key (e.g. `"tundra"`,
-    /// `"basalt_flats"`); a `String` is used here because the biome
-    /// taxonomy is data-driven and not represented as a typed enum.
+    /// The key is a type-safe wrapper around [`BiomeType`] that ensures
+    /// consistency with the biome registry and prevents silent filter
+    /// failures from typos or mismatched strings.
     CurrentBiome {
-        /// Biome registry key used as the equality value when matching
-        /// entries against this context.
-        biome_key: String,
+        /// Type-safe biome identifier that corresponds to a valid biome
+        /// registry entry. Constructed only from [`BiomeType`] enum values.
+        biome_key: BiomeKey,
     },
     // Future variants (CurrentSystem, TimePeriod, …) will be added when
     // the underlying world metadata is captured on JournalKey.  They are
@@ -345,6 +414,10 @@ pub fn matches_filter(entry: &JournalEntry, filter: &JournalFilter) -> bool {
         // UI affordance usable without producing a misleading "no
         // matching entries" panel for a filter that hasn't been
         // wired through to the data model yet.
+        //
+        // When biome capture is added, this arm will compare the entry's
+        // recorded biome key against `biome_key.biome_type()` — no other
+        // call site needs to change.
         JournalContext::CurrentBiome { .. } => true,
     });
 
@@ -1560,12 +1633,14 @@ fn build_filter_bar_text(filter: &JournalFilter) -> String {
         (None, None) => String::new(), // All filter - no text needed
         (Some(category), None) => format!("Filter: {}", category.display_label()),
         (None, Some(JournalContext::CurrentPlanet { .. })) => "Filter: Current Planet".to_string(),
-        (None, Some(JournalContext::CurrentBiome { .. })) => "Filter: Current Biome".to_string(),
+        (None, Some(JournalContext::CurrentBiome { biome_key })) => {
+            format!("Filter: Current Biome ({})", biome_key)
+        }
         (Some(category), Some(JournalContext::CurrentPlanet { .. })) => {
             format!("Filter: {} | Current Planet", category.display_label())
         }
-        (Some(category), Some(JournalContext::CurrentBiome { .. })) => {
-            format!("Filter: {} | Current Biome", category.display_label())
+        (Some(category), Some(JournalContext::CurrentBiome { biome_key })) => {
+            format!("Filter: {} | Current Biome ({})", category.display_label(), biome_key)
         }
     }
 }
@@ -1702,12 +1777,14 @@ fn build_help_text(entry_count: usize, state: &JournalUiState) -> String {
         (None, Some(JournalContext::CurrentPlanet { .. })) => {
             " [Filter: Current Planet]".to_string()
         }
-        (None, Some(JournalContext::CurrentBiome { .. })) => " [Filter: Current Biome]".to_string(),
+        (None, Some(JournalContext::CurrentBiome { biome_key })) => {
+            format!(" [Filter: Current Biome ({})]", biome_key)
+        }
         (Some(_), Some(JournalContext::CurrentPlanet { .. })) => {
             " [Filter: Category | Current Planet]".to_string()
         }
-        (Some(_), Some(JournalContext::CurrentBiome { .. })) => {
-            " [Filter: Category | Current Biome]".to_string()
+        (Some(_), Some(JournalContext::CurrentBiome { biome_key })) => {
+            format!(" [Filter: Category | Current Biome ({})]", biome_key)
         }
     };
 

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -5620,3 +5620,31 @@ fn test_planet_switch_updates_context_filter() {
         );
     }
 }
+
+#[test]
+fn biome_key_as_str_matches_serde_serialization() {
+    // Verify that BiomeKey::as_str() produces the same strings as serde
+    // serialization of BiomeType. This ensures the manual mapping stays
+    // in sync with BiomeType's #[serde(rename_all = "snake_case")] configuration.
+
+    let test_cases = [
+        BiomeType::ScorchedFlats,
+        BiomeType::MineralSteppe,
+        BiomeType::FrostShelf,
+    ];
+
+    for biome_type in test_cases {
+        let biome_key = BiomeKey::from(biome_type);
+        let manual_string = biome_key.as_str();
+        let serde_string = serde_json::to_string(&biome_type)
+            .unwrap()
+            .trim_matches('"')
+            .to_string();
+
+        assert_eq!(
+            manual_string, serde_string,
+            "BiomeKey::as_str() for {:?} should match serde serialization",
+            biome_type
+        );
+    }
+}

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -334,18 +334,18 @@ fn journal_ui_state_filter_persists_across_visibility_toggle() {
 }
 
 #[test]
-fn journal_context_biome_equality_is_string_based() {
-    // CurrentBiome carries a registry key as a String; equality is
-    // straightforward string equality, which is what the matching
-    // logic in later tasks will rely on.
+fn journal_context_biome_equality_is_type_safe() {
+    // CurrentBiome carries a type-safe BiomeKey; equality is based on
+    // the underlying BiomeType, ensuring consistency with the biome
+    // registry and preventing silent filter failures from typos.
     let a = JournalContext::CurrentBiome {
-        biome_key: "tundra".to_string(),
+        biome_key: BiomeKey::from(BiomeType::ScorchedFlats),
     };
     let b = JournalContext::CurrentBiome {
-        biome_key: "tundra".to_string(),
+        biome_key: BiomeKey::from(BiomeType::ScorchedFlats),
     };
     let c = JournalContext::CurrentBiome {
-        biome_key: "basalt_flats".to_string(),
+        biome_key: BiomeKey::from(BiomeType::FrostShelf),
     };
     assert_eq!(a, b);
     assert_ne!(a, c);
@@ -542,7 +542,7 @@ fn matches_filter_current_biome_is_no_op_until_data_capture() {
     let filter = JournalFilter {
         category: None,
         context: Some(JournalContext::CurrentBiome {
-            biome_key: "tundra".to_string(),
+            biome_key: BiomeKey::from(BiomeType::ScorchedFlats),
         }),
     };
     let entry = entry_with_observation(
@@ -5306,12 +5306,12 @@ fn filter_bar_renders_correctly() {
     let filter_biome = JournalFilter {
         category: None,
         context: Some(JournalContext::CurrentBiome {
-            biome_key: "tundra".to_string(),
+            biome_key: BiomeKey::from(BiomeType::ScorchedFlats),
         }),
     };
     let filter_bar_biome = build_filter_bar_text(&filter_biome);
     assert_eq!(
-        filter_bar_biome, "Filter: Current Biome",
+        filter_bar_biome, "Filter: Current Biome (scorched_flats)",
         "Biome filter should show biome context"
     );
 
@@ -5330,12 +5330,12 @@ fn filter_bar_renders_correctly() {
     let filter_combined_biome = JournalFilter {
         category: Some(ObservationCategory::Weight),
         context: Some(JournalContext::CurrentBiome {
-            biome_key: "basalt_flats".to_string(),
+            biome_key: BiomeKey::from(BiomeType::FrostShelf),
         }),
     };
     let filter_bar_combined_biome = build_filter_bar_text(&filter_combined_biome);
     assert_eq!(
-        filter_bar_combined_biome, "Filter: Weight | Current Biome",
+        filter_bar_combined_biome, "Filter: Weight | Current Biome (frost_shelf)",
         "Combined category+biome filter should show both"
     );
 }
@@ -5561,7 +5561,7 @@ fn test_planet_switch_updates_context_filter() {
         state.set_filter(JournalFilter {
             category: None,
             context: Some(JournalContext::CurrentBiome {
-                biome_key: "tundra".to_string(),
+                biome_key: BiomeKey::from(BiomeType::ScorchedFlats),
             }),
         });
     }
@@ -5582,7 +5582,7 @@ fn test_planet_switch_updates_context_filter() {
         assert_eq!(
             state.filter().context,
             Some(JournalContext::CurrentBiome {
-                biome_key: "tundra".to_string()
+                biome_key: BiomeKey::from(BiomeType::ScorchedFlats)
             }),
             "CurrentBiome filter should not be affected by planet changes"
         );


### PR DESCRIPTION
Closes #354

Generated by task-runner from issue #354.

Final task branch: `enhancement/354-bug-stringly-typed-biome-key-in-journalcontext-creates-silent-filter-failures`