### PR TITLE
fix: remove indoor room material spawning — deposits are sole material source

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -57,13 +57,14 @@ The **authoritative source** for when to stop and ask vs when to proceed is `doc
 
 ## 4. Development Workflow
 
-Agents manage their own PRs and issue label state using `gh` and `gt` (Graphite) CLIs. **Status is tracked via `status:*` labels on GitHub Issues, not a project board.**
+Agents manage their own issue label state using the `gh` CLI. **Status is tracked via `status:*` labels on GitHub Issues, not a project board.**
 
 The full workflow (pick story → implement → PR → review) is documented in `docs/bmad/agent-workflow.md`. Key constraints:
 
 - Only one story in progress at a time
 - Agents must **never** close an issue or transition it to Done (automation handles this)
 - If blocked: move to `status:blocked`, cascade to dependents, pick next ready story. **Collaborate, don't decide.**
+- **Before committing or opening a PR:** re-read `docs/bmad/planning-artifacts/architecture/core-principles.md` and verify your changes do not violate any of the 10 principles. This is not optional. The principles are short — read them in full, not just the ones that seem relevant. An agent that skips this step and ships a violation has failed the task.
 
 ### Branch & PR Naming
 

--- a/docs/bmad/agent-workflow-reference.md
+++ b/docs/bmad/agent-workflow-reference.md
@@ -4,33 +4,31 @@ _Reference tables and commands for the story workflow. Load this file when runni
 
 ---
 
-## In-Review Health Check (story ↔ PR linkage)
+## In-Review Health Check (story ↔ tag linkage)
 
-Run this check periodically (or when a story appears stuck in _In review_) to verify the close-link workflow is healthy:
+Run this check periodically (or when a story appears stuck in _In review_):
 
-1. List project items and identify stories currently in _In review_:
-   - `gh project item-list 1 --owner galamdring --format json`
-2. For each story issue `#N`, find referencing PRs:
-   - `gh pr list --state all --search "Closes #N" --repo galamdring/apeiron-cipher`
-3. Validate each matching PR:
-   - `gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body`
-4. Triage results:
-   - No referencing PR found -> fix PR body (`Closes #N`) or open the missing PR.
-   - PR not targeting `main` -> correct base to `main`.
-   - Dependency not merged yet -> keep _In review_ and retain `Depends on #X`.
-   - PR merged but issue still open -> manually investigate issue automation and board sync.
+1. List stories currently in _In review_:
+   - `gh issue list --label "status:in-review" --label "story" --json number,title --repo galamdring/apeiron-cipher`
+2. For each story issue `#N`, verify the tag exists on develop:
+   - `git tag --list "story-N.N-complete"`
+3. Triage:
+   - Tag missing → agent did not complete Step 4. Re-run tagging.
+   - Tag exists, no `@automation approve` comment → awaiting human playtest. Leave as-is.
+   - `@automation approve` posted but no staging PR → automation workflow may have failed. Check GitHub Actions logs.
+   - Staging PR open → awaiting human merge. Leave as-is.
+   - Staging PR merged but issue still open → investigate GitHub auto-close (`Closes #N` in PR body).
 
 ---
 
 ## Task Management
 
-**All task tracking uses GitHub Issues with labels as the state machine.** Status is tracked via `status:*` labels, not a GitHub Project board.
+**All task tracking uses GitHub Issues with labels as the state machine.** Status is tracked via `status:*` labels.
 
 - Epics are GitHub Issues labeled `epic` with stories linked via `epic-N` labels
 - Stories are GitHub Issues labeled `story` with full acceptance criteria, technical notes, dependency links, and implementation order in their body
 - Status flows via labels: `status:triage` → `status:backlog` → `status:ready` → `status:in-progress` → `status:in-review` → closed
 - Scoping flows via labels: `needs_refinement` → `in_scoping` → `sow_ready` → `stories_created`
-- n8n workflows respond to label changes via GitHub webhook events and manage automated transitions
 
 ### Label Taxonomy
 
@@ -46,8 +44,8 @@ Run this check periodically (or when a story appears stuck in _In review_) to ve
 | `status:backlog` | `#d4c5f9` | Classified, not yet ready |
 | `status:ready` | `#0e8a16` | Approved for work |
 | `status:in-progress` | `#1d76db` | Agent working |
-| `status:in-review` | `#5319e7` | PR up for review |
-| `status:blocked` | `#e11d48` | Blocked |
+| `status:in-review` | `#5319e7` | Tagged, awaiting human playtest |
+| `status:blocked` | `#e11d48` | Blocked, awaiting human input |
 | **Scoping Labels** | | |
 | `needs_refinement` | `#d876e3` | Needs initial AI pass |
 | `in_scoping` | `#c5def5` | Scoping conversation active |
@@ -61,7 +59,7 @@ Run this check periodically (or when a story appears stuck in _In review_) to ve
 ## Useful Commands
 
 ```bash
-# List all ready stories (sorted by implementation order in body)
+# List all ready stories
 gh issue list --label "status:ready" --label "story" --json number,title,body --repo galamdring/apeiron-cipher
 
 # List all stories for a specific epic
@@ -79,26 +77,21 @@ gh issue edit <N> --remove-label "status:in-progress" --add-label "status:blocke
 # View a specific story's acceptance criteria
 gh issue view <number> --repo galamdring/apeiron-cipher
 
-# Graphite: view the current stack
-gt log
+# Tag a completed story
+git tag story-N.N-complete
+git push origin develop --tags
 
-# Graphite: create a new stacked branch
-gt create <branch-name>
+# List all story tags
+git tag --list "story-*"
 
-# Graphite: submit all branches in the stack as PRs
-gt submit
+# Find the commit range between two story tags
+git log story-N.M-complete..story-N.N-complete --oneline
 
-# Graphite: rebase the stack after a change to a lower branch
-gt stack restack
-
-# Graphite: sync with remote (after a PR is merged on GitHub)
-gt stack sync
-
-# Find PRs that reference a story issue
-gh pr list --state all --search "Closes #<issue_number>" --repo galamdring/apeiron-cipher
+# View staging PRs
+gh pr list --state open --search "staging/" --repo galamdring/apeiron-cipher
 
 # Verify PR state/body
 gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body
 ```
 
-Last Updated: 2026-04-18
+Last Updated: 2026-05-13

--- a/docs/bmad/agent-workflow.md
+++ b/docs/bmad/agent-workflow.md
@@ -4,9 +4,19 @@ _This file contains the step-by-step workflow for the coding agent to implement 
 
 ---
 
-## Story Implementation Workflow
+## Branch and Release Model
 
-This is the mandatory workflow for implementing stories. Agents must follow these steps in order.
+- **`develop`** — the continuous stream of implementation work. All agent commits go here. CI runs on every push.
+- **`main`** — clean linear history of completed, playtested stories. Protected: no direct pushes. Merge only via PR.
+- **Story tags** — when a story is complete and passing CI, the agent tags the commit: `story-N.N-complete`. These are the playtest checkpoints.
+- **Staging branches** — created automatically by the `@automation approve` workflow (see Step 4). One per story, squashed, used solely as the PR source.
+- **Releases** — triggered automatically when a PR merges to `main`.
+
+**Why one story at a time:** Agents make architectural decisions that compound. A wrong assumption in story 3 becomes story 5's foundation. Keeping one story in progress at a time means bugs and drift are caught before the next story builds on them. This is a deliberate constraint, not a limitation.
+
+---
+
+## Story Implementation Workflow
 
 ### Step 1 — Pick a story
 
@@ -19,9 +29,10 @@ gh issue list --label "status:ready" --label "story" --json number,title,body --
 Read the issue body of each Ready story to find its _Implementation Order_ number. Pick the lowest-numbered story — that is the next story to implement.
 
 **Dependency validation:** Before picking a story, check its `Depends on: #N` declarations. For each dependency:
-- If the dependency issue is closed or has the `status:in-review` label, proceed — the code exists on its branch and can be stacked on.
-- If the dependency has any other status (`status:ready`, `status:in-progress`, `status:backlog`, `status:blocked`), skip this story and move to the next lowest-numbered Ready story.
-- If the dependency has an open PR, the agent stacks its branch on top of that PR's branch.
+- If the dependency issue is closed, proceed.
+- If the dependency has any other status, skip this story and move to the next lowest-numbered Ready story.
+
+Only one story should be In progress at a time.
 
 ### Step 2 — Move to In progress
 
@@ -31,17 +42,13 @@ Before writing any code, move the story to _In progress_:
 gh issue edit <N> --remove-label "status:ready" --add-label "status:in-progress" --repo galamdring/apeiron-cipher
 ```
 
-Only one story should be In progress at a time.
-
 ### Step 3 — Implement
 
-- Create a feature branch using Graphite so it stacks on the current branch:
+Ensure you are on `develop`:
 
 ```bash
-gt create epic-N/story-N.N-short-description
+git checkout develop
 ```
-
-If the previous story's branch is still open (PR not yet merged), Graphite automatically stacks the new branch on top of it. If starting fresh from `main`, check out `main` first.
 
 - Read the full issue body for acceptance criteria and technical notes:
 
@@ -49,21 +56,22 @@ If the previous story's branch is still open (PR not yet merged), Graphite autom
 gh issue view <number> --repo galamdring/apeiron-cipher
 ```
 
-- **Load architecture context:** Consult `docs/bmad/planning-artifacts/architecture/agent-context-routing.md` to determine which architecture shards are relevant to this story's domain (e.g., materials, persistence, error handling). Load those shards before writing code.
-- Implement the story. All acceptance criteria must be satisfied. The GitHub Issue is the canonical source for acceptance criteria — query it with `gh issue view <N> --repo galamdring/apeiron-cipher`.
-- Run `make check` (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`) before committing.
+- **Load architecture context:** Consult `docs/bmad/planning-artifacts/architecture/agent-context-routing.md` to determine which architecture shards are relevant to this story's domain. Load those shards before writing code.
+- Implement the story. All acceptance criteria must be satisfied. The GitHub Issue is the canonical source for acceptance criteria.
+- Run `make check` before committing.
+- Commit directly to `develop`. Commit messages should follow Conventional Commits: `feat: N.N - short description`.
 
 ### Step 3a — Block (when the agent cannot proceed)
 
-If the agent cannot proceed without human input, it blocks the story and cascades to dependents.
+If the agent cannot proceed without human input, it blocks the story.
 
 **When to block:** Architectural ambiguity, a question where multiple reasonable approaches exist (per "collaborate, don't decide"), or an unresolvable build failure.
 
-**What NOT to block on:** Trivial implementation choices, clippy lint approaches, cosmetic tuning, sensitivity values — handle these and note them in the PR for review.
+**What NOT to block on:** Trivial implementation choices, clippy lint approaches, cosmetic tuning, sensitivity values — handle these and note them in the issue comment for review.
 
 **Procedure:**
 
-1. Post a comment on the story issue prefixed with `[Indy] Blocked:` explaining the specific question or blocker.
+1. Post a comment on the story issue prefixed with `[Agent] Blocked:` explaining the specific question or blocker.
 2. Move the story to _Blocked_:
 
 ```bash
@@ -72,65 +80,77 @@ gh issue edit <N> --remove-label "status:in-progress" --add-label "status:blocke
 
 3. Return to Step 1 — pick the next Ready story that is not blocked.
 
-**Resumption:** The human answers the question and moves the story back to Ready. On the next pipeline pass, the agent reads all issue comments on a previously-blocked story to incorporate the human's answer before resuming implementation.
+**Resumption:** The human answers the question and moves the story back to Ready. On the next pipeline pass, the agent reads all issue comments on a previously-blocked story to incorporate the human's answer before resuming.
 
-### Step 4 — Create PR and move to In review
+### Step 4 — Tag and move to In review
 
-- Submit the branch (and any unstacked branches below it) as PRs using Graphite:
+Once all acceptance criteria are met and `make check` passes:
+
+1. Tag the current commit on `develop`:
 
 ```bash
-gt submit
+git tag story-N.N-complete
+git push origin develop --tags
 ```
 
-Graphite creates or updates the GitHub PR for each branch in the stack.
-
-- Every story PR must target `main` when created. Graphite branch ancestry is still used to model dependencies locally, but GitHub PR base must remain `main`.
-- If this story depends on an unmerged ancestor branch, add `Depends on #<dependency_pr_number>` in the PR body and do not merge out of dependency order.
-- The PR body _must_ include `Closes #<issue_number>` so merge to `main` auto-closes the story issue.
-- After a dependency PR merges, run `gt stack sync` and `gt submit`, then verify the dependent PR diff only contains that story's changes.
-- Move the story to _In review_:
+2. Move the story to _In review_:
 
 ```bash
 gh issue edit <N> --remove-label "status:in-progress" --add-label "status:in-review" --repo galamdring/apeiron-cipher
 ```
 
-### Handling change requests on stacked PRs
+3. Post a comment on the issue:
 
-When a reviewer requests changes on a lower branch in the stack:
+```
+[Agent] Implementation complete. Tagged `story-N.N-complete` on develop. Ready for playtest.
+```
 
-1. Check out the branch that needs changes: `gt checkout epic-N/story-N.N-...`
-2. Make fixes, commit, then sync the stack: `gt stack restack`
-3. Re-submit the entire stack: `gt submit`
+The human will playtest from `develop` at the tag. If changes are needed, they post feedback on the issue and move it back to `status:in-progress`. When satisfied, the human posts:
 
-Graphite automatically rebases all branches above the changed one.
+```
+@automation approve
+```
+
+This triggers the automation workflow (see below) which squashes all commits since the previous story tag into a single commit, opens a staging branch, and creates a PR to `main`.
 
 ### Step 5 — Done (automated, never agent-triggered)
 
-_An agent must NEVER move an issue to Done or close it._ The Done transition happens automatically:
+_An agent must NEVER close an issue or merge a PR._ The Done transition happens automatically:
 
-- When a PR with `Closes #N` merges, GitHub auto-closes the story issue.
-- The `story-close-check` n8n workflow detects story closure, checks if all sibling stories in the epic are closed, and auto-closes the parent epic when complete.
+- The human merges the staging PR to `main`.
+- GitHub auto-closes the story issue via `Closes #N` in the PR body.
+- The release workflow runs on merge to `main`.
+
+---
+
+## @automation approve — What it does
+
+When the human comments `@automation approve` on a story issue, a GitHub Actions workflow:
+
+1. Identifies the story's tag (`story-N.N-complete`) from the issue number.
+2. Finds the previous story tag to determine the commit range.
+3. Creates a staging branch: `staging/story-N.N`.
+4. Runs `git merge --squash` to collapse the full diff into a single staged change.
+5. Assembles a commit message from all commit messages in the range plus story issue metadata.
+6. Builds a PR description from the issue body (acceptance criteria) and commit log.
+7. Opens a PR: `staging/story-N.N` → `main` with `Closes #N` in the body.
+
+The automation has permission to push branches and open PRs. It does **not** have permission to merge.
 
 ---
 
 ## PR Review Communication
 
-The agent replies to inline PR review comments directly on GitHub using the `gh` API. Because the CLI authenticates as the repo owner, all agent replies are prefixed with **[Indy]** to distinguish them from human comments.
+The agent replies to inline PR review comments directly on GitHub using the `gh` API. All agent replies are prefixed with **[Agent]** to distinguish them from human comments.
 
-When asked to "check your open PRs for comments," the agent will:
+When asked to address PR review comments:
 
-1. `gh pr list --state open` to find all open PRs
+1. `gh pr list --state open` to find open PRs
 2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
-3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
-
-If inline reply posting fails due to permissions or readonly execution (for example, HTTP 403/resource not accessible):
-
-1. Continue implementing fixes on the branch.
-2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
-3. Flag the PR as needing a human to post the prepared replies.
+3. Address each comment, commit to `develop`, retag if needed, reply with `[Agent]` prefix
 
 ---
 
 _For label taxonomy, issue map, health checks, and command reference, see `agent-workflow-reference.md`._
 
-Last Updated: 2026-04-18
+Last Updated: 2026-05-13

--- a/docs/bmad/gdd.md
+++ b/docs/bmad/gdd.md
@@ -1287,7 +1287,7 @@ These are assessed through playtesting observation and player feedback — not t
 | Bevy engine + ecosystem crates | Game engine, ECS, rendering, audio | Bevy is pre-1.0; breaking changes between versions |
 | Rust compiler toolchain | Build system | Low risk — stable release channel |
 | GitHub | Source control, issue tracking, releases | Low risk |
-| Graphite | Stacked PR / branch management | Low risk — workflow tooling only |
+| GitHub Actions | CI, release automation, `@automation approve` squash-merge workflow | Low risk |
 
 No backend services required for single-player. Multiplayer networking stack (Ring 5, Epic 22) is a future technical decision with no current dependency.
 

--- a/docs/bmad/planning-artifacts/architecture/agent-context-routing.md
+++ b/docs/bmad/planning-artifacts/architecture/agent-context-routing.md
@@ -36,6 +36,7 @@ Load:
 - [System Scheduling & Ordering](./decisions/system-scheduling-ordering.md) — determinism enforcement, phase pipeline
 - [Material Seed Model](./cross-cutting/material-seed-model.md)
 - [Determinism Enforcement](./cross-cutting/determinism-enforcement.md)
+- [Material Identity & Knowledge Model ADR](./decisions/material-identity-and-knowledge-model.md) — type identity is query-time classification, not generation-time assignment; KnowledgeGraph as sole store
 
 ---
 
@@ -43,10 +44,11 @@ Load:
 
 Load:
 - [Authority Boundary Pattern](./decisions/authority-boundary-pattern.md) — diegetic outcome expression, journal event log, accretion test
-- [Data Architecture](./decisions/data-architecture.md) — knowledge graph, journal visualization layers
+- [Data Architecture](./decisions/data-architecture.md) — knowledge graph as sole store, journal as stateless query layer
 - [Asset Pipeline Conventions](./decisions/asset-pipeline-conventions.md) — if loading data files for UI
 - [Knowledge-Driven Presentation](./cross-cutting/knowledge-driven-presentation.md)
 - [Diegetic Feedback Contract](./cross-cutting/diegetic-feedback.md)
+- [Material Identity & Knowledge Model ADR](./decisions/material-identity-and-knowledge-model.md) — Journal does not store entries; queries KnowledgeGraph; inspect panel reads from KG node
 
 ---
 

--- a/docs/bmad/planning-artifacts/architecture/core-principles.md
+++ b/docs/bmad/planning-artifacts/architecture/core-principles.md
@@ -4,7 +4,7 @@ Rules that apply to every line of code, every system, every story. No exceptions
 
 1. **Knowledge is the only progression system.** There are no levels, no XP, no skill trees, no unlocks. The player progresses by understanding the world better. Every system serves this.
 2. **Accretion over reward.** Every player action must teach something new through consequence, never through confirmation.
-3. **Diegetic only.** The game never tells — it reveals through world behavior. No UI text explaining state. No popups. No progress bars.
+3. **Diegetic only.** The game never tells — it reveals through world behavior. No UI text explaining state. No popups. No progress bars. This applies to **reactive/feedback UI** — the game must never use text to explain why an action failed or what the player should do next. Physical in-world objects that display text as part of their nature (journal datapad, inscriptions, fabricator readouts) are *the diegetic mechanism*, not a violation of it.
 4. **Deterministic.** Same seed + same inputs = same outputs. Always. Seeded RNG only. Explicit system ordering. No float ambiguity.
 5. **Server-authoritative.** Intent is untrusted. Simulation decides. Even in single-player.
 6. **Data-driven.** All tuning lives in asset files. If a tuning value is hardcoded in Rust source, it's wrong. Only truly fixed values (mathematical constants, protocol versions) are `const`.

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/index.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/index.md
@@ -1,11 +1,11 @@
 # Cross-Cutting Concerns
 
 - [Mirror System](./mirror-system.md) — behavioral observation hooks across all gameplay systems
-- [Knowledge-Driven World Presentation](./knowledge-driven-presentation.md) — continuous knowledge spectrum affects rendering, interaction, NPC response
+- [Knowledge-Driven World Presentation](./knowledge-driven-presentation.md) — continuous knowledge spectrum affects rendering, interaction, NPC response; KnowledgeGraph as sole store, Journal as stateless query layer
 - [Server-Authoritative Boundary](./server-authoritative-boundary.md) — Intent/Simulation separation, per-system generation authority
 - [Determinism Enforcement](./determinism-enforcement.md) — seeded RNG, system ordering, float consistency
-- [Material Seed Model](./material-seed-model.md) — canonical seed-derived properties, cascading data model
+- [Material Seed Model](./material-seed-model.md) — seeds are generation inputs; type identity is query-time classification against asset ranges, never stored; see also [Material Identity ADR](../decisions/material-identity-and-knowledge-model.md)
 - [Telemetry](./telemetry.md) — centralized compile-time-toggled event channel
-- [Diegetic Feedback Contract](./diegetic-feedback.md) — no UI explanations, consequences only
+- [Diegetic Feedback Contract](./diegetic-feedback.md) — no UI explanations of failure or game state; physical in-world objects that display text (journal, datapads) are the diegetic mechanism, not a violation
 - [Asset Pipeline Architecture](./asset-pipeline.md) — hot-reload, versioned schemas, async loading
 - [Persistence / Save Architecture](./persistence.md) — deterministic serialization, version migration, knowledge preservation

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
@@ -1,3 +1,69 @@
 # Cross-Cutting Concern: Knowledge-Driven World Presentation
 
-Knowledge state is a continuous spectrum (not boolean gates) that affects three distinct system categories: *rendering* (entities appear differently based on what the player knows), *interaction availability* (options the player perceives depend on knowledge state), and *NPC dialogue/response* (conversations and reactions reflect what the player has demonstrated understanding of). Every system must handle the full gradient from "player knows nothing" to "player knows everything." Because many systems query knowledge state every frame, knowledge access is a **hot path** — requires fast-access data structures (dedicated `KnowledgeState` component with indexed lookups), not HashMap queries per entity per system per frame.
+## Core Principle
+
+Knowledge state is a continuous spectrum (not boolean gates) that affects three distinct system categories:
+- **Rendering** — entities appear differently based on what the player knows
+- **Interaction availability** — options the player perceives depend on knowledge state
+- **NPC dialogue/response** — conversations and reactions reflect what the player has demonstrated understanding of
+
+Every system must handle the full gradient from "player knows nothing" to "player knows everything."
+
+## Architecture: KnowledgeGraph as Source of Truth
+
+**The KnowledgeGraph is the sole store for player knowledge.** The Journal is a stateless query layer over it — it holds no knowledge state of its own.
+
+```
+KnowledgeGraph (store)
+    ↑ observation events from game systems
+    ↓ queried by
+Journal (query layer) → present to player
+Inspect panel (query layer) → present to player
+Fabrication system (query layer) → gate on knowledge
+```
+
+Any system that needs to know "what does the player know about X" must query the KnowledgeGraph, not read from entity components or Journal entries.
+
+## What the KnowledgeGraph Stores
+
+- **Nodes** — observed entities (specific material instances, locations, fabrication events)
+- **Edges** — observed relationships (found-at, similar-to, used-in, reacts-with)
+- **Revealed property flags** — which properties the player has observed on each node (density revealed on pickup, thermal resistance revealed by heat exposure, etc.)
+- **Sighting records** — where and when an entity was encountered (planet, tick)
+- **Confidence** — continuous f32 per observation, grows with repeated encounters
+
+## What Does NOT Belong on Entity Components
+
+`PropertyVisibility` and any other "what does the player know" state must not live on `GameMaterial` or any other entity component. Entity components hold **world facts** — the physical properties of objects in the world. Knowledge about those facts lives in the KnowledgeGraph.
+
+**Wrong:**
+```rust
+// Don't do this — knowledge state on a world entity
+mat.density.visibility = PropertyVisibility::Observable;
+```
+
+**Right:**
+```rust
+// Record an observation — KnowledgeGraph node gets the revealed flag
+observation_writer.write(RecordObservation {
+    key: material_node_key,
+    category: ObservationCategory::Density,
+    ...
+});
+```
+
+## Inspect Panel Pattern
+
+The inspect panel composes two layers from KnowledgeGraph queries:
+
+1. **Type-level knowledge** — all observations accumulated across every instance with matching property profile. "Iron is dense and non-reactive."
+2. **Instance-level sighting** — where this specific piece was found. "Found on planet Kessler."
+
+It does not read `PropertyVisibility` from the entity. It queries the KnowledgeGraph node for this entity's seed, finds which property observation edges exist, and renders accordingly.
+
+## Performance
+
+Knowledge access is a **hot path** — many systems query knowledge state every frame. Requirements:
+- O(1) node lookup via `HashMap<ConceptId, NodeIndex>` internal index
+- No per-entity HashMap query in systems that run every frame
+- Dedicated `KnowledgeState` component with indexed lookups for frequently-queried entities (future optimization when profiling warrants it)

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/material-seed-model.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/material-seed-model.md
@@ -1,3 +1,51 @@
 # Cross-Cutting Concern: Material Seed Model
 
-Canonical material properties are derived from world seed and propagate into crafting, construction, visual rendering, NPC economies, and alien cultures. This is the most load-bearing data model — changes here cascade everywhere.
+## Overview
+
+Material seeds are **inputs to procedural generation**, not type identifiers. A planet seed combined with a world position produces raw property values (density, reactivity, conductivity, thermal resistance, toxicity). Those property values are what get stored and reasoned about — not the seed itself.
+
+## Identity is Emergent, Not Assigned
+
+Material type names ("iron", "ferrite", "obsidian") are never assigned at generation time. They are the result of **query-time classification**: comparing a material's observed property values against asset-defined ranges.
+
+```
+planet_seed + position → raw property values (generation)
+raw property values → fall within range definition → "iron" (query-time, Journal only)
+```
+
+The KnowledgeGraph stores observed property values on instance nodes. The Journal queries those nodes against `assets/materials/classifications.toml` (or equivalent) to group them into named types at presentation time.
+
+**Consequence:** Two pieces of material from different planets with the same property profile are the same type. The player discovers this by accumulating observations until the Journal's range-match produces the same name — not because the game assigned them the same ID.
+
+## Instance Variation
+
+Property values generated from different planet seeds will naturally vary within ranges. A piece of iron from a high-gravity world may have density 0.91; iron from a low-gravity world may have density 0.74. Both fall within the iron classification range. The Journal can surface this variation ("heavier than the iron you found on Kessler") by comparing node values within the matched cluster — no separate instance modifier system is needed.
+
+## What Lives Where
+
+| Data | Lives In | Notes |
+|------|----------|-------|
+| Raw property values | `GameMaterial` entity component | Immutable after generation — these are world facts |
+| Which properties the player has observed | `KnowledgeGraph` node (revealed flags / observation edges) | Never on the entity component |
+| Planet of origin | `KnowledgeGraph` node (sighting record) | Not encoded in any key |
+| Type name ("iron") | Nowhere — computed at query time | Result of range-match against asset classification |
+| Classification ranges | `assets/` data files | Data-driven, never hardcoded in Rust |
+
+## Transient vs Knowledge State on Entities
+
+`GameMaterial` entity components hold **world facts** — the physical properties of this piece of matter. They do not hold player knowledge. `PropertyVisibility` on a `GameMaterial` component is a transient rendering hint at most — it must never be used as the source of truth for what the player knows. All knowledge state lives in the KnowledgeGraph.
+
+## Future: Classification Ranges in Assets
+
+Classification ranges are a Ring 2 deliverable. Until they exist, the Journal presents individual observed instances by their raw property values. The architecture is already correct — the Journal queries the KnowledgeGraph; it just won't have range definitions to group by yet. Adding range definitions slots in without changing the Journal or KnowledgeGraph.
+
+## Cascade Impact
+
+Changes to the material seed model cascade into:
+- Crafting and fabrication (material compatibility checks)
+- Construction (structural property lookups)  
+- Visual rendering (appearance driven by property values, not type assignment)
+- NPC economies (future — value derived from observed properties)
+- Save/load (KnowledgeGraph serialization, not entity component state)
+
+Any system that currently keys off `PropertyVisibility` on a `GameMaterial` entity component must be migrated to read from the KnowledgeGraph instead.

--- a/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
@@ -15,16 +15,18 @@
 - Registries are effectively write-rarely, read-constantly — `Res<T>` access only after initial insertion
 
 **Player Knowledge (Journal, Encyclopedia, Associative Web):**
-- `KnowledgeGraph` resource backed by `petgraph::Graph` (not `StableGraph`), behind a trait interface for swappability
-- Nodes = concepts (category, confidence as continuous f32 spectrum, set of revealed properties, discovery timestamp)
-- Edges = typed relationships (relationship type, confidence, discovery timestamp) — edges are first-class discoverable knowledge, not UI convenience
+- `KnowledgeGraph` resource backed by `petgraph::Graph` (not `StableGraph`), behind a trait interface for swappability — this is the **sole store** for all player knowledge; the Journal is a stateless query layer over it, not a parallel storage layer
+- Nodes = observed entities (specific material instances, locations, fabrication events) — the graph does not categorize; it stores observed facts about specific things
+- Edges = typed relationships (found-at, similar-to, used-in, reacts-with, co-located-with) — edges are first-class discoverable knowledge, not UI convenience
+- Revealed properties (e.g. density observed on pickup, thermal resistance revealed by heat exposure) are stored as flags/edges on the KnowledgeGraph node — never on the entity component; `PropertyVisibility` on a `GameMaterial` entity is transient world state only and must not be used as the source of truth for what the player knows
 - Append-only growth via event-driven `DiscoveryEvent` processing — updates are IMMEDIATE, no staging buffer or delayed flush
 - Internal indexes: `HashMap<ConceptId, NodeIndex>` for O(1) lookup, `HashMap<Category, Vec<NodeIndex>>` for encyclopedia view, timeline `Vec<(Timestamp, NodeIndex)>` for event log
 
-**Journal Visualization (Three Layers):**
-- **Structured encyclopedia** (primary view): category-scoped entry points (planets, species, flora, fauna, materials, techniques), entries fill in as knowledge accumulates
+**Journal Visualization (Query Layer — no storage):**
+- The Journal is a **stateless query layer** over the KnowledgeGraph — it holds no `JournalEntry` storage between frames beyond UI navigation position
+- **Structured encyclopedia** (primary view): Journal queries the KnowledgeGraph for nodes matching asset-defined classification ranges; a "material type" entry (e.g. "iron") is computed on the fly by finding all material nodes whose observed properties fall within iron's ranges — not retrieved from stored records
 - **Associative web** (differentiator): graph neighborhood visualization around selected node, bounded BFS traversal filtered by category scope, cross-category nodes visible at edges where connections exist, zoom controls density
-- **Event log** (secondary): chronological record of discoveries
+- **Event log** (secondary): chronological record of discoveries, derived from node/edge timestamps in the graph
 
 **New Dependency:**
 - `petgraph` with `serde-1` feature — added for Ring 1 (Epic 10 — Journal Architecture). Pure Rust, minimal transitive dependencies (`fixedbitset`, `indexmap`). Behind trait interface so `Graph` can be swapped to `StableGraph` if needed.
@@ -34,7 +36,10 @@
 - Tests assert semantic equality exactly — if semantic equality fails, the interface is broken.
 
 **Material Seed Canonicality:**
-- Material seed data is canonical; entities are instances. A material seed defines the durable truth of that material: its generated properties, learned observations, and any other canonical knowledge the player can carry across multiple samples. World entities are only physical instances of that seed. Entity components may store transient world state (transform, held/placed status, current heat exposure, temporary visual reaction state) but must not become the long-term source of truth for what a material *is* or what the player *knows* about it.
-- UI and journal systems read seed-level knowledge, not entity-local copies. Inspect panels, journals, fabrication history, and future save data must resolve material identity through the seed and shared knowledge model. If two entities share a seed, learning a property from one sample must make that knowledge available everywhere the same seed is referenced.
+- Material seeds are inputs to property generation — a planet seed + position produces raw property values. The seed is not a type identifier.
+- Material type identity is **emergent and query-time**: when the Journal (or any system) needs to classify a material as "iron", it compares observed property values against asset-defined classification ranges. The name "iron" is never stored on an entity or graph node — it is the result of a range match.
+- Entity components may store transient world state (transform, held/placed status, current heat exposure, temporary visual reaction state) but must not store player knowledge state (`PropertyVisibility` on a `GameMaterial` is transient world state; what the player *knows* about that material lives exclusively in the KnowledgeGraph).
+- If two entities share the same property profile, learning a property from one sample makes that knowledge available everywhere the same profile is encountered — because knowledge is keyed by the KnowledgeGraph node for that observed instance, and the Journal query groups nodes by range-match at query time.
+- Planet of origin is recorded as a sighting on the KnowledgeGraph node, not encoded into any key or identifier.
 
 **Rationale:** The hybrid model separates immutable ground-truth (seed-derived, write-once registries) from mutable player progression (append-only knowledge graph). Registry lookups are O(1) via entity ID components. The knowledge graph uses a real graph library rather than hand-rolling adjacency lists, getting BFS traversal, connected components, and serde serialization for free. Journal visualization queries map directly to bounded graph operations.

--- a/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
@@ -1,0 +1,146 @@
+# ADR: Material Identity, Knowledge Graph as Store, Journal as Query Layer
+
+- **Status:** Proposed — decision required before further Journal/inspection implementation
+- **Category:** Knowledge Model / Material System
+- **Affects:** `KnowledgeGraph`, `Journal`, `JournalKey`, `JournalEntry`, `GameMaterial`, inspect panel, save/load, material generation
+
+---
+
+## Context
+
+Story 10.6 surfaced a fundamental mismatch between the intended architecture and the current implementation. The data-architecture decision already establishes the correct principle:
+
+> "Material seed data is canonical; entities are instances. If two entities share a seed, learning a property from one sample must make that knowledge available everywhere the same seed is referenced."
+
+However, the implementation has drifted into a model where:
+
+- `Journal` holds `BTreeMap<JournalKey, JournalEntry>` — making it a storage layer
+- `KnowledgeGraph` is downstream of the Journal, reading from it rather than being the source of truth
+- `JournalKey::Material { seed, planet_seed }` encodes provenance into the key, splitting what should be unified knowledge into per-planet fragments
+- `PropertyVisibility` lives on `GameMaterial` entity components — "what the player knows" stored on a physical world object
+
+All of these contradict the intended design.
+
+---
+
+## Intended Architecture
+
+### KnowledgeGraph — the store
+
+The `KnowledgeGraph` is the source of truth for everything the player has observed. It stores **specific observed entities and the relationships between them** — not categories, not types, not classifications.
+
+```
+nodes = observed things (this piece of material, this location, this fabrication event)
+edges = observed relationships (found-at, similar-to, used-in, reacts-with, co-located-with)
+```
+
+The graph does not categorize. It does not know what "iron" is. It knows:
+- Entity A was observed at tick 1200 on planet Kessler
+- Entity A has observed density 0.82, observed reactivity unknown
+- Entity A is similar-to Entity B (edge, added when similarity threshold crossed)
+- Entity B was observed at tick 3400 on planet Vorn
+
+Graph traversal finds clusters, connections, and patterns. The graph never infers — every node and edge requires an observation event to exist.
+
+### Journal — the query layer
+
+The Journal is a **read-only presentation layer** that queries the KnowledgeGraph. It has no storage of its own. A `JournalEntry` is a computed view, not a stored record.
+
+When the player opens the journal and sees "Iron (4 sightings)", that entry was produced by:
+
+1. Querying the graph for all material nodes whose **observed properties fall within the classification ranges for iron** (loaded from assets)
+2. Aggregating those nodes — their sighting locations, observation counts, confidence levels
+3. Presenting the result as a single entry
+
+Classification ranges live in `assets/` (data-driven, Core Principle 6). The Journal holds no state between frames beyond UI navigation position.
+
+### Material Generation — properties first, identity emergent
+
+World generation uses planet seed + position to produce raw property values. Property values are what gets stored in the graph. Classification into named types ("iron", "ferrite") is a **query-time operation**, not a generation-time assignment.
+
+```
+planet_seed + position → raw property values → KnowledgeGraph node (on observation)
+                                                      ↓
+                               Journal query: which asset-defined ranges do these match?
+                                                      ↓
+                                         JournalEntry { "iron", 4 sightings }
+```
+
+The player discovers that two things are the same substance by accumulating enough observations that both fall within the same classification window. The name "iron" is not assigned at spawn — it resolves through play.
+
+### Instance vs Type
+
+There is no stored "type." There are only observed instances in the graph and asset-defined classification ranges that the Journal uses to group them at query time.
+
+Instance-level variation (this piece from a high-gravity world is denser than other iron) is naturally represented: the node's observed density value simply sits at a different point within the iron range. The Journal can present this as "heavier than the iron you found on Kessler" by comparing node values within the cluster — no separate instance modifier system needed.
+
+---
+
+## Current Implementation Bugs
+
+These directly contradict the decided architecture:
+
+1. **Journal is a storage layer** — `BTreeMap<JournalKey, JournalEntry>` accumulates records. Should be a stateless query over the KnowledgeGraph.
+
+2. **KnowledgeGraph is downstream of Journal** — it reads from Journal entries. Should be the other way: Journal queries the graph.
+
+3. **`planet_seed` in `JournalKey`** — provenance encoded into the key fragments cross-planet knowledge. Provenance belongs on graph nodes, not on journal keys.
+
+4. **`PropertyVisibility` on entity components** — player knowledge stored on a physical world object. Should be derived from what observation edges exist in the graph for that entity's node.
+
+5. **Observations fire on raycast target change only** — picking up a material, examining it in hand, carrying it — none of these record observations. Observation should fire on meaningful player interaction (pickup, examine, fabrication use).
+
+---
+
+## Scope
+
+### This is a significant refactor
+
+The correct architecture requires inverting the Journal/KnowledgeGraph relationship. This is not a small fix — it touches the core data flow of the knowledge system.
+
+### What belongs in Story 10.6 (current scope)
+
+10.6 was scoped around making the inspect panel update correctly from player interaction. The bugs above make that impossible to fix correctly without addressing the underlying model. However, a full Journal/KnowledgeGraph inversion is more than one story.
+
+**Recommended 10.6 scope:**
+- Remove `planet_seed` from `JournalKey::Material` — planet recorded as a field on `JournalEntry`, not part of the key. Unblocks cross-planet knowledge accumulation immediately.
+- Move `PropertyVisibility` out of entity components — revealed properties tracked in the Journal entry (acceptable interim step; full graph-query model is a follow-on story).
+- Fix observation trigger — fire on pickup, not on raycast target change.
+- Inspect panel reads from Journal entry by seed, not from entity component.
+
+**Follow-on story (new issue):**
+- Invert Journal/KnowledgeGraph relationship — Journal becomes a stateless query layer over the graph.
+- Asset-defined classification ranges — Journal groups material nodes by range match rather than by stored key.
+- Remove `BTreeMap<JournalKey, JournalEntry>` storage from Journal entirely.
+
+---
+
+## Decision
+
+1. **Adopt the graph-as-store, journal-as-query model** as the target architecture. This ADR supersedes any prior framing of the Journal as a storage layer.
+
+2. **`JournalKey` gains two material variants** to cleanly separate instance-level and type-level knowledge:
+   - `JournalKey::MaterialInstance { seed: u64 }` — identifies a specific observed material entity by its generation seed. Used by the inspect panel and instance-level journal entries.
+   - `JournalKey::Material { classification: String }` — identifies a material type by its classification name (e.g. "iron"). Used by the journal encyclopedia view. This key is a follow-on epic deliverable — classification ranges must exist before it can be populated.
+   - The existing `JournalKey::Material { seed, planet_seed }` is removed. `planet_seed` moves off the key onto `RecordObservation` as context for the `FoundOn` KnowledgeGraph edge.
+
+3. **Story 10.6** implements the pragmatic fixes that unblock correct inspect panel behavior:
+   - Rename `JournalKey::Material` → `JournalKey::MaterialInstance { seed: u64 }`, removing `planet_seed` from the key
+   - `planet_seed` moves to `RecordObservation` as a context field for the `FoundOn` KG edge
+   - `PropertyVisibility` removed from entity components; revealed properties tracked on KG node
+   - Observation fires on pickup, not raycast target change
+   - Inspect panel reads from KG node by seed
+   - Journal displays what is known about this specific material instance
+   - `JournalKey::Material { classification }` is **not** introduced in 10.6 — it is a follow-on epic deliverable
+
+4. **New epic (Knowledge Model Inversion)** delivers the full architecture:
+   - Story N.1: KnowledgeGraph as sole observation store
+   - Story N.2: Journal as stateless query layer (introduces `JournalKey::Material { classification }`)
+   - Story N.3: Asset-defined classification ranges in `assets/`
+   - Story N.4: Material generation produces raw property values only — no type assignment at spawn
+
+5. **Classification** is always query-time, never generation-time. Material type names are never stored on entities or in the graph — they are the result of matching observed property values against asset-defined ranges.
+
+---
+
+*Drafted: 2026-05-13. Decision confirmed 2026-05-13. Requires no further sign-off — proceed to implementation.*

--- a/docs/bmad/planning-artifacts/architecture/project-context-analysis.md
+++ b/docs/bmad/planning-artifacts/architecture/project-context-analysis.md
@@ -52,7 +52,7 @@ The GDD defines a procedurally generated open universe sandbox where knowledge i
 - 3 epics complete (A Room to Stand In, Things to Touch, Try and Learn) establishing baseline patterns
 - 46 coding rules already codified in `project-context.md` for AI agent consistency
 - n8n automation for GitHub issue lifecycle (labels as state machine)
-- Graphite for stacked PR/branch management
+- `develop` branch with story tags for playtest checkpoints; `@automation approve` triggers squash PR to `main`
 
 **Hard Constraints from project-context.md:**
 - No `unsafe` code

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -28,7 +28,6 @@ use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObserva
 use crate::materials::{GameMaterial, MaterialObject};
 use crate::observation::Confidence;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
-use crate::world_generation::WorldProfile;
 use leafwing_input_manager::prelude::*;
 
 const CONFIG_PATH: &str = "assets/config/carry.toml";
@@ -1372,16 +1371,14 @@ pub fn stash_entity_into_carry(
 /// `planet_seed` is the player's current planet seed (taken from
 /// `WorldProfile::planet_seed.0` at the call site), or `None` when no
 /// `WorldProfile` is in scope.  It is stamped onto the resulting
-/// [`JournalKey::Material`] so the journal's "current planet" filter
-/// (Story 10.3) can match this entry against the player's current
-/// planet without re-deriving provenance from observation history.
+/// Planet of origin is read directly from [`GameMaterial::origin_planet_seed`] —
+/// callers no longer need to extract it from `WorldProfile`.
 pub fn record_weight_observation(
     material: &GameMaterial,
     carry_strength: f32,
     config: &CarryConfig,
     journal_writer: &mut MessageWriter<RecordObservation>,
     descriptor_vocab: &crate::observation::DescriptorVocabulary,
-    planet_seed: Option<u64>,
 ) {
     // Use initial confidence for new observations - the journal system
     // will handle accumulation automatically for repeated observations
@@ -1406,11 +1403,11 @@ pub fn record_weight_observation(
         });
 
     journal_writer.write(RecordObservation {
-        key: JournalKey::Material {
+        key: JournalKey::MaterialInstance {
             seed: material.seed,
-            planet_seed,
         },
         name: material.name.clone(),
+        planet_seed: material.origin_planet_seed,
         observation: Observation {
             category: ObservationCategory::Weight,
             confidence: initial_confidence,
@@ -1469,9 +1466,7 @@ fn process_stash_intent(
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for _intent in reader.read() {
         let Some((held_entity, held_material)) = held_query.iter().next() else {
             reject_writer.write(CarryActionRejected {
@@ -1500,7 +1495,6 @@ fn process_stash_intent(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1519,9 +1513,7 @@ fn process_stash_held_for_pickup(
     config: Res<CarryConfig>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for request in reader.read() {
         let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
             continue;
@@ -1539,7 +1531,6 @@ fn process_stash_held_for_pickup(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         // Also record weight for the newly picked material.
         record_weight_observation(
@@ -1548,7 +1539,6 @@ fn process_stash_held_for_pickup(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1561,9 +1551,7 @@ fn process_observe_weight(
     config: Res<CarryConfig>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     player_query: Query<&CarryStrength, With<Player>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for request in reader.read() {
         let Ok(carry_strength) = player_query.single() else {
             continue;
@@ -1574,7 +1562,6 @@ fn process_observe_weight(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
     }
 }
@@ -1595,9 +1582,7 @@ fn process_cycle_carry_intent(
     camera_query: Query<Entity, With<PlayerCamera>>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     carried_material_query: Query<&GameMaterial, With<InCarry>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for _intent in reader.read() {
         let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
             continue;
@@ -1645,7 +1630,6 @@ fn process_cycle_carry_intent(
                 &config,
                 &mut journal_writer,
                 &descriptor_vocab,
-                planet_seed,
             );
         }
 
@@ -1665,7 +1649,6 @@ fn process_cycle_carry_intent(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1703,6 +1686,7 @@ mod tests {
             name: "Testite".into(),
             seed: 7,
             color: [0.1, 0.2, 0.3],
+            origin_planet_seed: None,
             density: property(value),
             thermal_resistance: property(0.5),
             reactivity: property(0.5),
@@ -2256,30 +2240,31 @@ exponent = 1.0
         // `record_weight_observation` takes a real `MessageWriter`, which
         // can only be obtained from a `World`.
         fn drive(
-            inputs: bevy::ecs::system::In<(GameMaterial, Option<u64>)>,
+            inputs: bevy::ecs::system::In<GameMaterial>,
             mut writer: MessageWriter<RecordObservation>,
             descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
         ) {
-            let (mat, seed) = inputs.0;
+            let mat = inputs.0;
             let cfg = CarryConfig::default();
-            record_weight_observation(&mat, 1.0, &cfg, &mut writer, &descriptor_vocab, seed);
+            record_weight_observation(&mat, 1.0, &cfg, &mut writer, &descriptor_vocab);
         }
 
-        let material = material_with_density(0.8);
-
-        for (label, supplied, expected) in [
+        for (label, origin_planet_seed, expected) in [
             (
-                "with current planet",
+                "with planet origin",
                 Some(0xDEAD_BEEFu64),
                 Some(0xDEAD_BEEFu64),
             ),
-            ("without WorldProfile", None, None),
+            ("without planet origin", None, None),
         ] {
+            let mut material = material_with_density(0.8);
+            material.origin_planet_seed = origin_planet_seed;
+
             let mut app = App::new();
             app.add_message::<RecordObservation>();
             app.insert_resource(crate::observation::DescriptorVocabulary::default());
             app.world_mut()
-                .run_system_cached_with(drive, (material.clone(), supplied))
+                .run_system_cached_with(drive, material.clone())
                 .expect("one-shot system should run");
 
             let mut messages = app
@@ -2288,14 +2273,14 @@ exponent = 1.0
             let recorded: Vec<RecordObservation> = messages.drain().collect();
             assert_eq!(recorded.len(), 1, "{label}: expected one observation");
             match &recorded[0].key {
-                JournalKey::Material { seed, planet_seed } => {
+                JournalKey::MaterialInstance { seed } => {
                     assert_eq!(*seed, material.seed, "{label}: material seed must match");
                     assert_eq!(
-                        *planet_seed, expected,
-                        "{label}: recorded planet_seed must equal the supplied value (no sentinel substitution)"
+                        recorded[0].planet_seed, expected,
+                        "{label}: planet_seed must come from material.origin_planet_seed"
                     );
                 }
-                other => panic!("{label}: expected JournalKey::Material, got {other:?}"),
+                other => panic!("{label}: expected JournalKey::MaterialInstance, got {other:?}"),
             }
         }
     }

--- a/src/diegetic_ui.rs
+++ b/src/diegetic_ui.rs
@@ -1,0 +1,584 @@
+//! Diegetic UI Framework — in-world information surfaces.
+//!
+//! # What "diegetic" means in Apeiron Cipher
+//!
+//! Every piece of information the player can read must exist as a physical
+//! object in the game world.  No HUD overlays, no floating labels, no
+//! tooltip popups.  A journal is a datapad you hold up and look at.  A
+//! fabricator status is a gauge on the workbench.  A glowing mineral is its
+//! own advertisement.  The player's knowledge comes from *observing the world*,
+//! not from reading system messages.
+//!
+//! # How to add a new diegetic surface
+//!
+//! 1. Spawn an entity with the [`DiegeticSurface`] marker component.
+//! 2. Add a [`DiegeticSurfaceKind`] component to declare how far away the
+//!    surface can be perceived and interacted with.
+//! 3. Add a [`DiegeticFocusState`] component (default is [`DiegeticFocusState::OutOfRange`]).
+//! 4. For text-displaying surfaces, also add a [`ReadableSurfaceContent`]
+//!    component.  Systems that own the information write their content there;
+//!    the rendering system reads it.
+//! 5. Register your rendering logic in whatever system drives your surface's
+//!    visuals.  Query for `(&DiegeticFocusState, &ReadableSurfaceContent)` —
+//!    only render when the state is [`DiegeticFocusState::Focused`] or
+//!    [`DiegeticFocusState::Active`].
+//!
+//! # Surface kind selection guide
+//!
+//! | What you're building | Use |
+//! |---|---|
+//! | Text you read (journal, datapad, inscriptions) | `DiegeticSurfaceKind::Readable` |
+//! | Live readouts via gauges/lights (fabricator, navigation console) | `DiegeticSurfaceKind::Instrument` |
+//! | A world object whose appearance *is* the message (glowing mineral, stress cracks) | `DiegeticSurfaceKind::PhysicalIndicator` |
+//!
+//! # System ordering
+//!
+//! [`DiegeticUiPlugin`] schedules [`update_diegetic_focus`] in
+//! [`DiegeticUiSet::FocusUpdate`], which runs in `Update` before any
+//! rendering.  Downstream rendering systems should run after this set to see
+//! up-to-date focus states.
+
+use bevy::prelude::*;
+
+use crate::player::Player;
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+/// Registers the diegetic UI framework systems onto the [`App`].
+///
+/// Adds [`DiegeticUiSet::FocusUpdate`] to `Update`.  All diegetic surface
+/// rendering systems should run *after* this set.
+pub struct DiegeticUiPlugin;
+
+impl Plugin for DiegeticUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.configure_sets(
+            Update,
+            (DiegeticUiSet::FocusUpdate, DiegeticUiSet::VisibilitySync).chain(),
+        )
+        .add_systems(
+            Update,
+            update_diegetic_focus.in_set(DiegeticUiSet::FocusUpdate),
+        )
+        .add_systems(
+            Update,
+            sync_readable_surface_visibility.in_set(DiegeticUiSet::VisibilitySync),
+        );
+    }
+}
+
+// ── System sets ─────────────────────────────────────────────────────────────
+
+/// System sets for the diegetic UI framework.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DiegeticUiSet {
+    /// Proximity-based [`DiegeticFocusState`] updates.
+    ///
+    /// Runs every `Update` frame.  All downstream rendering systems that
+    /// care about focus state must run *after* this set.
+    FocusUpdate,
+    /// Visibility gating: sets [`Visibility`] on diegetic surface entities
+    /// based on [`DiegeticFocusState`].
+    ///
+    /// Runs after [`FocusUpdate`](DiegeticUiSet::FocusUpdate) so that focus
+    /// transitions and visibility are always in sync within the same frame.
+    VisibilitySync,
+}
+
+// ── Components ───────────────────────────────────────────────────────────────
+
+/// Marker component — every in-world information surface must carry this.
+///
+/// CI compliance tests query for `Text` nodes that are *not* descended from
+/// a [`DiegeticSurface`] entity.  Any screen-space text without this marker
+/// is an architectural violation.
+///
+/// See the module-level documentation for a step-by-step guide on adding
+/// new diegetic surfaces.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct DiegeticSurface;
+
+/// Determines how a diegetic surface is perceived and interacted with.
+///
+/// This drives the [`update_diegetic_focus`] system's proximity thresholds
+/// and is the primary selector for how your rendering code should behave.
+///
+/// Choose based on the interaction model, not the visual style:
+/// - **Readable** — the player approaches and reads static or paged text.
+/// - **Instrument** — real-time readouts through visual indicators (no text).
+/// - **PhysicalIndicator** — the object *is* the message; no proximity logic.
+#[derive(Component, Clone, Debug)]
+pub enum DiegeticSurfaceKind {
+    /// A surface the player reads (journal datapad, inscriptions, signage).
+    ///
+    /// Text rendering happens on a world-space quad; the player physically
+    /// moves close enough for the text to resolve.
+    Readable {
+        /// Distance at which the surface starts to be perceivable (fade-in
+        /// begins, text is blurry/dim).
+        perceivable_range: f32,
+        /// Distance at which text becomes fully legible (focus completes).
+        ///
+        /// Must be ≤ `perceivable_range`.
+        legible_range: f32,
+    },
+    /// An instrument with dynamic readouts (fabricator display, navigation console).
+    ///
+    /// State is communicated through visual indicators (lights, gauges), not
+    /// text.  The single `interaction_range` determines both when the surface
+    /// becomes perceivable (2×) and fully interactable (1×).
+    Instrument {
+        /// Distance at which the player can fully interact with the instrument.
+        ///
+        /// The perceivable threshold is `interaction_range * 2.0`.
+        interaction_range: f32,
+    },
+    /// A physical indicator — glow, heat shimmer, stress cracks, etc.
+    ///
+    /// No proximity logic is applied; the object communicates state purely
+    /// through its appearance.  [`update_diegetic_focus`] skips these
+    /// entities entirely.
+    PhysicalIndicator,
+}
+
+/// Current focus relationship between a diegetic surface and the player.
+///
+/// Transitions are driven by [`update_diegetic_focus`] based on player
+/// proximity.  The [`Active`](DiegeticFocusState::Active) state is managed
+/// exclusively by interaction systems — proximity updates never clear it.
+///
+/// Rendering systems should gate their work on this component:
+/// - [`OutOfRange`](DiegeticFocusState::OutOfRange) → nothing visible.
+/// - [`Perceivable`](DiegeticFocusState::Perceivable) → dim/blurry preview.
+/// - [`Focused`](DiegeticFocusState::Focused) → fully legible, awaiting activation.
+/// - [`Active`](DiegeticFocusState::Active) → player is actively using the surface.
+#[derive(Component, Clone, Debug, Default, PartialEq)]
+pub enum DiegeticFocusState {
+    /// Player is beyond perceivable range — surface produces no output.
+    #[default]
+    OutOfRange,
+    /// Player is within perceivable range but not yet within legible/interaction
+    /// range.  `proximity` is `1.0` at the legible boundary and `0.0` at the
+    /// perceivable boundary — use it to scale alpha, blur, or LOD.
+    Perceivable {
+        /// `0.0` = just entered perceivable range.  `1.0` = at legible boundary.
+        proximity: f32,
+    },
+    /// Player is within legible/interaction range.  The surface is fully
+    /// readable but the player has not yet activated it.
+    Focused,
+    /// Player is actively interacting (reading, operating an instrument).
+    ///
+    /// Set and cleared by interaction systems, *not* by proximity logic.
+    /// A surface stays `Active` even if the player steps away, until the
+    /// interaction system explicitly transitions it back.
+    Active,
+}
+
+/// Text content for a [`DiegeticSurfaceKind::Readable`] surface.
+///
+/// Owning systems (e.g. the journal plugin) write to this component every
+/// frame when the surface is [`Active`](DiegeticFocusState::Active).  The
+/// rendering system reads it — the two systems are decoupled through this
+/// component, which keeps each within the four-parameter limit.
+///
+/// Content lines should use qualitative language only — no raw numbers, no
+/// system identifiers.  The game never shows internal state.
+#[derive(Component, Clone, Debug, Default)]
+pub struct ReadableSurfaceContent {
+    /// Lines of text to display, already formatted for the player.
+    ///
+    /// Each element is one visible line.  The rendering system displays
+    /// `visible_lines` of them starting at `scroll_offset`.
+    pub lines: Vec<String>,
+    /// Index of the first visible line (for multi-page content).
+    pub scroll_offset: usize,
+    /// How many lines the surface's physical display area can show at once.
+    ///
+    /// Set once at spawn based on the surface's physical dimensions.
+    /// The rendering system clamps `scroll_offset` to keep the view valid.
+    pub visible_lines: usize,
+}
+
+// ── Systems ───────────────────────────────────────────────────────────────────
+
+/// Updates [`DiegeticFocusState`] on every diegetic surface based on how far
+/// the player is from it.
+///
+/// # Rules
+///
+/// - [`DiegeticSurfaceKind::PhysicalIndicator`] surfaces are skipped — they
+///   are always visible through their world appearance alone.
+/// - [`DiegeticFocusState::Active`] surfaces are never overridden here — that
+///   state is managed exclusively by interaction systems.
+/// - For all other surfaces the transition ladder is:
+///   `OutOfRange → Perceivable { proximity } → Focused`
+///
+/// Runs in [`DiegeticUiSet::FocusUpdate`].
+pub(crate) fn update_diegetic_focus(
+    player_query: Query<&Transform, With<Player>>,
+    mut surfaces: Query<
+        (&Transform, &DiegeticSurfaceKind, &mut DiegeticFocusState),
+        With<DiegeticSurface>,
+    >,
+) {
+    let Ok(player_transform) = player_query.single() else {
+        return;
+    };
+    let player_pos = player_transform.translation;
+
+    for (surface_transform, kind, mut focus_state) in surfaces.iter_mut() {
+        // Active state is owned by interaction systems — never clobber it.
+        if matches!(*focus_state, DiegeticFocusState::Active) {
+            continue;
+        }
+
+        // Physical indicators have no proximity logic — their appearance is
+        // always present in the world.
+        let (perceivable_range, legible_range) = match kind {
+            DiegeticSurfaceKind::Readable {
+                perceivable_range,
+                legible_range,
+            } => (*perceivable_range, *legible_range),
+            DiegeticSurfaceKind::Instrument { interaction_range } => {
+                (interaction_range * 2.0, *interaction_range)
+            }
+            DiegeticSurfaceKind::PhysicalIndicator => continue,
+        };
+
+        let distance = player_pos.distance(surface_transform.translation);
+
+        *focus_state = if distance <= legible_range {
+            DiegeticFocusState::Focused
+        } else if distance <= perceivable_range {
+            // Interpolate: 0.0 at outer perceivable edge, 1.0 at legible edge.
+            let span = perceivable_range - legible_range;
+            let proximity = if span > f32::EPSILON {
+                1.0 - (distance - legible_range) / span
+            } else {
+                // Degenerate: perceivable == legible, jump straight to focused.
+                1.0
+            };
+            DiegeticFocusState::Perceivable { proximity }
+        } else {
+            DiegeticFocusState::OutOfRange
+        };
+    }
+}
+
+/// Gates [`Visibility`] on every [`DiegeticSurface`] entity based on its
+/// current [`DiegeticFocusState`].
+///
+/// | State | Visibility |
+/// |---|---|
+/// | [`OutOfRange`](DiegeticFocusState::OutOfRange) | `Hidden` |
+/// | [`Perceivable`](DiegeticFocusState::Perceivable) | `Visible` (renderer dims via alpha) |
+/// | [`Focused`](DiegeticFocusState::Focused) | `Visible` |
+/// | [`Active`](DiegeticFocusState::Active) | `Visible` |
+///
+/// Downstream renderers are responsible for reading `proximity` from
+/// [`Perceivable`](DiegeticFocusState::Perceivable) and adjusting alpha /
+/// LOD accordingly — this system only manages show/hide.
+///
+/// Runs in [`DiegeticUiSet::VisibilitySync`], after [`DiegeticUiSet::FocusUpdate`].
+pub(crate) fn sync_readable_surface_visibility(
+    mut surfaces: Query<(&DiegeticFocusState, &mut Visibility), With<DiegeticSurface>>,
+) {
+    for (focus_state, mut visibility) in surfaces.iter_mut() {
+        *visibility = match focus_state {
+            DiegeticFocusState::OutOfRange => Visibility::Hidden,
+            _ => Visibility::Visible,
+        };
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::app::App;
+
+    // ── Phase 1 tests ────────────────────────────────────────────────────────
+
+    /// Default focus state is OutOfRange.
+    #[test]
+    fn default_focus_state_is_out_of_range() {
+        let state = DiegeticFocusState::default();
+        assert_eq!(state, DiegeticFocusState::OutOfRange);
+    }
+
+    /// Readable variant is constructible with expected parameters.
+    #[test]
+    fn readable_kind_constructible() {
+        let kind = DiegeticSurfaceKind::Readable {
+            perceivable_range: 5.0,
+            legible_range: 2.0,
+        };
+        match kind {
+            DiegeticSurfaceKind::Readable {
+                perceivable_range,
+                legible_range,
+            } => {
+                assert_eq!(perceivable_range, 5.0);
+                assert_eq!(legible_range, 2.0);
+            }
+            _ => panic!("expected Readable variant"),
+        }
+    }
+
+    /// Instrument variant is constructible with expected parameters.
+    #[test]
+    fn instrument_kind_constructible() {
+        let kind = DiegeticSurfaceKind::Instrument {
+            interaction_range: 3.0,
+        };
+        match kind {
+            DiegeticSurfaceKind::Instrument { interaction_range } => {
+                assert_eq!(interaction_range, 3.0);
+            }
+            _ => panic!("expected Instrument variant"),
+        }
+    }
+
+    /// PhysicalIndicator variant is constructible.
+    #[test]
+    fn physical_indicator_kind_constructible() {
+        let kind = DiegeticSurfaceKind::PhysicalIndicator;
+        assert!(matches!(kind, DiegeticSurfaceKind::PhysicalIndicator));
+    }
+
+    // ── Phase 2 tests ────────────────────────────────────────────────────────
+
+    /// Builds a minimal App with just enough to run `update_diegetic_focus`.
+    fn focus_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(bevy::app::Update, update_diegetic_focus);
+        app
+    }
+
+    fn spawn_player_at(app: &mut App, pos: Vec3) -> Entity {
+        app.world_mut()
+            .spawn((Player, Transform::from_translation(pos)))
+            .id()
+    }
+
+    fn spawn_surface_at(
+        app: &mut App,
+        pos: Vec3,
+        kind: DiegeticSurfaceKind,
+        initial_state: DiegeticFocusState,
+    ) -> Entity {
+        app.world_mut()
+            .spawn((
+                DiegeticSurface,
+                kind,
+                initial_state,
+                Transform::from_translation(pos),
+            ))
+            .id()
+    }
+
+    fn focus_state(app: &App, entity: Entity) -> DiegeticFocusState {
+        app.world()
+            .entity(entity)
+            .get::<DiegeticFocusState>()
+            .unwrap()
+            .clone()
+    }
+
+    /// Player beyond perceivable_range → OutOfRange.
+    #[test]
+    fn player_beyond_perceivable_range_is_out_of_range() {
+        let mut app = focus_test_app();
+        // Player at origin, surface 10 units away; perceivable_range = 5.
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(10.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::OutOfRange);
+    }
+
+    /// Player between perceivable and legible range → Perceivable with proximity in [0,1).
+    #[test]
+    fn player_in_perceivable_band_gives_proximity() {
+        let mut app = focus_test_app();
+        // perceivable = 6.0, legible = 2.0 → band is [2, 6]
+        // Player at distance 4.0 → midpoint → proximity = 1 - (4-2)/(6-2) = 0.5
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(4.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        match focus_state(&app, surface) {
+            DiegeticFocusState::Perceivable { proximity } => {
+                assert!(
+                    (proximity - 0.5).abs() < 1e-5,
+                    "expected proximity ~0.5, got {proximity}"
+                );
+            }
+            other => panic!("expected Perceivable, got {other:?}"),
+        }
+    }
+
+    /// Player within legible_range → Focused.
+    #[test]
+    fn player_within_legible_range_is_focused() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(1.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::Focused);
+    }
+
+    /// Active state is preserved even when player moves away.
+    #[test]
+    fn active_state_preserved_when_player_moves_away() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(100.0, 0.0, 0.0), // far away
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::Active, // already active
+        );
+        app.update();
+        // Must remain Active despite distance.
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::Active);
+    }
+
+    /// Proximity interpolates correctly: 0.0 at outer edge, 1.0 at legible edge.
+    #[test]
+    fn proximity_interpolates_between_zero_and_one() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+
+        // At the perceivable boundary (distance == perceivable_range) → proximity ≈ 0.0
+        let outer = spawn_surface_at(
+            &mut app,
+            Vec3::new(6.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        // At the legible boundary (distance == legible_range) → Focused (not Perceivable)
+        let inner = spawn_surface_at(
+            &mut app,
+            Vec3::new(2.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+
+        match focus_state(&app, outer) {
+            DiegeticFocusState::Perceivable { proximity } => {
+                assert!(
+                    proximity < 0.01,
+                    "expected proximity ≈ 0.0 at outer edge, got {proximity}"
+                );
+            }
+            other => panic!("expected Perceivable at outer edge, got {other:?}"),
+        }
+        // At exactly legible_range, the system transitions to Focused.
+        assert_eq!(focus_state(&app, inner), DiegeticFocusState::Focused);
+    }
+
+    // ── Phase 3 tests ────────────────────────────────────────────────────────
+
+    fn visibility_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(
+            bevy::app::Update,
+            (update_diegetic_focus, sync_readable_surface_visibility).chain(),
+        );
+        app
+    }
+
+    fn spawn_surface_with_visibility(
+        app: &mut App,
+        pos: Vec3,
+        kind: DiegeticSurfaceKind,
+        initial_state: DiegeticFocusState,
+    ) -> Entity {
+        app.world_mut()
+            .spawn((
+                DiegeticSurface,
+                kind,
+                initial_state,
+                Transform::from_translation(pos),
+                Visibility::Hidden,
+            ))
+            .id()
+    }
+
+    fn vis(app: &App, entity: Entity) -> Visibility {
+        *app.world().entity(entity).get::<Visibility>().unwrap()
+    }
+
+    /// OutOfRange surface stays Hidden after sync.
+    #[test]
+    fn out_of_range_surface_is_hidden() {
+        let mut app = visibility_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_with_visibility(
+            &mut app,
+            Vec3::new(100.0, 0.0, 0.0), // far beyond range
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(vis(&app, surface), Visibility::Hidden);
+    }
+
+    /// Focused surface becomes Visible after sync.
+    #[test]
+    fn focused_surface_is_visible() {
+        let mut app = visibility_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_with_visibility(
+            &mut app,
+            Vec3::new(1.0, 0.0, 0.0), // within legible_range
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(vis(&app, surface), Visibility::Visible);
+    }
+}

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -293,8 +293,9 @@ fn tick_processing(
             description,
             recorded_at: 0,
         },
-        // Populate input seeds so the knowledge graph can create DerivedFrom
-        // edges from the output material back to each input material.
+        // Pass input material seeds so the knowledge graph can wire DerivedFrom
+        // edges from the output concept to each input material (Story 10.5).
+        planet_seed: None,
         input_seeds: input_mats.iter().map(|m| m.seed).collect(),
         context_location: None,
     });
@@ -438,6 +439,9 @@ fn rule_combine(rules: &CombinationRules, a: &GameMaterial, b: &GameMaterial) ->
         name,
         seed: combined_seed,
         color,
+        // Fabricated materials have no planet origin — they are produced at
+        // the fabricator, not found in the world.
+        origin_planet_seed: None,
         density: {
             let base_density = apply_rule_with_perturbation(
                 &pair_rules.density,
@@ -489,6 +493,7 @@ mod tests {
             name: name.into(),
             seed,
             color: [0.5, 0.5, 0.5],
+            origin_planet_seed: None,
             density: MaterialProperty::new(density, PropertyVisibility::Observable),
             thermal_resistance: prop(0.4),
             reactivity: prop(0.6),

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -21,7 +21,6 @@ use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObserva
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::Confidence;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
-use crate::world_generation::WorldProfile;
 
 /// Plugin that manages heat sources and temperature-based material interactions.
 pub struct HeatPlugin;
@@ -278,11 +277,9 @@ fn reveal_thermal_property(
         ),
         With<MaterialObject>,
     >,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
     let reveal_secs = hs_cfg.reveal_seconds;
     let mut revealed_seeds = Vec::new();
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
 
     for (entity, exp, mut mat, recorded) in &mut material_query {
         if exp.elapsed < reveal_secs {
@@ -313,20 +310,9 @@ fn reveal_thermal_property(
             let initial_confidence = Confidence(0.2);
 
             journal_writer.write(RecordObservation {
-                key: JournalKey::Material {
-                    seed: mat.seed,
-                    // Capture the planet on which this thermal observation
-                    // is being recorded so the journal's "current planet"
-                    // filter (Story 10.3) can match this entry against the
-                    // player's current `WorldProfile::planet_seed`.  When
-                    // no `WorldProfile` is in scope (early bring-up or
-                    // ad-hoc integration tests) the field stays `None` —
-                    // see `JournalKey::Material::planet_seed`'s docs for
-                    // why "unknown provenance" is kept explicit instead
-                    // of defaulting to a sentinel.
-                    planet_seed,
-                },
+                key: JournalKey::MaterialInstance { seed: mat.seed },
                 name: mat.name.clone(),
+                planet_seed: mat.origin_planet_seed,
                 observation: Observation {
                     category: ObservationCategory::ThermalBehavior,
                     confidence: initial_confidence,
@@ -382,6 +368,7 @@ mod tests {
             name: format!("TestMat-{seed}"),
             seed,
             color: [0.5, 0.5, 0.5],
+            origin_planet_seed: None,
             density: MaterialProperty::new(0.5, PropertyVisibility::Observable),
             thermal_resistance: MaterialProperty::new(0.65, PropertyVisibility::Hidden),
             reactivity: MaterialProperty::new(0.35, PropertyVisibility::Hidden),
@@ -624,7 +611,11 @@ mod tests {
 
         app.world_mut().spawn((
             MaterialObject,
-            test_material(7),
+            {
+                let mut mat = test_material(7);
+                mat.origin_planet_seed = Some(expected_seed);
+                mat
+            },
             HeatExposure {
                 elapsed: 5.0,
                 in_zone: true,
@@ -643,15 +634,15 @@ mod tests {
             "exactly one thermal observation should be recorded for one revealed entity"
         );
         match &recorded[0].key {
-            JournalKey::Material { seed, planet_seed } => {
+            JournalKey::MaterialInstance { seed } => {
                 assert_eq!(*seed, 7, "material seed should match the test material");
                 assert_eq!(
-                    *planet_seed,
+                    recorded[0].planet_seed,
                     Some(expected_seed),
                     "observation must capture the WorldProfile's planet seed so the journal's current-planet filter can match it"
                 );
             }
-            other => panic!("expected JournalKey::Material, got {other:?}"),
+            other => panic!("expected JournalKey::MaterialInstance, got {other:?}"),
         }
     }
 
@@ -690,14 +681,14 @@ mod tests {
         let recorded: Vec<RecordObservation> = messages.drain().collect();
         assert_eq!(recorded.len(), 1);
         match &recorded[0].key {
-            JournalKey::Material { seed, planet_seed } => {
+            JournalKey::MaterialInstance { seed } => {
                 assert_eq!(*seed, 11);
                 assert_eq!(
-                    *planet_seed, None,
+                    recorded[0].planet_seed, None,
                     "without a WorldProfile, planet_seed must be None — never a sentinel"
                 );
             }
-            other => panic!("expected JournalKey::Material, got {other:?}"),
+            other => panic!("expected JournalKey::MaterialInstance, got {other:?}"),
         }
     }
 }

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -21,13 +21,10 @@ use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, Ra
 use bevy::prelude::*;
 
 use crate::carry::{CarryConfig, CarryState, ObserveWeight, StashHeldForPickup};
-use crate::descriptions::{
-    describe_color, describe_density, describe_thermal_observation, describe_value,
-};
+use crate::descriptions::describe_density;
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
-use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
+use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject};
 use crate::observation::Confidence;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
@@ -152,11 +149,8 @@ fn update_interaction_target(
     mut ray_cast: MeshRayCast,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     held_query: Query<(), With<HeldItem>>,
-    mut encounter_writer: MessageWriter<RecordObservation>,
-    descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let previous_target = target.entity;
+    let _previous_target = target.entity;
     target.entity = None;
 
     let Ok((camera, cam_gtf)) = camera_query.single() else {
@@ -183,56 +177,6 @@ fn update_interaction_target(
         && hit.distance <= INTERACTION_RANGE
     {
         target.entity = Some(entity);
-    }
-
-    if target.entity != previous_target
-        && let Some(entity) = target.entity
-        && let Ok(material) = material_query.get(entity)
-    {
-        encounter_writer.write(RecordObservation {
-            key: JournalKey::Material {
-                seed: material.seed,
-                // Capture the planet on which this material is being
-                // observed so the journal's "current planet" filter
-                // (Story 10.3) can match the entry against the player's
-                // current `WorldProfile::planet_seed` without re-deriving
-                // provenance from observation history.  When no
-                // `WorldProfile` is in scope (early bring-up, ad-hoc
-                // integration tests, future non-planetary discovery
-                // sites) the field stays `None` rather than defaulting to
-                // a sentinel — see `JournalKey::Material::planet_seed`'s
-                // docs for why "unknown provenance" is kept explicit.
-                planet_seed: world_profile.as_deref().map(|p| p.planet_seed.0),
-            },
-            name: material.name.clone(),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.1), // Low initial confidence for first observation
-                description: {
-                    // Use the DescriptorVocabulary for surface appearance
-                    // For surface appearance, we'll use the density value as the primary property
-                    // since it's more quantifiable than color
-                    descriptor_vocab
-                        .describe(
-                            &ObservationCategory::SurfaceAppearance,
-                            material.density.value(),
-                            Confidence(0.1),
-                        )
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| {
-                            // Fallback to old system if vocabulary lookup fails
-                            format!(
-                                "Color: {}\nWeight: {}",
-                                describe_color(&material.color),
-                                describe_density(material.density.value())
-                            )
-                        })
-                },
-                recorded_at: 0,
-            },
-            input_seeds: Vec::new(),
-            context_location: None,
-        });
     }
 }
 
@@ -412,6 +356,10 @@ fn process_pickup(
             .insert(HeldItem)
             .set_parent_in_place(camera_entity)
             .insert(Transform::from_translation(carry_config.hold_offset_vec3()));
+        // Density is revealed on pickup via the ObserveWeight message above,
+        // which fires a RecordObservation → KnowledgeGraph.reveal_property("Weight").
+        // The inspect panel reads revealed properties from the KG node — no
+        // entity component mutation needed here.
     }
 }
 
@@ -833,15 +781,13 @@ fn update_examine_panel(
     state: Res<ExamineState>,
     target: Res<InteractionTarget>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
-    held_query: Query<&GameMaterial, With<HeldItem>>,
-    material_query: Query<&GameMaterial, With<MaterialObject>>,
-    mut panel_query: Query<&mut Visibility, With<ExaminePanel>>,
-    mut text_query: Query<&mut Text, With<ExamineText>>,
+    graph: Res<crate::knowledge_graph::KnowledgeGraph>,
+    mut queries: ExaminePanelQueries,
 ) {
-    let Ok(mut vis) = panel_query.single_mut() else {
+    let Ok(mut vis) = queries.panel_query.single_mut() else {
         return;
     };
-    let Ok(mut text) = text_query.single_mut() else {
+    let Ok(mut text) = queries.text_query.single_mut() else {
         return;
     };
 
@@ -850,11 +796,11 @@ fn update_examine_panel(
         return;
     }
 
-    // Prefer held item; fall back to whatever the player is looking at.
-    let mat = held_query
-        .iter()
-        .next()
-        .or_else(|| target.entity.and_then(|e| material_query.get(e).ok()));
+    let mat = queries.held_query.iter().next().or_else(|| {
+        target
+            .entity
+            .and_then(|e| queries.material_query.get(e).ok())
+    });
 
     let Some(mat) = mat else {
         *vis = Visibility::Hidden;
@@ -862,70 +808,76 @@ fn update_examine_panel(
     };
 
     *vis = Visibility::Visible;
-    text.0 = build_examine_text(mat, &descriptor_vocab);
+    text.0 = build_examine_text(mat, &descriptor_vocab, &graph);
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct ExaminePanelQueries<'w, 's> {
+    held_query: Query<'w, 's, &'static GameMaterial, With<HeldItem>>,
+    material_query: Query<'w, 's, &'static GameMaterial, With<MaterialObject>>,
+    panel_query: Query<'w, 's, &'static mut Visibility, With<ExaminePanel>>,
+    text_query: Query<'w, 's, &'static mut Text, With<ExamineText>>,
+}
+
+/// Build the examine panel text for a material, reading revealed properties
+/// from the KnowledgeGraph node rather than from entity `PropertyVisibility`.
+///
+/// The KnowledgeGraph `revealed_properties` set uses
+/// `ObservationCategory::display_label()` strings as keys — the same strings
+/// written by `update_knowledge_graph` when it calls `reveal_property`.
 fn build_examine_text(
     mat: &GameMaterial,
     descriptor_vocab: &crate::observation::DescriptorVocabulary,
+    graph: &crate::knowledge_graph::KnowledgeGraph,
 ) -> String {
+    // Look up what the player has revealed about this material instance.
+    let revealed = graph
+        .lookup_material_by_seed(mat.seed)
+        .and_then(|idx| graph.node_weight(idx))
+        .map(|node| &node.revealed_properties);
+
+    let is_revealed = |label: &str| -> bool {
+        revealed.is_some_and(|r: &std::collections::HashSet<String>| r.contains(label))
+    };
+
     let mut lines = vec![mat.name.clone()];
     lines.push(String::new());
 
-    append_prop(&mut lines, "Weight", &mat.density, describe_density);
-    append_thermal_prop(&mut lines, mat, descriptor_vocab);
-    append_prop(&mut lines, "Reactivity", &mat.reactivity, describe_value);
-    append_prop(
-        &mut lines,
-        "Conductivity",
-        &mat.conductivity,
-        describe_value,
-    );
-    append_prop(&mut lines, "Toxicity", &mat.toxicity, describe_value);
-
-    lines.join("\n")
-}
-
-fn append_prop(
-    lines: &mut Vec<String>,
-    label: &str,
-    prop: &crate::materials::MaterialProperty,
-    describer: fn(f32) -> &'static str,
-) {
-    if prop.visibility == PropertyVisibility::Observable
-        || prop.visibility == PropertyVisibility::Revealed
-    {
-        lines.push(format!("{label}: {}", describer(prop.value())));
+    // Weight — revealed on pickup via Weight observation
+    if is_revealed("Weight") {
+        lines.push(format!("Weight: {}", describe_density(mat.density.value())));
     } else {
-        lines.push(format!("{label}: ???"));
+        lines.push("Weight: ???".to_string());
     }
-}
 
-fn append_thermal_prop(
-    lines: &mut Vec<String>,
-    mat: &GameMaterial,
-    descriptor_vocab: &crate::observation::DescriptorVocabulary,
-) {
-    match mat.thermal_resistance.visibility {
-        PropertyVisibility::Hidden => lines.push("Heat response: ???".to_string()),
-        PropertyVisibility::Observable | PropertyVisibility::Revealed => {
-            // Use a default confidence for examine panel display
-            // The actual confidence tracking happens in the journal system
-            let display_confidence = Confidence(0.5);
-            let description = descriptor_vocab
-                .describe(
-                    &ObservationCategory::ThermalBehavior,
+    // Heat response — revealed by heat exposure system
+    if is_revealed("Thermal") {
+        let display_confidence = Confidence(0.5);
+        let description = descriptor_vocab
+            .describe(
+                &crate::journal::ObservationCategory::ThermalBehavior,
+                mat.thermal_resistance.value(),
+                display_confidence,
+            )
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                crate::descriptions::describe_thermal_observation(
                     mat.thermal_resistance.value(),
                     display_confidence,
                 )
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| {
-                    // Fallback to old system if vocabulary lookup fails
-                    describe_thermal_observation(mat.thermal_resistance.value(), display_confidence)
-                });
-            lines.push(format!("Heat response: {description}"));
-        }
+            });
+        lines.push(format!("Heat response: {description}"));
+    } else {
+        lines.push("Heat response: ???".to_string());
     }
+
+    // Remaining properties — no reveal mechanism exists yet; always ???
+    // These will be wired when their observation systems are implemented.
+    lines.push("Reactivity: ???".to_string());
+    lines.push("Conductivity: ???".to_string());
+    lines.push("Toxicity: ???".to_string());
+
+    lines.join("\n")
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -954,67 +906,102 @@ mod tests {
     }
 
     fn test_material() -> GameMaterial {
+        use crate::materials::PropertyVisibility;
         GameMaterial {
             name: "TestMat".into(),
             seed: 1,
             color: [0.5, 0.5, 0.5],
-            density: MaterialProperty::new(0.78, PropertyVisibility::Observable),
+            origin_planet_seed: None,
+            density: MaterialProperty::new(0.78, PropertyVisibility::Hidden),
             thermal_resistance: MaterialProperty::new(0.65, PropertyVisibility::Hidden),
             reactivity: MaterialProperty::new(0.35, PropertyVisibility::Hidden),
-            conductivity: MaterialProperty::new(0.72, PropertyVisibility::Revealed),
+            conductivity: MaterialProperty::new(0.72, PropertyVisibility::Hidden),
             toxicity: MaterialProperty::new(0.05, PropertyVisibility::Hidden),
         }
     }
 
-    #[test]
-    fn examine_text_shows_observable_and_revealed_hides_hidden() {
-        let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
+    fn graph_with_weight_revealed(seed: u64) -> crate::knowledge_graph::KnowledgeGraph {
+        use crate::journal::{JournalKey, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+        graph.reveal_property(
+            node,
+            ObservationCategory::Weight.display_label().to_string(),
+        );
+        graph
+    }
 
+    fn graph_with_thermal_revealed(seed: u64) -> crate::knowledge_graph::KnowledgeGraph {
+        use crate::journal::{JournalKey, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+        graph.reveal_property(
+            node,
+            ObservationCategory::ThermalBehavior
+                .display_label()
+                .to_string(),
+        );
+        graph
+    }
+
+    #[test]
+    fn examine_text_shows_name_always() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
         assert!(text.contains("TestMat"));
-        assert!(text.contains("Weight: Very heavy"));
-        assert!(text.contains("Conductivity: Very high"));
-        assert!(text.contains("Heat response: ???"));
-        assert!(text.contains("Reactivity: ???"));
-        assert!(text.contains("Toxicity: ???"));
     }
 
     #[test]
     fn examine_text_name_is_first_line() {
         let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
-        let first_line = text.lines().next().unwrap();
-        assert_eq!(first_line, "TestMat");
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert_eq!(text.lines().next().unwrap(), "TestMat");
     }
 
     #[test]
-    fn examine_text_shows_heat_response_for_revealed_thermal_property() {
-        let mut mat = test_material();
-        mat.thermal_resistance.visibility = PropertyVisibility::Revealed;
-
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
-        // Check for the presence of Heat response rather than specific confidence language
-        assert!(text.contains("Heat response:"));
-        // Check that the heat response line specifically doesn't contain "???"
-        let heat_line = text
-            .lines()
-            .find(|line| line.contains("Heat response:"))
-            .unwrap();
-        assert!(!heat_line.contains("???"));
-    }
-
-    #[test]
-    fn examine_text_shows_thermal_knowledge_for_hidden_property_when_previously_observed() {
+    fn examine_text_weight_hidden_without_observation() {
         let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert!(text.contains("Weight: ???"));
+    }
 
-        // With the new system, hidden properties always show "???" regardless of previous observations
-        // The confidence tracking is now handled in the journal system, not the examine panel
-        let text = build_examine_text(&mat, &descriptor_vocab);
+    #[test]
+    fn examine_text_weight_shown_after_weight_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = graph_with_weight_revealed(mat.seed);
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert!(!text.contains("Weight: ???"));
+        assert!(text.contains("Weight:"));
+    }
+
+    #[test]
+    fn examine_text_heat_hidden_without_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
         assert!(text.contains("Heat response: ???"));
+    }
+
+    #[test]
+    fn examine_text_heat_shown_after_thermal_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = graph_with_thermal_revealed(mat.seed);
+        let text = build_examine_text(&mat, &vocab, &graph);
+        let heat_line = text.lines().find(|l| l.contains("Heat response:")).unwrap();
+        assert!(!heat_line.contains("???"));
     }
 
     #[test]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -6,18 +6,18 @@
 //! fabricator. Unknown properties are omitted entirely rather than shown as
 //! placeholders.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
+use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
 use crate::input::InputAction;
-use crate::knowledge_graph::{ConceptId, KnowledgeGraph, RelationshipType};
 use crate::observation::Confidence;
 use crate::player::{Player, cursor_is_captured, spawn_player};
-use crate::world_generation::{BiomeType, WorldProfile};
+use crate::world_generation::BiomeType;
 
 // ── Biome key type safety ──────────────────────────────────────────────
 
@@ -118,7 +118,7 @@ impl ObservationCategory {
     }
 
     /// Player-facing label used as a group header in the detail panel.
-    fn display_label(&self) -> &'static str {
+    pub fn display_label(&self) -> &'static str {
         match self {
             ObservationCategory::SurfaceAppearance => "Surface",
             ObservationCategory::ThermalBehavior => "Thermal",
@@ -180,46 +180,35 @@ pub struct Observation {
 
 /// Unique key identifying a journal subject.
 ///
-/// Each variant encodes both the *type* of subject (material, fabrication
-/// output, etc.) and the identity that distinguishes one instance from
+/// Each variant encodes both the *type* of subject (material instance,
+/// fabrication output, etc.) and the identity that distinguishes one from
 /// another. The enum is intentionally non-exhaustive so future systems
-/// (navigation, trade, language) can add variants without breaking
-/// existing match arms.
+/// (navigation, trade, language, material classification) can add variants
+/// without breaking existing match arms.
+///
+/// # Material identity
+///
+/// `MaterialInstance` identifies a specific observed material entity by its
+/// generation seed. Planet of origin is carried on [`RecordObservation`] as
+/// context for the `FoundOn` KnowledgeGraph edge — not baked into the key.
+///
+/// A future `Material { classification: String }` variant will identify a
+/// material *type* (e.g. "iron") once asset-defined classification ranges
+/// exist. See `docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md`.
 ///
 /// `Ord` is derived so that `JournalKey` can serve as a `BTreeMap` key,
 /// giving the journal a stable, deterministic iteration order.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum JournalKey {
-    /// A raw or discovered material, keyed by its procedural seed.
+    /// A specific observed material instance, keyed by its generation seed.
     ///
-    /// The optional `planet_seed` records the planet on which this
-    /// material was first observed, so context-aware filters
-    /// (Story 10.3 — "entries relevant to current planet") can match
-    /// entries against the player's [`WorldProfile::planet_seed`]
-    /// without re-deriving provenance from observation history.
-    ///
-    /// `planet_seed` is `None` for entries created in contexts where
-    /// no planetary world profile is in scope (early bring-up, ad-hoc
-    /// integration tests, future non-planetary discovery sites).
-    /// Treating it as `Option<u64>` rather than baking in a sentinel
-    /// keeps the "unknown provenance" case explicit at every match
-    /// site.
-    ///
-    /// Field ordering is `seed` then `planet_seed` so the derived
-    /// `Ord` continues to sort primarily by material identity — the
-    /// existing journal iteration order is preserved when
-    /// `planet_seed` is `None` everywhere, which matches the
-    /// pre-extension behaviour bit-for-bit.
-    Material {
-        /// The deterministic seed that uniquely identifies this material
-        /// within the world generation system.
+    /// All knowledge accumulated about this material — density, reactivity,
+    /// thermal response, sightings — is stored on the KnowledgeGraph node
+    /// identified by this key.  Planet of origin is recorded as a `FoundOn`
+    /// edge on that node, not as part of this key.
+    MaterialInstance {
+        /// The generation seed that uniquely identifies this material instance.
         seed: u64,
-        /// The planet on which this material was first observed, taken
-        /// from `WorldProfile::planet_seed.0` at observation time.
-        /// `None` indicates the recording site had no planetary context
-        /// available; such entries are excluded from
-        /// [`JournalContext::CurrentPlanet`] filtering.
-        planet_seed: Option<u64>,
     },
     /// The output of a fabrication process, keyed by the resulting
     /// material's seed.
@@ -227,34 +216,34 @@ pub enum JournalKey {
         /// The deterministic seed of the fabricated output material.
         output_seed: u64,
     },
+    /// A planetary or regional location, keyed by its planet seed.
+    ///
+    /// Created automatically by the knowledge graph system whenever a
+    /// material observation carries planet provenance — giving the graph
+    /// a concrete node to attach `FoundOn` and `ObservedAt` edges to.
+    /// Location entries are not displayed in the main journal entry list
+    /// because the player encounters planets through the world, not
+    /// through a catalog — but they are reachable as cross-reference
+    /// targets from material entries.
+    Location {
+        /// The planet seed that uniquely identifies this location within
+        /// the world generation system.  Matches `WorldProfile::planet_seed.0`.
+        planet_seed: u64,
+    },
 }
 
 impl JournalKey {
-    /// Planet on which the subject identified by this key was first
-    /// observed, when that information is available.
+    /// Planet on which the subject identified by this key was observed,
+    /// when that information is available.
     ///
-    /// Returns `Some(seed)` for [`JournalKey::Material`] entries that
-    /// were recorded with a planetary world profile in scope, and `None`
-    /// for materials recorded without one (early bring-up, ad-hoc
-    /// integration tests, future non-planetary discovery sites).
-    ///
-    /// [`JournalKey::Fabrication`] entries return `None` because
-    /// fabrications are produced at the player's fabricator and are
-    /// intentionally not tied to a discovery planet — the same recipe
-    /// produces the same output regardless of where it was crafted.  The
-    /// "current planet" filter therefore intentionally hides
-    /// fabrications, which matches the player-mental-model of the
-    /// filter ("show me things tied to where I am") better than
-    /// pretending fabrications belong to whichever planet the player
-    /// happened to be standing on at craft time.
-    ///
-    /// Used by [`matches_filter`] to evaluate
-    /// [`JournalContext::CurrentPlanet`] without re-deriving provenance
-    /// from observation history.
+    /// `Location` keys return their planet seed directly. All other variants
+    /// return `None` — planet provenance for material instances is stored on
+    /// the KnowledgeGraph node as a `FoundOn` edge, not on the key.
     pub fn planet_seed(&self) -> Option<u64> {
         match self {
-            JournalKey::Material { planet_seed, .. } => *planet_seed,
+            JournalKey::MaterialInstance { .. } => None,
             JournalKey::Fabrication { .. } => None,
+            JournalKey::Location { planet_seed } => Some(*planet_seed),
         }
     }
 }
@@ -392,7 +381,7 @@ pub fn matches_filter(entry: &JournalEntry, filter: &JournalFilter) -> bool {
 
     let context_match = filter.context.as_ref().is_none_or(|ctx| match ctx {
         JournalContext::CurrentPlanet { planet_seed } => {
-            entry.key.planet_seed() == Some(*planet_seed)
+            entry.origin_planet_seed == Some(*planet_seed)
         }
         // Biome provenance is not yet captured on JournalKey; until it
         // is, the biome filter is a no-op (matches everything) rather
@@ -453,6 +442,7 @@ impl Plugin for JournalPlugin {
             .init_resource::<JournalUiState>()
             .init_resource::<JournalSelectionTracker>()
             .init_resource::<JournalRenderCache>()
+            .init_resource::<JournalNavigationStack>()
             .configure_sets(
                 Update,
                 (JournalSet::Navigate, JournalSet::Compute, JournalSet::Sync).chain(),
@@ -471,15 +461,21 @@ impl Plugin for JournalPlugin {
                     toggle_journal_visibility
                         .in_set(JournalSet::Navigate)
                         .after(emit_toggle_journal_intent),
-                    journal_navigation
+                    sync_journal_ui_state_from_focus
                         .in_set(JournalSet::Navigate)
                         .after(toggle_journal_visibility),
+                    journal_navigation
+                        .in_set(JournalSet::Navigate)
+                        .after(sync_journal_ui_state_from_focus),
                     update_journal_context_on_planet_change
                         .in_set(JournalSet::Navigate)
                         .after(journal_navigation),
                     apply_observations.in_set(JournalSet::Navigate),
+                    journal_cross_ref_navigation
+                        .in_set(JournalSet::Navigate)
+                        .after(journal_navigation),
                     compute_journal_panels.in_set(JournalSet::Compute),
-                    append_cross_reference_spans
+                    populate_cross_ref_links
                         .in_set(JournalSet::Compute)
                         .after(compute_journal_panels),
                     sync_journal_ui.in_set(JournalSet::Sync),
@@ -500,10 +496,15 @@ impl Plugin for JournalPlugin {
 /// **Planet seed handling:** For [`JournalKey::Material`] observations,
 /// the `planet_seed` field is automatically resolved by the ingestion
 /// system from the current [`WorldProfile`] resource. Observation producers
-/// should pass `planet_seed: None` and let the system fill it in centrally.
-/// This eliminates the need for every observation site to manually extract
-/// `world_profile.as_deref().map(|p| p.planet_seed.0)` and prevents silent
-/// failures when new observation sites forget this pattern.
+/// Message sent by any game system to record a player observation.
+///
+/// The knowledge graph system wires `FoundOn` and `ObservedAt` edges from
+/// the `planet_seed` and `context_location` fields respectively.
+/// Journal ingestion ignores both — they are purely for graph wiring.
+///
+/// **Cross-reference metadata:** The `input_seeds` field is optional
+/// metadata consumed by the knowledge graph system to wire `DerivedFrom`
+/// edges for fabrication observations.
 #[derive(Message, Clone)]
 pub struct RecordObservation {
     /// Which journal subject this observation belongs to.
@@ -515,14 +516,24 @@ pub struct RecordObservation {
     /// The observation payload including category, confidence, description,
     /// and game-time tick.
     pub observation: Observation,
-    /// For fabrication observations: the seeds of the input materials that
-    /// were combined to produce this output. Used by the knowledge graph to
-    /// create `DerivedFrom` edges. Empty for non-fabrication observations.
+    /// Planet on which this observation was made.
+    ///
+    /// When `Some`, the knowledge graph system wires a `FoundOn` edge from
+    /// the observed subject to the corresponding location concept.  Callers
+    /// that don't have planetary context (integration tests, fabrication)
+    /// leave this `None`.
+    pub planet_seed: Option<u64>,
+    /// For fabrication observations: seeds of the input materials that were
+    /// combined to produce the output. The knowledge graph system uses these
+    /// to wire `DerivedFrom` edges from the output concept to each input.
+    ///
+    /// Empty for non-fabrication observations.
     pub input_seeds: Vec<u64>,
-    /// The location where this observation occurred, if applicable. Used by
-    /// the knowledge graph to create `FoundOn` / `ObservedAt` edges. `None`
-    /// when the observation has no spatial context (e.g., fabrication results,
-    /// abstract property comparisons).
+    /// Optional location context where this observation was made.
+    ///
+    /// When `Some`, the knowledge graph system wires an `ObservedAt` edge
+    /// from the observed subject to this location concept. Callers that
+    /// don't have explicit location context leave this `None`.
     pub context_location: Option<JournalKey>,
 }
 
@@ -541,11 +552,15 @@ pub struct JournalEntry {
     pub key: JournalKey,
     /// Player-facing display name for this subject.
     pub name: String,
-    /// Observations grouped by category, each group in chronological order.
+    /// Planet on which this material instance was first observed.
     ///
-    /// Using a `BTreeMap` gives deterministic iteration order over categories
-    /// (important for rendering stability and save/load reproducibility).
-    /// Within each category the `Vec` preserves insertion (chronological) order.
+    /// Populated from [`GameMaterial::origin_planet_seed`] on first
+    /// `RecordObservation` for this entry. Used by the `CurrentPlanet`
+    /// filter while the full KnowledgeGraph query layer is pending
+    /// (follow-on epic). `None` for fabricated materials and entries
+    /// recorded without planetary context.
+    pub origin_planet_seed: Option<u64>,
+    /// Observations grouped by category, each group in chronological order.
     pub observations: BTreeMap<ObservationCategory, Vec<Observation>>,
     /// Game-time tick when the player first recorded *any* observation about
     /// this subject.
@@ -564,6 +579,7 @@ impl JournalEntry {
         Self {
             key,
             name,
+            origin_planet_seed: None,
             observations: BTreeMap::new(),
             first_observed_at: tick,
             last_updated_at: tick,
@@ -798,55 +814,6 @@ impl Journal {
 
 // ── UI state ────────────────────────────────────────────────────────────
 
-/// Tracks navigation history for back-navigation through cross-references.
-///
-/// When the player follows a cross-reference link, the source entry's key is
-/// pushed onto this stack.  Pressing Backspace while the journal is open pops
-/// the stack and returns to the previous entry.  The stack is bounded by
-/// `max_depth` to prevent unbounded growth during deep exploration sessions.
-#[derive(Clone, Debug)]
-pub struct JournalNavigationStack {
-    /// Previously visited entry keys, oldest first.
-    pub history: Vec<JournalKey>,
-    /// Maximum number of entries retained in the history.  When the stack
-    /// reaches this limit, the oldest entry is dropped before pushing a new
-    /// one.
-    pub max_depth: usize,
-}
-
-impl JournalNavigationStack {
-    /// Default maximum history depth — deep enough for any reasonable
-    /// exploration session without unbounded memory growth.
-    const DEFAULT_MAX_DEPTH: usize = 32;
-
-    fn new() -> Self {
-        Self {
-            history: Vec::new(),
-            max_depth: Self::DEFAULT_MAX_DEPTH,
-        }
-    }
-
-    /// Push a key onto the history stack, evicting the oldest entry when the
-    /// stack is at capacity.
-    fn push(&mut self, key: JournalKey) {
-        if self.history.len() >= self.max_depth {
-            self.history.remove(0);
-        }
-        self.history.push(key);
-    }
-
-    /// Pop the most recently visited key, returning it if the stack is
-    /// non-empty.
-    fn pop(&mut self) -> Option<JournalKey> {
-        self.history.pop()
-    }
-
-    /// Whether the stack has any history to go back to.
-    fn can_go_back(&self) -> bool {
-        !self.history.is_empty()
-    }
-}
-
 /// Tracks the journal panel's visibility and navigation state.
 ///
 /// Fields are deliberately **private**.  External systems must go through
@@ -891,19 +858,6 @@ pub struct JournalUiState {
     /// accessor and setter on this type, keeping the [`JournalSet`]
     /// ordering contract enforceable.
     filter: JournalFilter,
-    /// Index of the currently highlighted cross-reference link in the detail
-    /// panel, or `None` when no link is focused.
-    ///
-    /// When `Some(i)`, the i-th cross-reference link in the "Related" section
-    /// is highlighted and can be followed with Enter.  Arrow keys within the
-    /// detail panel cycle through links; Escape or ArrowLeft returns to the
-    /// entry list without following a link.
-    selected_link_index: Option<usize>,
-    /// Navigation history for back-navigation through cross-reference links.
-    ///
-    /// When the player follows a link, the source entry's key is pushed here.
-    /// Backspace pops the stack and returns to the previous entry.
-    navigation_stack: JournalNavigationStack,
 }
 
 impl JournalUiState {
@@ -973,19 +927,6 @@ impl JournalUiState {
         self.filter = filter;
     }
 
-    /// Index of the currently highlighted cross-reference link, or `None`
-    /// when no link is focused.
-    #[allow(dead_code)]
-    pub fn selected_link_index(&self) -> Option<usize> {
-        self.selected_link_index
-    }
-
-    /// Whether the navigation stack has any history to go back to.
-    #[allow(dead_code)]
-    pub fn can_go_back(&self) -> bool {
-        self.navigation_stack.can_go_back()
-    }
-
     /// Clamp `selected_index` and `scroll_offset` so they stay within valid
     /// bounds for the given total entry count.  Called after any navigation
     /// input and before rendering so the UI never references out-of-range
@@ -1016,8 +957,6 @@ impl Default for JournalUiState {
             scroll_offset: 0,
             entries_per_page: Self::DEFAULT_ENTRIES_PER_PAGE,
             filter: JournalFilter::default(),
-            selected_link_index: None,
-            navigation_stack: JournalNavigationStack::new(),
         }
     }
 }
@@ -1084,6 +1023,68 @@ struct JournalSelectionTracker {
     last_scroll_offset: usize,
 }
 
+// ── Cross-reference navigation stack ────────────────────────────────────
+
+/// Tracks the player's breadcrumb trail through journal cross-reference links.
+///
+/// When the player presses Enter on a cross-reference link, the current
+/// entry's [`JournalKey`] is pushed here before the view jumps to the
+/// linked entry. Pressing Backspace pops the stack and returns to the
+/// previous entry. This gives the player a browser-history-like
+/// back-navigation experience.
+///
+/// The stack is bounded at [`Self::MAX_DEPTH`] entries to prevent
+/// unbounded growth from very long browsing sessions. When the limit is
+/// reached, the oldest entry is silently dropped (the stack slides).
+///
+/// Persists across journal close/reopen so the player can close the
+/// journal mid-browse and return to their trail.
+#[derive(Resource, Default)]
+pub struct JournalNavigationStack {
+    /// Breadcrumb entries from oldest to newest.
+    ///
+    /// Back of the deque is the most recently visited entry — the one that
+    /// Backspace will return the player to. Front of the deque is the oldest
+    /// entry (evicted first when the depth limit is reached).
+    history: VecDeque<(JournalKey, JournalFilter)>,
+}
+
+impl JournalNavigationStack {
+    /// Maximum number of entries held in the navigation history.
+    ///
+    /// Capped to prevent unbounded memory growth and to keep the
+    /// back-navigation depth reasonable. 32 steps should cover any
+    /// real browsing session.
+    pub const MAX_DEPTH: usize = 32;
+
+    /// Push the current entry and active filter onto the back-navigation stack
+    /// before jumping to a cross-reference target. Backspace pops and restores
+    /// both.
+    pub fn push(&mut self, key: JournalKey, filter: JournalFilter) {
+        if self.history.len() >= Self::MAX_DEPTH {
+            // Evict the oldest entry in O(1) — VecDeque makes this free.
+            self.history.pop_front();
+        }
+        self.history.push_back((key, filter));
+    }
+
+    /// Pop and return the most recent entry on the back-navigation stack.
+    ///
+    /// Returns `None` when the history is empty (the player is already at
+    /// their starting point and there is nothing to go back to).
+    pub fn pop(&mut self) -> Option<(JournalKey, JournalFilter)> {
+        self.history.pop_back()
+    }
+
+    /// Returns `true` when there are entries on the back-navigation stack.
+    ///
+    /// Used by the navigation system to decide whether to show the Backspace
+    /// hint in the help bar.
+    pub fn can_go_back(&self) -> bool {
+        !self.history.is_empty()
+    }
+}
+
 /// Root container for the entire journal overlay (two-panel layout).
 #[derive(Component)]
 struct JournalPanel;
@@ -1138,6 +1139,27 @@ fn spawn_journal_ui(mut commands: Commands) {
     commands
         .spawn((
             JournalPanel,
+            // ── Diegetic surface registration (Story 10.6) ───────────────
+            //
+            // The journal is an in-world datapad the player holds up to read,
+            // not a HUD overlay.  Attaching these three components registers it
+            // with the DiegeticUiPlugin:
+            //   • DiegeticSurface  — marks it as a diegetic information surface
+            //     so the CI compliance test can verify no rogue screen-space text exists.
+            //   • DiegeticSurfaceKind::Readable — declares interaction model.
+            //     The player "holds up" the datapad (Active state); physical distance
+            //     does not drive focus here because the journal is always on the player.
+            //     The ranges are set to 0.0 so proximity logic collapses to Focused
+            //     the moment the entity exists — actual open/close is managed by
+            //     toggle_journal_datapad_focus below.
+            //   • DiegeticFocusState::OutOfRange — journal starts closed.
+            DiegeticSurface,
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 0.0,
+                legible_range: 0.0,
+            },
+            DiegeticFocusState::OutOfRange,
+            // ─────────────────────────────────────────────────────────────
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(24.0),
@@ -1258,9 +1280,14 @@ fn spawn_journal_ui(mut commands: Commands) {
 
 fn emit_toggle_journal_intent(
     player_query: Query<&ActionState<InputAction>, With<Player>>,
-    cursor_options: Single<&bevy::window::CursorOptions>,
+    cursor_options: Option<Single<&bevy::window::CursorOptions>>,
     mut writer: MessageWriter<ToggleJournalIntent>,
 ) {
+    // If no window entity exists (e.g. headless integration tests), the journal
+    // cannot receive input — skip gracefully.
+    let Some(cursor_options) = cursor_options else {
+        return;
+    };
     if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
@@ -1275,11 +1302,38 @@ fn emit_toggle_journal_intent(
 
 fn toggle_journal_visibility(
     mut reader: MessageReader<ToggleJournalIntent>,
-    mut state: ResMut<JournalUiState>,
+    mut panel_query: Query<&mut DiegeticFocusState, With<JournalPanel>>,
 ) {
     for _ in reader.read() {
-        state.visible = !state.visible;
+        let Ok(mut focus) = panel_query.single_mut() else {
+            continue;
+        };
+        // Toggle the journal datapad between Active (open) and OutOfRange (closed).
+        // DiegeticUiPlugin's VisibilitySync will flip the Visibility component;
+        // sync_journal_ui_state_from_focus keeps JournalUiState.visible in lockstep.
+        *focus = match *focus {
+            DiegeticFocusState::Active => DiegeticFocusState::OutOfRange,
+            _ => DiegeticFocusState::Active,
+        };
     }
+}
+
+/// Keeps [`JournalUiState::visible`] in lockstep with the journal panel's
+/// [`DiegeticFocusState`].
+///
+/// All existing journal systems (navigation, compute, sync) gate on
+/// `JournalUiState::visible` — this bridge system means none of them need
+/// to know about the diegetic framework.  It runs in [`JournalSet::Navigate`]
+/// before navigation so that `compute_journal_panels` always sees a
+/// consistent `visible` flag.
+fn sync_journal_ui_state_from_focus(
+    panel_query: Query<&DiegeticFocusState, With<JournalPanel>>,
+    mut state: ResMut<JournalUiState>,
+) {
+    let Ok(focus) = panel_query.single() else {
+        return;
+    };
+    state.visible = matches!(focus, DiegeticFocusState::Active);
 }
 
 // ── Navigation ──────────────────────────────────────────────────────────
@@ -1298,19 +1352,11 @@ fn toggle_journal_visibility(
 /// - Home/End: jump to first/last entry.
 /// - Scroll offset auto-adjusts via `clamp_to_entry_count` so the
 ///   selected entry is always within the visible window.
-/// - When a cross-reference link is focused (selected_link_index is Some):
-///   - Up/Down moves the link cursor within the "Related" section.
-///   - Enter follows the focused link, pushing the current entry onto the
-///     navigation stack and jumping to the related entry.
-///   - Backspace or Escape clears the link cursor without navigating.
-/// - Backspace when no link is focused pops the navigation stack and
-///   returns to the previously visited entry.
 fn journal_navigation(
     mut state: ResMut<JournalUiState>,
     keys: Res<ButtonInput<KeyCode>>,
     q: Query<&Journal, With<Player>>,
     world_profile: Option<Res<crate::world_generation::WorldProfile>>,
-    graph: Option<Res<KnowledgeGraph>>,
 ) {
     if !state.visible {
         return;
@@ -1411,180 +1457,124 @@ fn journal_navigation(
         state.scroll_offset = 0;
     }
 
-    // ── Cross-reference link navigation ───────────────────────────────
-    //
-    // When a link is focused (selected_link_index is Some), arrow keys move
-    // the cursor within the "Related" section.  Enter follows the focused
-    // link.  Escape or Backspace clears the cursor.
-    //
-    // When no link is focused, Backspace pops the navigation stack to return
-    // to the previously visited entry.  Tab/Shift+Tab and arrow keys operate
-    // on the entry list as usual.
-    //
-    // The link count is derived from the KnowledgeGraph for the currently
-    // selected entry.  When the graph is absent (test apps) link navigation
-    // is silently skipped.
-    let link_count = graph.as_ref().and_then(|g| {
-        let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-        sorted.sort_by(|a, b| a.name.cmp(&b.name));
-        let filtered: Vec<&JournalEntry> = sorted
-            .into_iter()
-            .filter(|e| matches_filter(e, state.filter()))
-            .collect();
-        let entry = filtered.get(state.selected_index)?;
-        let node_idx = g.lookup(&ConceptId::new(entry.key.clone()))?;
-        let rels = g.relationships(node_idx);
-        if rels.is_empty() {
-            None
-        } else {
-            Some(rels.len())
-        }
-    });
-
-    if let Some(link_idx) = state.selected_link_index {
-        // ── Link cursor is active ──────────────────────────────────────
-        let count = link_count.unwrap_or(0);
-
-        if keys.just_pressed(KeyCode::ArrowUp) {
-            state.selected_link_index = if link_idx == 0 {
-                // Wrap back to entry list navigation by clearing the cursor.
-                None
-            } else {
-                Some(link_idx - 1)
-            };
-            // Early return — do not also move the entry list selection.
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::ArrowDown) {
-            if count > 0 && link_idx + 1 < count {
-                state.selected_link_index = Some(link_idx + 1);
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Escape) || keys.just_pressed(KeyCode::ArrowLeft) {
-            // Cancel link focus without navigating.
-            state.selected_link_index = None;
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Backspace) {
-            // Backspace while a link is focused: cancel link focus first.
-            state.selected_link_index = None;
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Enter) {
-            // Follow the focused link: look up the target entry and jump to it.
-            if let Some(g) = graph.as_ref() {
-                let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-                sorted.sort_by(|a, b| a.name.cmp(&b.name));
-                let filtered: Vec<&JournalEntry> = sorted
-                    .iter()
-                    .copied()
-                    .filter(|e| matches_filter(e, state.filter()))
-                    .collect();
-                if let Some(current_entry) = filtered.get(state.selected_index) {
-                    let concept_id = ConceptId::new(current_entry.key.clone());
-                    if let Some(node_idx) = g.lookup(&concept_id) {
-                        let rels = g.relationships(node_idx);
-                        // Build ref_lines in the same sort order as
-                        // append_cross_reference_spans: (rel_label, target_name).
-                        let mut ref_lines: Vec<(String, String, JournalKey)> = rels
-                            .iter()
-                            .filter_map(|(neighbor_idx, edge)| {
-                                let neighbor_node = g.node(*neighbor_idx)?;
-                                let target_key = neighbor_node.id.key().clone();
-                                let rel_label =
-                                    relationship_display_label(&edge.relationship).to_string();
-                                let target_name = journal
-                                    .entries
-                                    .get(&target_key)
-                                    .map(|e| e.name.clone())
-                                    .unwrap_or_else(|| format!("{target_key:?}"));
-                                Some((rel_label, target_name, target_key))
-                            })
-                            .collect();
-                        ref_lines.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-
-                        if let Some((_, _, target_key)) = ref_lines.get(link_idx) {
-                            // Push the current entry onto the navigation stack.
-                            state.navigation_stack.push(current_entry.key.clone());
-                            // Find the target entry's index in the filtered list.
-                            if let Some(target_pos) =
-                                filtered.iter().position(|e| &e.key == target_key)
-                            {
-                                state.selected_index = target_pos;
-                            }
-                            // Clear the link cursor after following the link.
-                            state.selected_link_index = None;
-                        }
-                    }
-                }
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        // Any other key while link cursor is active: fall through to normal
-        // entry-list navigation (Tab, Shift+Tab, PageUp/Down, Home/End).
-    } else {
-        // ── No link cursor — handle Backspace for back-navigation ─────
-        if keys.just_pressed(KeyCode::Backspace) && state.navigation_stack.can_go_back() {
-            if let Some(prev_key) = state.navigation_stack.pop() {
-                // Find the previous entry in the filtered list.
-                let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-                sorted.sort_by(|a, b| a.name.cmp(&b.name));
-                let filtered: Vec<&JournalEntry> = sorted
-                    .into_iter()
-                    .filter(|e| matches_filter(e, state.filter()))
-                    .collect();
-                if let Some(pos) = filtered.iter().position(|e| e.key == prev_key) {
-                    state.selected_index = pos;
-                }
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-
-        // ArrowRight enters link mode when the selected entry has cross-references.
-        if keys.just_pressed(KeyCode::ArrowRight) && link_count.is_some() {
-            state.selected_link_index = Some(0);
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-    }
-
     if keys.just_pressed(KeyCode::ArrowUp) {
         state.selected_index = state.selected_index.saturating_sub(1);
-        // Moving the entry list selection clears any stale link cursor.
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::ArrowDown) {
         state.selected_index = (state.selected_index + 1).min(entry_count - 1);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::PageUp) {
         state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::PageDown) {
         state.selected_index = (state.selected_index + state.entries_per_page).min(entry_count - 1);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::Home) {
         state.selected_index = 0;
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::End) {
         state.selected_index = entry_count - 1;
-        state.selected_link_index = None;
     }
 
     state.clamp_to_entry_count(entry_count);
 }
 
-/// System that automatically updates the journal context filter when the
+/// Handles cross-reference link navigation within the journal detail panel.
+///
+/// Runs in Update in [`JournalSet::Navigate`], after `journal_navigation`.
+/// Only active when the journal is visible and the current entry has cross-
+/// reference links (i.e. `cache.cross_ref_links` is non-empty).
+///
+/// Key bindings:
+/// - `Alt+Down` / `Alt+Up` — cycle the highlighted cross-reference link.
+/// - `Enter` — follow the highlighted link: push current key onto
+///   [`JournalNavigationStack`], then find the linked entry's position
+///   in the sorted filtered list and set `selected_index` to it.
+/// - `Backspace` — pop the navigation stack and return to the previous
+///   entry.
+fn journal_cross_ref_navigation(
+    mut state: ResMut<JournalUiState>,
+    mut cache: ResMut<JournalRenderCache>,
+    mut nav_stack: ResMut<JournalNavigationStack>,
+    keys: Res<ButtonInput<KeyCode>>,
+    q: Query<&Journal, With<Player>>,
+) {
+    if !state.visible {
+        return;
+    }
+
+    // ── Back-navigation (Backspace) ─────────────────────────────────
+    if keys.just_pressed(KeyCode::Backspace) {
+        if let Some((prev_key, prev_filter)) = nav_stack.pop() {
+            let Ok(journal) = q.single() else {
+                return;
+            };
+            // Restore the saved filter first, then locate the previous entry
+            // within that filter's view — so the player lands exactly where
+            // they were before following the link.
+            state.set_filter(prev_filter);
+            let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
+            sorted.sort_by(|a, b| a.name.cmp(&b.name));
+            let filtered: Vec<&JournalEntry> = sorted
+                .iter()
+                .copied()
+                .filter(|e| matches_filter(e, state.filter()))
+                .collect();
+            if let Some(pos) = filtered.iter().position(|e| e.key == prev_key) {
+                state.selected_index = pos;
+                state.scroll_offset = pos.saturating_sub(state.entries_per_page / 2);
+                state.clamp_to_entry_count(filtered.len());
+            }
+        }
+        return;
+    }
+
+    let link_count = cache.cross_ref_links.len();
+    if link_count == 0 {
+        return;
+    }
+
+    // ── Cross-ref link cursor movement (Alt+Up / Alt+Down) ───────────
+    let alt = keys.pressed(KeyCode::AltLeft) || keys.pressed(KeyCode::AltRight);
+    if alt && keys.just_pressed(KeyCode::ArrowDown) {
+        cache.selected_cross_ref = (cache.selected_cross_ref + 1).min(link_count - 1);
+    }
+    if alt && keys.just_pressed(KeyCode::ArrowUp) {
+        cache.selected_cross_ref = cache.selected_cross_ref.saturating_sub(1);
+    }
+
+    // ── Follow cross-reference (Enter) ────────────────────────────────
+    if keys.just_pressed(KeyCode::Enter) {
+        let selected_idx = cache.selected_cross_ref.min(link_count - 1);
+        let (_, target_key, _) = cache.cross_ref_links[selected_idx].clone();
+
+        let Ok(journal) = q.single() else {
+            return;
+        };
+
+        // Build the sorted entry list once. Clearing the filter (below) doesn't
+        // change `journal.entries` — only the view — so this list remains valid
+        // for both push-to-stack and jump-to-target.
+        let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
+        sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Push the current selection AND active filter onto the back-nav stack
+        // so Backspace restores the player to exactly where they were.
+        if let Some(current_entry) = sorted.get(state.selected_index) {
+            nav_stack.push(current_entry.key.clone(), state.filter().clone());
+        }
+
+        // Clear filter so the target is always in view, then jump.
+        state.set_filter(JournalFilter::default());
+
+        if let Some(pos) = sorted.iter().position(|e| e.key == target_key) {
+            state.selected_index = pos;
+            state.scroll_offset = pos.saturating_sub(state.entries_per_page / 2);
+            state.clamp_to_entry_count(sorted.len());
+            cache.selected_cross_ref = 0;
+        }
+    }
+}
 /// planet changes (WorldProfile resource changes).
 ///
 /// When the player switches planets, this system detects the change in
@@ -1650,51 +1640,45 @@ fn update_journal_context_on_planet_change(
 /// death context. If the player died recently and is now observing the
 /// death-relevant domain, confidence accumulates faster. If they're
 /// avoiding the death domain, it accumulates slower.
-fn apply_observations(
+pub(crate) fn apply_observations(
     mut reader: MessageReader<RecordObservation>,
     mut player_query: Query<&mut Journal, With<Player>>,
     time: Res<Time>,
     config: Res<crate::observation::ConfidenceConfig>,
     death_context: Option<Res<crate::observation::DeathContext>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
     let Ok(mut journal) = player_query.single_mut() else {
         return;
     };
 
     let tick = time.elapsed().as_millis() as u64;
-    let current_planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
 
     for event in reader.read() {
         let mut obs = event.observation.clone();
         obs.recorded_at = tick;
 
-        // Automatically resolve planet_seed for Material observations if not already set
-        let key = match &event.key {
-            JournalKey::Material {
-                seed,
-                planet_seed: None,
-            } => JournalKey::Material {
-                seed: *seed,
-                planet_seed: current_planet_seed,
-            },
-            key => key.clone(),
-        };
-
         // Calculate recovery multiplier based on death context
         let recovery_multiplier = if let Some(death_ctx) = &death_context {
             death_ctx.recovery_multiplier(&obs.category, tick, &config)
         } else {
-            1.0 // No death context, use base rate
+            1.0
         };
 
         journal.record_with_domain_weighted_accumulation(
-            key,
+            event.key.clone(),
             &event.name,
             obs,
             &config,
             recovery_multiplier,
         );
+
+        // Stamp origin_planet_seed on first encounter so CurrentPlanet filter works.
+        if let Some(planet_seed) = event.planet_seed
+            && let Some(entry) = journal.entries.get_mut(&event.key)
+            && entry.origin_planet_seed.is_none()
+        {
+            entry.origin_planet_seed = Some(planet_seed);
+        }
     }
 }
 
@@ -1714,6 +1698,23 @@ struct JournalRenderCache {
     detail_spans: Vec<DetailSpan>,
     /// Text for the bottom help bar.
     help: String,
+    /// Cross-reference links available on the currently selected entry.
+    ///
+    /// Each entry is `(relationship_label, target_key, target_name)`. The
+    /// navigation system uses this list to jump to a related entry when Enter
+    /// is pressed. Populated each frame by `compute_journal_panels`.
+    cross_ref_links: Vec<(String, JournalKey, String)>,
+    /// Index of the currently highlighted cross-reference link.
+    ///
+    /// `0` when no cross-references exist (no link is highlighted). Clamped
+    /// to `[0, cross_ref_links.len() - 1]` each frame.
+    selected_cross_ref: usize,
+    /// The journal key of the entry whose cross-references are currently cached.
+    ///
+    /// When `populate_cross_ref_links` finds a different selected entry than this
+    /// key, it resets `selected_cross_ref` to 0 so the link cursor doesn't carry
+    /// over from a different entry.
+    cross_ref_entry_key: Option<JournalKey>,
 }
 
 /// A single line in the entry list panel, carrying its display text and
@@ -1739,15 +1740,18 @@ enum DetailSpanKind {
     /// Qualitative confidence label (e.g. "Uncertain", "Noted", "Confirmed")
     /// rendered after each observation description in a subdued style.
     ConfidenceLabel,
-    /// Section header for the "Related" cross-reference block (e.g. "\n\nRelated").
-    CrossReferenceHeader,
-    /// A single cross-reference link line (e.g. "\n  → Found on: Volcanic Plains").
-    CrossReferenceLink,
-    /// A cross-reference link that is currently highlighted by the link cursor.
-    /// Rendered with a brighter color to signal that Enter will follow it.
-    CrossReferenceLinkSelected,
     /// Placeholder text when the journal is empty.
     Placeholder,
+    /// A cross-reference link in the "Related" section.
+    ///
+    /// The selected link is highlighted with a brighter cyan accent so the
+    /// player can see which one Enter will follow.  Unselected links use a
+    /// muted teal.
+    CrossRef {
+        /// Whether this link is the one currently highlighted by the
+        /// cross-reference cursor (i.e. Enter will follow this link).
+        selected: bool,
+    },
 }
 
 /// A styled segment in the detail panel.  The panel is rebuilt each frame
@@ -1885,8 +1889,146 @@ fn compute_journal_panels(
 
     cache.filter_bar = build_filter_bar_text(state.filter());
     cache.list_lines = build_entry_list_lines(&filtered_entries, &state);
+
+    // ── Cross-reference links ─────────────────────────────────────────
+    //
+    // Query the knowledge graph for relationships on the currently selected
+    // entry so that build_detail_spans can render the "Related" section.
+    // The graph is not a Bevy system parameter here (to respect the 4-param
+    // limit); instead, the caller (this system) reads it from the world
+    // directly via Option<Res<…>>. Since KnowledgeGraphPlugin runs in the
+    // same app, the resource is always present when the journal is visible.
+    // If it is somehow absent (e.g. in lightweight integration tests that
+    // don't register the full plugin set), cross-references are silently
+    // omitted — a graceful fallback.
+    //
+    // cross_ref_links is cleared and rebuilt every frame so it always
+    // reflects the currently selected entry.
+    cache.cross_ref_links.clear();
+    // selected_cross_ref is clamped after rebuild — NOT reset to 0 — so
+    // the player's cursor position survives across frames while they read.
+
+    // KnowledgeGraph is queried by `populate_cross_ref_links`, which runs
+    // next in the same Compute set. That system rebuilds cross_ref_links,
+    // re-runs build_detail_spans_with_cross_refs, and writes cache.help.
+    // This system only clears the stale list so the next system always
+    // starts from a known-empty state.
+
     cache.detail_spans = build_detail_spans(&filtered_entries, &state, !journal.entries.is_empty());
-    cache.help = build_help_text(entry_count, &state);
+    // Write a default help text (no cross-ref count yet). If `populate_cross_ref_links`
+    // runs next (when KnowledgeGraph is registered), it overwrites this with the
+    // final count. Tests that only register `compute_journal_panels` get a valid
+    // help string from this line.
+    cache.help = build_help_text(entry_count, &state, 0);
+}
+
+/// Populates [`JournalRenderCache::cross_ref_links`] from the knowledge
+/// graph for the currently selected journal entry.
+///
+/// Runs in the [`JournalSet::Compute`] set, immediately after
+/// [`compute_journal_panels`], which must clear `cross_ref_links` first
+/// so this system always rebuilds from fresh data.
+///
+/// The system is separate from `compute_journal_panels` to respect the
+/// 4-system-parameter limit: the parent system already uses all four
+/// slots (state, journal query, cache, tracker) and cannot absorb an
+/// additional [`crate::knowledge_graph::KnowledgeGraph`] parameter
+/// without splitting.
+///
+/// If the KnowledgeGraph resource is absent (e.g. lightweight tests that
+/// don't register KnowledgeGraphPlugin), cross-references are silently
+/// omitted — the cache is left empty and the journal renders without a
+/// "Related" section.
+fn populate_cross_ref_links(
+    state: Res<JournalUiState>,
+    player_query: Query<&Journal, With<Player>>,
+    mut cache: ResMut<JournalRenderCache>,
+    graph: Option<Res<crate::knowledge_graph::KnowledgeGraph>>,
+) {
+    // cross_ref_links was cleared by compute_journal_panels already.
+    // If the journal is invisible or the graph is absent, nothing to do.
+    if !state.visible {
+        return;
+    }
+    let Some(graph) = graph else {
+        return;
+    };
+    let Ok(journal) = player_query.single() else {
+        return;
+    };
+
+    // Find the currently selected entry's key.
+    let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
+    sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let filtered: Vec<&JournalEntry> = sorted
+        .into_iter()
+        .filter(|e| matches_filter(e, state.filter()))
+        .collect();
+
+    let Some(selected_entry) = filtered.get(state.selected_index) else {
+        return;
+    };
+
+    // Reset the link cursor when the selected entry has changed since the
+    // last frame so the player always starts at link 0 on a newly-selected entry.
+    if cache.cross_ref_entry_key.as_ref() != Some(&selected_entry.key) {
+        cache.selected_cross_ref = 0;
+        cache.cross_ref_entry_key = Some(selected_entry.key.clone());
+    }
+
+    // Look up the concept node for this journal key.
+    let concept_id = crate::knowledge_graph::ConceptId(selected_entry.key.clone());
+    let Some(node_idx) = graph.lookup(&concept_id) else {
+        // Entry has no graph node yet — no cross-references to show.
+        return;
+    };
+
+    // Collect all relationships and resolve neighbor names.
+    for (neighbor_idx, edge) in graph.relationships(node_idx) {
+        let Some(neighbor_node) = graph.node(neighbor_idx) else {
+            continue;
+        };
+        // Resolve a human-readable name for the neighbor by looking up the
+        // journal entry (if it exists) or falling back to a generic label
+        // derived from the concept category.
+        let target_name = journal
+            .entries
+            .get(&neighbor_node.id.0)
+            .map(|e| e.name.clone())
+            .unwrap_or_else(|| format!("{:?}", neighbor_node.category));
+
+        let rel_label = edge.relationship.display_label().to_string();
+        cache
+            .cross_ref_links
+            .push((rel_label, neighbor_node.id.0.clone(), target_name));
+    }
+
+    // Clamp the selected link cursor so it stays in bounds after the link
+    // list is rebuilt (e.g. if entries were added or removed).
+    let link_count = cache.cross_ref_links.len();
+    if link_count > 0 {
+        cache.selected_cross_ref = cache.selected_cross_ref.min(link_count - 1);
+    } else {
+        cache.selected_cross_ref = 0;
+    }
+
+    // Rebuild the detail spans now that we have cross-reference data, so
+    // the "Related" section appears with correct link highlights.
+    // Clone cross_ref data out of cache before the mutable borrow for detail_spans.
+    // This avoids a simultaneous mutable + immutable borrow of cache.
+    let links_snapshot = cache.cross_ref_links.clone();
+    let selected_cross_ref = cache.selected_cross_ref;
+
+    cache.detail_spans = build_detail_spans_with_cross_refs(
+        &filtered,
+        &state,
+        !journal.entries.is_empty(),
+        &links_snapshot,
+        selected_cross_ref,
+    );
+    // Rebuild the help text to show the Alt+↑↓ / Enter / Backspace hint.
+    cache.help = build_help_text(filtered.len(), &state, links_snapshot.len());
 }
 
 /// Syncs the cached text into the Bevy UI `Text` nodes and toggles
@@ -1903,7 +2045,6 @@ fn sync_journal_ui(
     state: Res<JournalUiState>,
     cache: Res<JournalRenderCache>,
     mut commands: Commands,
-    mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
     list_query: Query<(Entity, Option<&Children>), With<JournalEntryListText>>,
     detail_query: Query<(Entity, Option<&Children>), With<JournalDetailText>>,
     mut texts: ParamSet<(
@@ -1913,16 +2054,12 @@ fn sync_journal_ui(
         Query<&mut Text, With<JournalHelpText>>,
     )>,
 ) {
-    let Ok(mut panel_vis) = panel_query.single_mut() else {
-        return;
-    };
-
+    // Visibility is now managed by DiegeticUiPlugin::sync_readable_surface_visibility.
+    // This system only updates text content; it skips work when the journal is not
+    // visible to avoid rebuilding TextSpan trees every frame while closed.
     if !state.visible {
-        *panel_vis = Visibility::Hidden;
         return;
     }
-
-    *panel_vis = Visibility::Visible;
 
     // ── Entry list: rebuild TextSpan children for per-line coloring ──
     //
@@ -1979,13 +2116,6 @@ fn sync_journal_ui(
     let body_color = TextColor(Color::srgba(0.92, 0.92, 0.88, 1.0));
     let confidence_color = TextColor(Color::srgba(0.6, 0.65, 0.7, 1.0));
     let placeholder_color = TextColor(Color::srgba(0.55, 0.55, 0.50, 1.0));
-    // Cross-reference section header uses the same amber accent as category headers.
-    let cross_ref_header_color = TextColor(Color::srgba(0.75, 0.68, 0.45, 1.0));
-    // Cross-reference links use a cyan-tinted color to signal navigability.
-    let cross_ref_link_color = TextColor(Color::srgba(0.45, 0.80, 0.85, 1.0));
-    // Selected cross-reference link uses a bright white-cyan to signal it is
-    // focused and can be followed with Enter.
-    let cross_ref_link_selected_color = TextColor(Color::srgba(1.0, 1.0, 0.35, 1.0));
 
     if let Ok((detail_entity, detail_children)) = detail_query.single() {
         if let Some(children) = detail_children {
@@ -2005,10 +2135,16 @@ fn sync_journal_ui(
                     DetailSpanKind::CategoryGroupHeader => category_group_color,
                     DetailSpanKind::Body => body_color,
                     DetailSpanKind::ConfidenceLabel => confidence_color,
-                    DetailSpanKind::CrossReferenceHeader => cross_ref_header_color,
-                    DetailSpanKind::CrossReferenceLink => cross_ref_link_color,
-                    DetailSpanKind::CrossReferenceLinkSelected => cross_ref_link_selected_color,
                     DetailSpanKind::Placeholder => placeholder_color,
+                    // Selected cross-reference link: bright cyan to draw the eye.
+                    DetailSpanKind::CrossRef { selected: true } => {
+                        TextColor(Color::srgba(0.3, 0.9, 0.85, 1.0))
+                    }
+                    // Unselected cross-reference link: muted teal — visible but not
+                    // competing with the observation text.
+                    DetailSpanKind::CrossRef { selected: false } => {
+                        TextColor(Color::srgba(0.3, 0.65, 0.62, 1.0))
+                    }
                 };
                 parent.spawn((TextSpan::new(span.text.clone()), span_font.clone(), color));
             }
@@ -2088,10 +2224,32 @@ fn build_entry_list_lines(entries: &[&JournalEntry], state: &JournalUiState) -> 
 /// The `has_any_entries` parameter distinguishes between an empty journal
 /// (shows "No observations yet.") and a filter that produces no results
 /// (shows "No matching entries").
+///
+/// The `cross_ref_links` slice is `(relationship_label, target_name)` pairs
+/// from the knowledge graph, built by `compute_journal_panels`. When the
+/// slice is non-empty a "Related" section is appended to the panel; the
+/// entry at `selected_cross_ref` is highlighted as the link the player
+/// would follow with Enter.
 fn build_detail_spans(
     entries: &[&JournalEntry],
     state: &JournalUiState,
     has_any_entries: bool,
+) -> Vec<DetailSpan> {
+    build_detail_spans_with_cross_refs(entries, state, has_any_entries, &[], 0)
+}
+
+/// Internal implementation of detail-span building that accepts cross-reference
+/// data computed externally.
+///
+/// Separated from `build_detail_spans` to keep both call sites simple: the
+/// cross-ref-free variant (used in tests and no-graph contexts) delegates
+/// here with empty slices.
+fn build_detail_spans_with_cross_refs(
+    entries: &[&JournalEntry],
+    state: &JournalUiState,
+    has_any_entries: bool,
+    cross_ref_links: &[(String, JournalKey, String)],
+    selected_cross_ref: usize,
 ) -> Vec<DetailSpan> {
     if entries.is_empty() {
         let message = if has_any_entries {
@@ -2161,150 +2319,39 @@ fn build_detail_spans(
         }
     }
 
+    // ── Related section (cross-references) ──────────────────────────
+    //
+    // Appended after all observation categories when the knowledge graph
+    // knows of relationships on this entry. Each link shows a relationship
+    // type label and the target entry's name. The currently highlighted
+    // link (selected_cross_ref) is rendered with the CrossRef { selected:
+    // true } kind so it gets the brighter cyan color.
+    if !cross_ref_links.is_empty() {
+        spans.push(DetailSpan {
+            text: "\n\nRelated".to_string(),
+            kind: DetailSpanKind::CategoryGroupHeader,
+        });
+        for (i, (rel_label, _, target_name)) in cross_ref_links.iter().enumerate() {
+            let selected = i == selected_cross_ref;
+            let prefix = if selected { "→ " } else { "  " };
+            spans.push(DetailSpan {
+                text: format!("\n{prefix}{}: {}", rel_label, target_name),
+                kind: DetailSpanKind::CrossRef { selected },
+            });
+        }
+    }
+
     spans
 }
 
-/// Appends cross-reference spans to the detail panel render cache.
-///
-/// Runs in [`JournalSet::Compute`] after [`compute_journal_panels`].  Reads
-/// the [`KnowledgeGraph`] to find all relationships for the currently selected
-/// journal entry and appends a "Related" section to the cached detail spans.
-///
-/// The section is omitted entirely when the selected entry has no cross-
-/// references in the graph, keeping the panel clean for newly discovered
-/// concepts.
-///
-/// Each cross-reference line shows the relationship type label and the display
-/// name of the related concept (looked up from the player's journal).  When
-/// the related concept has no journal entry yet (e.g., a location concept that
-/// predates the journal entry system), the raw key debug representation is
-/// used as a fallback.
-fn append_cross_reference_spans(
-    state: Res<JournalUiState>,
-    player_query: Query<&Journal, With<Player>>,
-    mut cache: ResMut<JournalRenderCache>,
-    graph: Option<Res<KnowledgeGraph>>,
-) {
-    // Only append when the journal is visible and has a selected entry.
-    if !state.visible {
-        return;
-    }
-
-    // KnowledgeGraph may not be present in test apps that don't add
-    // KnowledgeGraphPlugin — skip gracefully rather than panicking.
-    let Some(graph) = graph else {
-        return;
-    };
-
-    let Ok(journal) = player_query.single() else {
-        return;
-    };
-
-    // Sort entries alphabetically — same order as compute_journal_panels.
-    let mut sorted_entries: Vec<&JournalEntry> = journal.entries.values().collect();
-    sorted_entries.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let filtered_entries: Vec<&JournalEntry> = sorted_entries
-        .into_iter()
-        .filter(|entry| matches_filter(entry, state.filter()))
-        .collect();
-
-    let Some(entry) = filtered_entries.get(
-        state
-            .selected_index
-            .min(filtered_entries.len().saturating_sub(1)),
-    ) else {
-        return;
-    };
-
-    // Look up the concept node for the selected entry.
-    let concept_id = ConceptId::new(entry.key.clone());
-    let Some(node_idx) = graph.lookup(&concept_id) else {
-        // No concept node yet — no cross-references to show.
-        return;
-    };
-
-    let relationships = graph.relationships(node_idx);
-    if relationships.is_empty() {
-        return;
-    }
-
-    // Append the "Related" section header.
-    cache.detail_spans.push(DetailSpan {
-        text: "\n\nRelated".to_string(),
-        kind: DetailSpanKind::CrossReferenceHeader,
-    });
-
-    // Append one line per cross-reference, sorted by relationship type label
-    // then by target name for stable display order.
-    let mut ref_lines: Vec<(String, String)> = relationships
-        .iter()
-        .filter_map(|(neighbor_idx, edge)| {
-            let neighbor_node = graph.node(*neighbor_idx)?;
-            let target_key = neighbor_node.id.key();
-            // Prefer the journal entry name; fall back to a key-derived label.
-            let target_name = journal
-                .entries
-                .get(target_key)
-                .map(|e| e.name.clone())
-                .unwrap_or_else(|| format!("{target_key:?}"));
-            let rel_label = relationship_display_label(&edge.relationship).to_string();
-            Some((rel_label, target_name))
-        })
-        .collect();
-
-    ref_lines.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-
-    for (link_idx, (rel_label, target_name)) in ref_lines.iter().enumerate() {
-        // Highlight the link that the cursor is currently on so the player
-        // knows which entry Enter will jump to.
-        let kind = if state.selected_link_index == Some(link_idx) {
-            DetailSpanKind::CrossReferenceLinkSelected
-        } else {
-            DetailSpanKind::CrossReferenceLink
-        };
-        cache.detail_spans.push(DetailSpan {
-            text: format!("\n  \u{2192} {rel_label}: {target_name}"),
-            kind,
-        });
-    }
-}
-
-/// Returns the player-facing label for a [`RelationshipType`].
-///
-/// These labels appear in the "Related" section of the journal detail panel.
-/// They are intentionally terse — the arrow prefix (`→`) already signals
-/// directionality, so the label only needs to name the relationship.
-fn relationship_display_label(rel: &RelationshipType) -> &'static str {
-    match rel {
-        RelationshipType::FoundOn => "Found on",
-        RelationshipType::CombinedWith => "Combined with",
-        RelationshipType::DerivedFrom => "Derived from",
-        RelationshipType::SimilarTo => "Similar to",
-        RelationshipType::ObservedAt => "Observed at",
-    }
-}
-
 /// Builds the bottom help bar showing navigation hints and a page indicator.
-fn build_help_text(entry_count: usize, state: &JournalUiState) -> String {
+fn build_help_text(entry_count: usize, state: &JournalUiState, cross_ref_count: usize) -> String {
     if entry_count == 0 {
         return "J: Close".to_string();
     }
 
     let page_start = state.scroll_offset + 1;
     let page_end = (state.scroll_offset + state.entries_per_page).min(entry_count);
-
-    // When a cross-reference link is focused, show link-specific hints.
-    if state.selected_link_index.is_some() {
-        let back_hint = if state.navigation_stack.can_go_back() {
-            "  Backspace: Cancel"
-        } else {
-            "  Esc: Cancel"
-        };
-        return format!(
-            "\u{2191}\u{2193} Move link  Enter: Follow  {back_hint}  J: Close  [{page_start}-{page_end} of {entry_count}]"
-        );
-    }
 
     // Show active filter status if any filter is applied
     let filter_status = match (&state.filter().category, &state.filter().context) {
@@ -2324,14 +2371,15 @@ fn build_help_text(entry_count: usize, state: &JournalUiState) -> String {
         }
     };
 
-    let back_hint = if state.navigation_stack.can_go_back() {
-        "  Backspace: Back"
+    // Cross-reference hint when links exist.
+    let cross_ref_hint = if cross_ref_count > 0 {
+        "  Alt+↑↓: Link  Enter: Follow  Backspace: Back"
     } else {
         ""
     };
 
     format!(
-        "\u{2191}\u{2193} Navigate  \u{2192}: Links  PgUp/PgDn: Page  Home/End: Jump  Shift+Tab: Context Filter  J: Close{filter_status}{back_hint}  [{page_start}-{page_end} of {entry_count}]"
+        "\u{2191}\u{2193} Navigate  PgUp/PgDn: Page  Home/End: Jump  Shift+Tab: Context Filter  J: Close{filter_status}{cross_ref_hint}  [{page_start}-{page_end} of {entry_count}]"
     )
 }
 

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -97,10 +97,7 @@ fn build_journal_text(journal: &Journal) -> String {
 fn journal_omits_unknown_properties() {
     let mut journal = Journal::default();
     journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -138,10 +135,7 @@ fn journal_includes_fabrication_history() {
 fn journal_shows_thermal_observation_when_present() {
     let mut journal = Journal::default();
     journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "TestMat",
         Observation {
             category: ObservationCategory::ThermalBehavior,
@@ -157,50 +151,22 @@ fn journal_shows_thermal_observation_when_present() {
 
 #[test]
 fn journal_key_material_equality() {
-    let a = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let b = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let c = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
+    let a = JournalKey::MaterialInstance { seed: 42 };
+    let b = JournalKey::MaterialInstance { seed: 42 };
+    let c = JournalKey::MaterialInstance { seed: 99 };
     assert_eq!(a, b);
     assert_ne!(a, c);
 }
 
-/// `planet_seed` participates in `JournalKey::Material` identity: two
-/// otherwise-identical material keys captured on different planets
-/// must be distinct so the journal records them as separate entries.
-/// This is what lets the upcoming context filter (Story 10.3) treat
-/// "Ferrite seen on Planet A" and "Ferrite seen on Planet B" as
-/// independent observations.
+/// `MaterialInstance` keys are equal when seeds match — planet of origin
+/// is stored on the entry, not the key.
 #[test]
-fn journal_key_material_planet_seed_participates_in_equality() {
-    let unknown = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let on_planet_a = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(1),
-    };
-    let on_planet_b = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(2),
-    };
-    let on_planet_a_again = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(1),
-    };
-
-    assert_ne!(unknown, on_planet_a);
-    assert_ne!(on_planet_a, on_planet_b);
-    assert_eq!(on_planet_a, on_planet_a_again);
+fn journal_key_material_instance_equality_is_seed_only() {
+    let a = JournalKey::MaterialInstance { seed: 42 };
+    let b = JournalKey::MaterialInstance { seed: 42 };
+    let c = JournalKey::MaterialInstance { seed: 99 };
+    assert_eq!(a, b);
+    assert_ne!(a, c);
 }
 
 /// Derived `Ord` sorts material keys primarily by `seed`, with
@@ -212,43 +178,19 @@ fn journal_key_material_planet_seed_participates_in_equality() {
 #[test]
 fn journal_key_material_ord_seed_then_planet_seed() {
     let mut keys = vec![
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(0),
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(99),
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(1),
-        },
+        JournalKey::MaterialInstance { seed: 2 },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 1 },
     ];
     keys.sort();
     assert_eq!(
         keys,
         vec![
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: None
-            },
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: Some(1)
-            },
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: Some(99)
-            },
-            JournalKey::Material {
-                seed: 2,
-                planet_seed: Some(0)
-            },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 2 },
         ],
     );
 }
@@ -359,7 +301,16 @@ fn journal_context_biome_equality_is_string_based() {
 // with a single observation so the category dimension can be
 // exercised independently of the context dimension.
 fn entry_with_observation(key: JournalKey, category: ObservationCategory) -> JournalEntry {
+    entry_with_observation_on_planet(key, category, Some(7))
+}
+
+fn entry_with_observation_on_planet(
+    key: JournalKey,
+    category: ObservationCategory,
+    planet_seed: Option<u64>,
+) -> JournalEntry {
     let mut entry = JournalEntry::new(key, "Subject".to_string(), 0);
+    entry.origin_planet_seed = planet_seed;
     entry.add_observation(Observation {
         category,
         confidence: Confidence(0.2),
@@ -376,20 +327,14 @@ fn matches_filter_default_accepts_every_entry() {
     // must pass.  This is the Story 10.3 default behaviour.
     let filter = JournalFilter::default();
     let entry = JournalEntry::new(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Empty".to_string(),
         0,
     );
     assert!(matches_filter(&entry, &filter));
 
     let populated = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(99),
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
     );
     assert!(matches_filter(&populated, &filter));
@@ -405,19 +350,13 @@ fn matches_filter_category_only_keeps_matching_entries() {
     };
 
     let thermal = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::ThermalBehavior,
     );
     assert!(matches_filter(&thermal, &filter));
 
     let surface = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
     );
     assert!(!matches_filter(&surface, &filter));
@@ -432,10 +371,7 @@ fn matches_filter_category_rejects_entry_with_no_observations() {
         context: None,
     };
     let empty = JournalEntry::new(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Empty".to_string(),
         0,
     );
@@ -443,40 +379,32 @@ fn matches_filter_category_rejects_entry_with_no_observations() {
 }
 
 #[test]
-fn matches_filter_current_planet_uses_key_planet_seed() {
-    // CurrentPlanet matches an entry iff its key's planet_seed
-    // equals the filter's seed.  Entries without a recorded planet
-    // (planet_seed == None) are excluded — "unknown provenance"
-    // must not silently masquerade as "current planet".
+fn matches_filter_current_planet_uses_entry_origin_planet_seed() {
+    // CurrentPlanet matches an entry iff its origin_planet_seed equals
+    // the filter's seed. Entries without a recorded planet are excluded.
     let filter = JournalFilter {
         category: None,
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
 
-    let on_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+    let on_planet = entry_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
+        Some(7),
     );
     assert!(matches_filter(&on_planet, &filter));
 
-    let other_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(8),
-        },
+    let other_planet = entry_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
+        Some(99),
     );
     assert!(!matches_filter(&other_planet, &filter));
 
-    let no_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+    let no_planet = entry_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 3 },
         ObservationCategory::SurfaceAppearance,
+        None,
     );
     assert!(!matches_filter(&no_planet, &filter));
 }
@@ -489,9 +417,10 @@ fn matches_filter_current_planet_excludes_fabrications() {
         category: None,
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
-    let fab = entry_with_observation(
+    let fab = entry_with_observation_on_planet(
         JournalKey::Fabrication { output_seed: 42 },
         ObservationCategory::FabricationResult,
+        None, // fabrications have no planet origin
     );
     assert!(!matches_filter(&fab, &filter));
 }
@@ -502,10 +431,7 @@ fn matches_filter_combined_uses_and_logic() {
     // 2x2 truth table for an entry on planet 7 with a Surface
     // observation against a Surface + planet 7 filter.
     let entry = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
     );
 
@@ -548,37 +474,29 @@ fn matches_filter_current_biome_is_no_op_until_data_capture() {
         }),
     };
     let entry = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
     );
     assert!(matches_filter(&entry, &filter));
 }
 
+/// `planet_seed()` on `JournalKey` only returns a value for Location keys.
+/// Material instances carry planet provenance on `JournalEntry::origin_planet_seed`,
+/// not on the key itself.
 #[test]
 fn journal_key_planet_seed_accessor() {
-    // Material carries an Option<u64>; Fabrication is always None.
     assert_eq!(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(42),
-        }
-        .planet_seed(),
-        Some(42)
-    );
-    assert_eq!(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        }
-        .planet_seed(),
-        None
+        JournalKey::MaterialInstance { seed: 1 }.planet_seed(),
+        None,
+        "material instance keys do not carry planet_seed — it lives on the entry"
     );
     assert_eq!(
         JournalKey::Fabrication { output_seed: 7 }.planet_seed(),
         None
+    );
+    assert_eq!(
+        JournalKey::Location { planet_seed: 42 }.planet_seed(),
+        Some(42)
     );
 }
 
@@ -591,16 +509,15 @@ fn matches_filter_handles_500_entries_quickly() {
     // regressions that would land us in the seconds.
     let entries: Vec<JournalEntry> = (0..500u64)
         .map(|i| {
-            entry_with_observation(
-                JournalKey::Material {
-                    seed: i,
-                    planet_seed: Some(i % 4),
-                },
+            // Give entries a planet seed of i%4 so some match planet 2 and some don't
+            entry_with_observation_on_planet(
+                JournalKey::MaterialInstance { seed: i },
                 if i % 2 == 0 {
                     ObservationCategory::SurfaceAppearance
                 } else {
                     ObservationCategory::ThermalBehavior
                 },
+                Some(i % 4), // seeds 0,1,2,3 → planet 0,1,2,3
             )
         })
         .collect();
@@ -638,10 +555,7 @@ fn journal_key_fabrication_equality() {
 
 #[test]
 fn journal_key_variants_are_distinct() {
-    let mat = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mat = JournalKey::MaterialInstance { seed: 42 };
     let fab = JournalKey::Fabrication { output_seed: 42 };
     assert_ne!(mat, fab);
 }
@@ -649,10 +563,7 @@ fn journal_key_variants_are_distinct() {
 #[test]
 fn journal_key_serde_round_trip() {
     let keys = vec![
-        JournalKey::Material {
-            seed: 123,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 123 },
         JournalKey::Fabrication { output_seed: 456 },
     ];
     for key in &keys {
@@ -668,48 +579,21 @@ fn journal_key_btreemap_ordering_is_stable() {
     use std::collections::BTreeMap;
     let mut map = BTreeMap::new();
     map.insert(JournalKey::Fabrication { output_seed: 1 }, "fab");
-    map.insert(
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
-        "mat99",
-    );
-    map.insert(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        "mat1",
-    );
+    map.insert(JournalKey::MaterialInstance { seed: 99 }, "mat99");
+    map.insert(JournalKey::MaterialInstance { seed: 1 }, "mat1");
 
     let keys: Vec<_> = map.keys().collect();
     // Derived Ord: enum variants ordered by declaration (Material < Fabrication),
     // then by field values within each variant.
-    assert_eq!(
-        *keys[0],
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None
-        }
-    );
-    assert_eq!(
-        *keys[1],
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None
-        }
-    );
+    assert_eq!(*keys[0], JournalKey::MaterialInstance { seed: 1 });
+    assert_eq!(*keys[1], JournalKey::MaterialInstance { seed: 99 });
     assert_eq!(*keys[2], JournalKey::Fabrication { output_seed: 1 });
 }
 
 #[test]
 fn journal_shows_weight_observation_only_when_present() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 4,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 4 };
     journal.record(
         key.clone(),
         "Ferrite",
@@ -743,10 +627,7 @@ fn journal_shows_weight_observation_only_when_present() {
 
 #[test]
 fn journal_entry_new_sets_timestamps() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let entry = JournalEntry::new(key.clone(), "Ferrite".into(), 100);
     assert_eq!(entry.key, key);
     assert_eq!(entry.name, "Ferrite");
@@ -757,10 +638,7 @@ fn journal_entry_new_sets_timestamps() {
 
 #[test]
 fn journal_entry_add_observation_updates_timestamp() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -777,10 +655,7 @@ fn journal_entry_add_observation_updates_timestamp() {
 
 #[test]
 fn journal_entry_accumulates_multiple_observations() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -808,10 +683,7 @@ fn journal_entry_accumulates_multiple_observations() {
 
 #[test]
 fn journal_entry_observations_by_category() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -848,10 +720,7 @@ fn journal_entry_observations_by_category() {
 #[test]
 fn new_journal_ensure_entry_creates_and_retrieves() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     journal.ensure_entry(key.clone(), "Ferrite", 100);
     journal.ensure_entry(key.clone(), "Ignored Name", 200);
@@ -867,10 +736,7 @@ fn new_journal_ensure_entry_creates_and_retrieves() {
 #[test]
 fn new_journal_record_accumulates_observations() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     journal.record(
         key.clone(),
@@ -902,10 +768,7 @@ fn new_journal_record_accumulates_observations() {
 #[test]
 fn new_journal_different_keys_coexist() {
     let mut journal = Journal::default();
-    let mat_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let mat_key = JournalKey::MaterialInstance { seed: 1 };
     let fab_key = JournalKey::Fabrication { output_seed: 2 };
 
     journal.record(
@@ -938,10 +801,7 @@ fn new_journal_different_keys_coexist() {
 fn new_journal_serde_round_trip() {
     let mut journal = Journal::default();
     journal.record(
-        JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 42 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -968,10 +828,7 @@ fn new_journal_serde_round_trip() {
     assert_eq!(deserialized.entries.len(), 2);
     let ferrite = deserialized
         .entries
-        .get(&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        })
+        .get(&JournalKey::MaterialInstance { seed: 42 })
         .expect("Ferrite entry should exist");
     assert_eq!(ferrite.name, "Ferrite");
     assert_eq!(ferrite.observation_count(), 1);
@@ -994,10 +851,7 @@ fn empty_journal_renders_no_observations_yet() {
 #[test]
 fn single_observation_recorded_correctly() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 55,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 55 };
 
     journal.record(
         key.clone(),
@@ -1031,10 +885,7 @@ fn single_observation_recorded_correctly() {
 
 #[test]
 fn duplicate_observation_same_category_and_description_is_skipped() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -1058,10 +909,7 @@ fn duplicate_observation_same_category_and_description_is_skipped() {
 
 #[test]
 fn duplicate_observation_upgrades_confidence() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -1089,10 +937,7 @@ fn duplicate_observation_upgrades_confidence() {
 
 #[test]
 fn duplicate_does_not_downgrade_confidence() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -1124,10 +969,7 @@ fn duplicate_does_not_downgrade_confidence() {
 #[test]
 fn examine_same_material_twice_does_not_duplicate() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     let observation = Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -1166,10 +1008,7 @@ fn examine_same_material_twice_does_not_duplicate() {
 #[test]
 fn examine_same_material_twice_upgrades_confidence() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     journal.record(
         key.clone(),
@@ -1206,10 +1045,7 @@ fn examine_same_material_twice_upgrades_confidence() {
 
 #[test]
 fn same_category_different_description_is_not_duplicate() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -1236,10 +1072,7 @@ fn same_category_different_description_is_not_duplicate() {
 
 #[test]
 fn same_description_different_category_is_not_duplicate() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
 
     entry.add_observation(Observation {
@@ -1270,10 +1103,7 @@ fn same_description_different_category_is_not_duplicate() {
 #[test]
 fn multiple_observations_for_same_key_accumulate() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 77,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 77 };
 
     // First observation — creates the entry.
     journal.record(
@@ -1390,22 +1220,10 @@ fn multiple_observations_for_same_key_accumulate() {
 fn all_types_serde_round_trip() {
     // ── JournalKey variants ─────────────────────────────────────
     let keys = vec![
-        JournalKey::Material {
-            seed: 0,
-            planet_seed: None,
-        },
-        JournalKey::Material {
-            seed: u64::MAX,
-            planet_seed: None,
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
-        JournalKey::Material {
-            seed: 7,
-            planet_seed: Some(u64::MAX),
-        },
+        JournalKey::MaterialInstance { seed: 0 },
+        JournalKey::MaterialInstance { seed: u64::MAX },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 7 },
         JournalKey::Fabrication { output_seed: 42 },
     ];
     for key in &keys {
@@ -1453,10 +1271,7 @@ fn all_types_serde_round_trip() {
 
     // ── JournalEntry struct ─────────────────────────────────────
     let mut entry = JournalEntry::new(
-        JournalKey::Material {
-            seed: 7,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 7 },
         "Ferrite".into(),
         10,
     );
@@ -1495,10 +1310,7 @@ fn all_types_serde_round_trip() {
     let mut journal = Journal::default();
 
     // Material entry with surface, thermal, and weight observations.
-    let mat_key = JournalKey::Material {
-        seed: 100,
-        planet_seed: None,
-    };
+    let mat_key = JournalKey::MaterialInstance { seed: 100 };
     journal.record(
         mat_key.clone(),
         "Silite",
@@ -1631,14 +1443,8 @@ fn different_keys_stored_independently() {
     // Three keys: two Material keys with different seeds and one
     // Fabrication key whose output_seed numerically equals the first
     // Material seed (verifies variant-level isolation).
-    let mat_a = JournalKey::Material {
-        seed: 10,
-        planet_seed: None,
-    };
-    let mat_b = JournalKey::Material {
-        seed: 20,
-        planet_seed: None,
-    };
+    let mat_a = JournalKey::MaterialInstance { seed: 10 };
+    let mat_b = JournalKey::MaterialInstance { seed: 20 };
     let fab_a = JournalKey::Fabrication { output_seed: 10 };
 
     // Record a surface observation on material A.
@@ -1789,10 +1595,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
     let mut journal = Journal::default();
 
     // ── Material entry with surface, thermal, and weight observations ──
-    let mat_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mat_key = JournalKey::MaterialInstance { seed: 42 };
 
     journal.record(
         mat_key.clone(),
@@ -1838,10 +1641,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
     // ── Second material with only surface observation ───────────────
     // Legacy equivalent: entry with surface_observations only (no thermal
     // or weight).
-    let mat_key_b = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
+    let mat_key_b = JournalKey::MaterialInstance { seed: 99 };
     journal.record(
         mat_key_b,
         "Silite",
@@ -1981,10 +1781,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         let key = if i % 3 == 0 {
             JournalKey::Fabrication { output_seed: i }
         } else {
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            }
+            JournalKey::MaterialInstance { seed: i }
         };
 
         let name = format!("Subject-{i}");
@@ -2046,7 +1843,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
     let material_count = journal
         .entries
         .keys()
-        .filter(|k| matches!(k, JournalKey::Material { .. }))
+        .filter(|k| matches!(k, JournalKey::MaterialInstance { .. }))
         .count();
     let fabrication_count = journal
         .entries
@@ -2094,10 +1891,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     let mut journal = Journal::default();
 
     // ── Material 1: Ferrite ─────────────────────────────────────
-    let key_ferrite = JournalKey::Material {
-        seed: 10,
-        planet_seed: None,
-    };
+    let key_ferrite = JournalKey::MaterialInstance { seed: 10 };
     journal.record(
         key_ferrite.clone(),
         "Ferrite",
@@ -2120,10 +1914,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 2: Silite ──────────────────────────────────────
-    let key_silite = JournalKey::Material {
-        seed: 20,
-        planet_seed: None,
-    };
+    let key_silite = JournalKey::MaterialInstance { seed: 20 };
     journal.record(
         key_silite.clone(),
         "Silite",
@@ -2146,10 +1937,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 3: Volite ──────────────────────────────────────
-    let key_volite = JournalKey::Material {
-        seed: 30,
-        planet_seed: None,
-    };
+    let key_volite = JournalKey::MaterialInstance { seed: 30 };
     journal.record(
         key_volite.clone(),
         "Volite",
@@ -2182,10 +1970,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 4: Crystite (ensures "3+" is exceeded) ─────────
-    let key_crystite = JournalKey::Material {
-        seed: 40,
-        planet_seed: None,
-    };
+    let key_crystite = JournalKey::MaterialInstance { seed: 40 };
     journal.record(
         key_crystite.clone(),
         "Crystite",
@@ -2300,10 +2085,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
 fn make_journal_with_n_entries(n: usize) -> Journal {
     let mut journal = Journal::default();
     for i in 0..n {
-        let key = JournalKey::Material {
-            seed: i as u64,
-            planet_seed: None,
-        };
+        let key = JournalKey::MaterialInstance { seed: i as u64 };
         let name = format!("Material-{i:03}");
         journal.record(
             key,
@@ -2334,8 +2116,6 @@ fn entry_list_shows_selected_entry_with_prefix() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     let list = build_entry_list_text(&entries, &state);
@@ -2355,10 +2135,7 @@ fn entry_list_shows_selected_entry_with_prefix() {
 #[test]
 fn entry_list_shows_observation_count() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     journal.record(
         key.clone(),
         "Ferrite",
@@ -2392,10 +2169,7 @@ fn entry_list_shows_observation_count() {
 #[test]
 fn detail_shows_selected_entry_observations() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     journal.record(
         key,
         "Ferrite",
@@ -2419,8 +2193,6 @@ fn detail_shows_selected_entry_observations() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
@@ -2456,10 +2228,7 @@ fn detail_filtered_empty_shows_no_matching_entries() {
 #[test]
 fn detail_spans_have_correct_kinds() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
     journal.record(
         key.clone(),
         "Ferrite",
@@ -2493,8 +2262,6 @@ fn detail_spans_have_correct_kinds() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     let spans = build_detail_spans(&entries, &state, true);
@@ -2532,10 +2299,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
 
     // Create three entries with distinct observations.
     journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2545,10 +2309,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         },
     );
     journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2558,10 +2319,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         },
     );
     journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Neoite",
         Observation {
             category: ObservationCategory::Weight,
@@ -2588,8 +2346,6 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
     assert!(detail.contains("Ferrite"), "header should be Ferrite");
@@ -2613,8 +2369,6 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
     assert!(detail.contains("Neoite"), "header should be Neoite");
@@ -2638,8 +2392,6 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
     assert!(detail.contains("Silite"), "header should be Silite");
@@ -2660,10 +2412,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
 #[test]
 fn detail_panel_shows_all_observations_for_multi_category_entry() {
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 1 };
 
     journal.record(
         key.clone(),
@@ -2698,10 +2447,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
 
     // Add a second entry to confirm isolation.
     journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2724,8 +2470,6 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let spans = build_detail_spans(&entries, &state, true);
     let detail = detail_spans_to_string(&spans);
@@ -2765,8 +2509,6 @@ fn navigation_clamp_up_from_first_stays_at_first() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate pressing up — selection would go to saturating_sub(1) = 0.
     state.selected_index = state.selected_index.saturating_sub(1);
@@ -2782,8 +2524,6 @@ fn navigation_clamp_down_from_last_stays_at_last() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.selected_index = (state.selected_index + 1).min(4);
     state.clamp_to_entry_count(5);
@@ -2798,8 +2538,6 @@ fn scroll_offset_adjusts_when_selection_moves_past_visible_range() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Move selection to index 4 (past the 3-entry window).
     state.selected_index = 4;
@@ -2820,8 +2558,6 @@ fn scroll_offset_adjusts_when_selection_moves_above_visible_range() {
         scroll_offset: 3,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(10);
     assert_eq!(
@@ -2838,8 +2574,6 @@ fn page_down_moves_selection_by_entries_per_page() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate PageDown: advance by entries_per_page.
     state.selected_index = (state.selected_index + state.entries_per_page).min(20 - 1);
@@ -2857,8 +2591,6 @@ fn page_down_clamps_to_last_entry() {
         scroll_offset: 5,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let entry_count = 10;
     // PageDown from index 8 with page size 5 would overshoot — should clamp to 9.
@@ -2875,8 +2607,6 @@ fn page_up_moves_selection_by_entries_per_page() {
         scroll_offset: 10,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate PageUp: go back by entries_per_page.
     state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
@@ -2895,8 +2625,6 @@ fn page_up_clamps_to_first_entry() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // PageUp from index 2 with page size 5 would underflow — saturating_sub clamps to 0.
     state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
@@ -2913,8 +2641,6 @@ fn home_jumps_to_first_entry() {
         scroll_offset: 30,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate Home key — sets selected_index to 0.
     state.selected_index = 0;
@@ -2931,8 +2657,6 @@ fn end_jumps_to_last_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let entry_count = 50;
     // Simulate End key — sets selected_index to last entry.
@@ -2951,8 +2675,6 @@ fn page_down_adjusts_scroll_offset_past_visible_range() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // PageDown jumps selection to index 3, which is outside window [0..3).
     state.selected_index = (state.selected_index + state.entries_per_page).min(10 - 1);
@@ -2972,8 +2694,6 @@ fn clamp_to_entry_count_zero_entries() {
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(0);
     assert_eq!(state.selected_index, 0);
@@ -2995,8 +2715,6 @@ fn entry_list_respects_scroll_offset_and_page_size() {
         scroll_offset: 3,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     let list = build_entry_list_text(&entries, &state);
@@ -3017,10 +2735,8 @@ fn help_text_shows_page_indicator() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help = build_help_text(42, &state);
+    let help = build_help_text(42, &state, 0);
     assert!(
         help.contains("[1-15 of 42]"),
         "help should show page indicator, got: {help}"
@@ -3030,7 +2746,7 @@ fn help_text_shows_page_indicator() {
 #[test]
 fn help_text_empty_journal() {
     let state = JournalUiState::default();
-    let help = build_help_text(0, &state);
+    let help = build_help_text(0, &state, 0);
     assert!(help.contains("J: Close"), "help should show close hint");
     assert!(
         !help.contains("Navigate"),
@@ -3053,8 +2769,6 @@ fn two_panel_rendering_100_plus_entries_does_not_panic() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(entries.len());
 
@@ -3062,7 +2776,7 @@ fn two_panel_rendering_100_plus_entries_does_not_panic() {
     assert!(!list.is_empty());
     let detail = build_detail_spans(&entries, &state, true);
     assert!(!detail.is_empty());
-    let help = build_help_text(entries.len(), &state);
+    let help = build_help_text(entries.len(), &state, 0);
     assert!(help.contains("of 120"));
 }
 
@@ -3112,10 +2826,7 @@ fn panels_render_without_panic() {
             .expect("player must exist");
         for i in 0..5u64 {
             journal.record(
-                JournalKey::Material {
-                    seed: i,
-                    planet_seed: None,
-                },
+                JournalKey::MaterialInstance { seed: i },
                 &format!("Mat-{i}"),
                 Observation {
                     category: ObservationCategory::SurfaceAppearance,
@@ -3163,8 +2874,6 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let lines = build_entry_list_lines(&entries, &state);
     assert_eq!(lines.len(), 3);
@@ -3179,8 +2888,6 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 4,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let lines = build_entry_list_lines(&entries, &state);
     assert_eq!(lines.len(), 3);
@@ -3211,8 +2918,6 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 8,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let lines = build_entry_list_lines(&entries, &state);
     assert_eq!(
@@ -3233,8 +2938,6 @@ fn toggle_close_reopen_preserves_selection_and_scroll() {
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     // Toggle closed.
@@ -3253,19 +2956,34 @@ fn toggle_close_reopen_preserves_selection_and_scroll() {
 /// that runs in-game, not just direct field manipulation.
 #[test]
 fn toggle_visibility_system_preserves_navigation_state() {
+    use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
+
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.add_message::<ToggleJournalIntent>();
+    // Start visible: the journal panel starts Active so JournalUiState.visible = true.
     app.insert_resource(JournalUiState {
         visible: true,
         selected_index: 7,
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
-    app.add_systems(Update, toggle_journal_visibility);
+    // Spawn the JournalPanel with diegetic components so toggle_journal_visibility
+    // can find it.  Start Active (open) to match visible: true above.
+    app.world_mut().spawn((
+        JournalPanel,
+        DiegeticSurface,
+        DiegeticSurfaceKind::Readable {
+            perceivable_range: 0.0,
+            legible_range: 0.0,
+        },
+        DiegeticFocusState::Active,
+    ));
+    app.add_systems(
+        Update,
+        (toggle_journal_visibility, sync_journal_ui_state_from_focus).chain(),
+    );
 
     // ── Close: send one toggle intent. ──────────────────────────
     app.world_mut().write_message(ToggleJournalIntent);
@@ -3321,8 +3039,6 @@ fn navigation_ignored_when_journal_is_hidden() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
@@ -3331,10 +3047,7 @@ fn navigation_ignored_when_journal_is_hidden() {
     let mut journal = Journal::default();
     for i in 0..10 {
         journal.record(
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: i },
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
@@ -3377,18 +3090,13 @@ fn navigation_active_when_journal_is_visible() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     let mut journal = Journal::default();
     for i in 0..10 {
         journal.record(
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: i },
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
@@ -3431,17 +3139,14 @@ fn navigation_first_to_last_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     let mut journal = Journal::default();
     for i in 0..entry_count {
         journal.record(
-            JournalKey::Material {
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3553,17 +3258,12 @@ fn navigation_bounds_single_entry_journal() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     let mut journal = Journal::default();
     journal.record(
-        JournalKey::Material {
-            seed: 0,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 0 },
         "Sole-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -3620,17 +3320,14 @@ fn navigation_bounds_page_keys_at_extremes() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     let mut journal = Journal::default();
     for i in 0..entry_count {
         journal.record(
-            JournalKey::Material {
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3701,8 +3398,6 @@ fn clamp_corrects_out_of_range_selected_index() {
         scroll_offset: 20,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(10);
     assert_eq!(
@@ -3747,17 +3442,14 @@ fn navigation_never_exceeds_bounds_under_key_sequence() {
         scroll_offset: 0,
         entries_per_page,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     let mut journal = Journal::default();
     for i in 0..entry_count {
         journal.record(
-            JournalKey::Material {
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3871,8 +3563,6 @@ fn make_panel_app(initial_entries_per_page: usize) -> App {
         scroll_offset: 0,
         entries_per_page: initial_entries_per_page,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, compute_journal_panels);
     app.world_mut()
@@ -3921,28 +3611,19 @@ fn selection_follows_subject_when_entry_inserted_before_it() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Charlie",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
@@ -3959,10 +3640,7 @@ fn selection_follows_subject_when_entry_inserted_before_it() {
     // index 1 to index 2.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Alpha",
         4,
     );
@@ -3984,37 +3662,25 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Delta",
         4,
     );
@@ -4029,13 +3695,7 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
     // Delete "Bravo".  Sorted list becomes [Alpha, Charlie, Delta].
     // "Charlie" now occupies the old slot (index 1) — that is the
     // nearest entry by sort position.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 2 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4049,10 +3709,7 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 3,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 3 }),
         "tracker must re-anchor onto the nearest entry"
     );
 }
@@ -4066,28 +3723,19 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4102,13 +3750,7 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
     // Delete "Charlie".  Sorted list becomes [Alpha, Bravo].  There
     // is no entry at the old slot (index 2), so the nearest valid
     // entry is the new last one (index 1, "Bravo").
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 3 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4119,10 +3761,7 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 2,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 2 }),
         "tracker must re-anchor onto Bravo"
     );
 }
@@ -4136,19 +3775,13 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
@@ -4160,20 +3793,8 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     app.update();
 
     // Delete both entries.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-    );
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 1 });
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 2 });
     app.update();
 
     let tracker = app.world().resource::<JournalSelectionTracker>();
@@ -4186,10 +3807,7 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     // the new entry rather than wait for a (deleted) prior key.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Charlie",
         10,
     );
@@ -4200,10 +3818,7 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     assert_eq!(state.selected_index, 0);
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 99,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 99 }),
         "tracker must anchor onto the new sole entry"
     );
 }
@@ -4218,28 +3833,19 @@ fn selection_follows_subject_when_entry_deleted_before_it() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4253,13 +3859,7 @@ fn selection_follows_subject_when_entry_deleted_before_it() {
 
     // Delete "Alpha".  Sorted list becomes [Bravo, Charlie].
     // "Charlie" now sits at index 1.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 1 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4297,55 +3897,37 @@ fn new_entry_before_visible_window_keeps_visible_entries_stable() {
     // Sorted order will match insertion order since names are alphabetical.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Charlie",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Echo",
         4,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 5 },
         "Foxtrot",
         5,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 6,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 6 },
         "Golf",
         6,
     );
@@ -4373,10 +3955,7 @@ fn new_entry_before_visible_window_keeps_visible_entries_stable() {
     // from 4 to 5.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Alpha",
         7,
     );
@@ -4403,28 +3982,19 @@ fn new_entry_after_visible_window_does_not_move_view() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4441,10 +4011,7 @@ fn new_entry_after_visible_window_does_not_move_view() {
     // past the visible window).  Nothing in view should change.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Zulu",
         4,
     );
@@ -4475,37 +4042,25 @@ fn new_entry_between_top_and_selection_shifts_only_selection() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Echo",
         4,
     );
@@ -4523,10 +4078,7 @@ fn new_entry_between_top_and_selection_shifts_only_selection() {
     // unchanged at index 0.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Charlie",
         5,
     );
@@ -4583,46 +4135,31 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // Bravo, Delta, Echo, Foxtrot, Hotel.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Delta",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Echo",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Foxtrot",
         4,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 5 },
         "Hotel",
         5,
     );
@@ -4697,10 +4234,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // update to reflect the new total of six.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 10,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 10 },
         "Alpha",
         10,
     );
@@ -4737,10 +4271,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // index advances by one; the highlight must follow.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 11,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 11 },
         "Charlie",
         11,
     );
@@ -4769,10 +4300,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // indicator reflects the new total.  Echo's highlight remains.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 12,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 12 },
         "Zulu",
         12,
     );
@@ -4783,10 +4311,9 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
         let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
         let journal = q.single(app.world()).expect("player must exist");
         assert!(
-            journal.entries.contains_key(&JournalKey::Material {
-                seed: 12,
-                planet_seed: None
-            }),
+            journal
+                .entries
+                .contains_key(&JournalKey::MaterialInstance { seed: 12 }),
             "Zulu entry must be present in the journal after recording"
         );
     }
@@ -4809,10 +4336,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
         let journal = q.single(app.world()).expect("player must exist");
         let echo = journal
             .entries
-            .get(&JournalKey::Material {
-                seed: 3,
-                planet_seed: None,
-            })
+            .get(&JournalKey::MaterialInstance { seed: 3 })
             .expect("Echo entry must still exist");
         assert_eq!(
             echo.observation_count(),
@@ -4825,10 +4349,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 3,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 3 }),
         "tracker must remain anchored on Echo across all three insertions"
     );
 }
@@ -4848,50 +4369,53 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
 /// closed and reopened."
 #[test]
 fn reopen_journal_preserves_same_selected_entry() {
+    use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
+
     let mut app = make_panel_app(15);
     app.add_message::<ToggleJournalIntent>();
-    // Run the visibility toggle before panel reconciliation so any
-    // visibility flip this frame is reflected in the same update().
+    // Spawn the JournalPanel with diegetic components.  Start Active so the
+    // initial JournalUiState.visible = true (set by make_panel_app) is consistent.
+    app.world_mut().spawn((
+        JournalPanel,
+        DiegeticSurface,
+        DiegeticSurfaceKind::Readable {
+            perceivable_range: 0.0,
+            legible_range: 0.0,
+        },
+        DiegeticFocusState::Active,
+    ));
+    // Run toggle → sync_from_focus → compute in order so visibility is consistent
+    // within each update().
     app.add_systems(
         Update,
-        toggle_journal_visibility.before(compute_journal_panels),
+        (toggle_journal_visibility, sync_journal_ui_state_from_focus)
+            .chain()
+            .before(compute_journal_panels),
     );
 
     // Populate four entries.  Sorted alphabetically the order is
     // Alpha (0), Bravo (1), Charlie (2), Delta (3).
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Delta",
         4,
     );
@@ -4966,8 +4490,6 @@ fn shift_tab_cycles_context_filter() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
@@ -4984,10 +4506,7 @@ fn shift_tab_cycles_context_filter() {
 
     // Material from planet 0
     journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Planet0-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -4999,10 +4518,7 @@ fn shift_tab_cycles_context_filter() {
 
     // Material from planet 1
     journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(1),
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Planet1-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5014,10 +4530,7 @@ fn shift_tab_cycles_context_filter() {
 
     // Material with no planet context
     journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Unknown-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5098,8 +4611,6 @@ fn tab_cycles_category_filter() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
@@ -5108,10 +4619,7 @@ fn tab_cycles_category_filter() {
 
     // Add a material entry with SurfaceAppearance observation
     journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Surface-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5123,10 +4631,7 @@ fn tab_cycles_category_filter() {
 
     // Add a material entry with ThermalBehavior observation
     journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(0),
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Thermal-Material",
         Observation {
             category: ObservationCategory::ThermalBehavior,
@@ -5138,10 +4643,7 @@ fn tab_cycles_category_filter() {
 
     // Add a material entry with Weight observation
     journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: Some(0),
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Heavy-Material",
         Observation {
             category: ObservationCategory::Weight,
@@ -5291,10 +4793,8 @@ fn help_text_shows_context_filter_hint_and_status() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_all = build_help_text(10, &state_all);
+    let help_all = build_help_text(10, &state_all, 0);
     assert!(
         help_all.contains("Shift+Tab: Context Filter"),
         "help should show Shift+Tab hint, got: {help_all}"
@@ -5313,10 +4813,8 @@ fn help_text_shows_context_filter_hint_and_status() {
             category: None,
             context: Some(JournalContext::CurrentPlanet { planet_seed: 42 }),
         },
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_planet = build_help_text(10, &state_planet);
+    let help_planet = build_help_text(10, &state_planet, 0);
     assert!(
         help_planet.contains("Shift+Tab: Context Filter"),
         "help should show Shift+Tab hint with filter active, got: {help_planet}"
@@ -5335,10 +4833,8 @@ fn help_text_shows_context_filter_hint_and_status() {
             category: Some(ObservationCategory::SurfaceAppearance),
             context: Some(JournalContext::CurrentPlanet { planet_seed: 42 }),
         },
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_combined = build_help_text(10, &state_combined);
+    let help_combined = build_help_text(10, &state_combined, 0);
     assert!(
         help_combined.contains("[Filter: Category | Current Planet]"),
         "help should show combined filter status, got: {help_combined}"
@@ -5427,8 +4923,6 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
@@ -5702,10 +5196,7 @@ fn test_confidence_accumulation_in_journal_entry() {
     use crate::observation::{Confidence, ConfidenceConfig};
 
     // Create a test journal entry
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(123),
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
     let mut entry = JournalEntry::new(key, "Test Material".to_string(), 0);
 
     // Create a confidence config
@@ -5803,10 +5294,7 @@ fn test_confidence_accumulation_different_descriptions() {
     use crate::observation::{Confidence, ConfidenceConfig};
 
     // Create a test journal entry
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(123),
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
     let mut entry = JournalEntry::new(key, "Test Material".to_string(), 0);
 
     // Create a confidence config
@@ -5863,10 +5351,7 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     use crate::observation::{Confidence, ConfidenceConfig};
 
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     // Create a confidence config with a reasonable accumulation weight
     let config = ConfidenceConfig {
@@ -6028,10 +5513,7 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
     use crate::observation::{Confidence, DescriptorVocabulary};
 
     let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     // Create a descriptor vocabulary to generate confident language
     let vocab = DescriptorVocabulary::default();
@@ -6077,8 +5559,6 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     let detail_spans = build_detail_spans(&entries, &state, true);
@@ -6138,19 +5618,14 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         domain_recovery_multiplier: 2.0,
         passive_recovery_multiplier: 0.8,
         base_observation_weight: 0.25, // Reasonable accumulation rate
+        similarity_threshold: 0.85,
     };
 
     // ── Phase 1: Establish confident language ──────────────────────────────
 
     let mut journal = Journal::default();
-    let thermal_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let weight_key = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
+    let thermal_key = JournalKey::MaterialInstance { seed: 42 };
+    let weight_key = JournalKey::MaterialInstance { seed: 99 };
 
     // Create observations with confident-level confidence (≥0.7)
     let confident_thermal = Observation {
@@ -6408,506 +5883,5 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         final_weight_desc.contains("among the"),
         "Weight language should have recovered to confident: '{}'",
         final_weight_desc
-    );
-}
-
-// ── Cross-reference link navigation tests ───────────────────────────────
-
-#[test]
-fn navigation_stack_push_and_pop() {
-    let mut stack = JournalNavigationStack::new();
-    assert!(!stack.can_go_back(), "empty stack has no history");
-
-    let key_a = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let key_b = JournalKey::Material {
-        seed: 2,
-        planet_seed: None,
-    };
-
-    stack.push(key_a.clone());
-    assert!(stack.can_go_back());
-
-    stack.push(key_b.clone());
-    assert_eq!(stack.pop(), Some(key_b));
-    assert_eq!(stack.pop(), Some(key_a));
-    assert_eq!(stack.pop(), None);
-    assert!(!stack.can_go_back());
-}
-
-#[test]
-fn navigation_stack_respects_max_depth() {
-    let mut stack = JournalNavigationStack {
-        history: Vec::new(),
-        max_depth: 3,
-    };
-
-    for seed in 0..5u64 {
-        stack.push(JournalKey::Material {
-            seed,
-            planet_seed: None,
-        });
-    }
-
-    // Only the last 3 entries should remain.
-    assert_eq!(stack.history.len(), 3);
-    // The oldest retained entry should be seed=2.
-    assert_eq!(
-        stack.history[0],
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None
-        }
-    );
-}
-
-#[test]
-fn selected_link_index_defaults_to_none() {
-    let state = JournalUiState::default();
-    assert_eq!(state.selected_link_index(), None);
-    assert!(!state.can_go_back());
-}
-
-#[test]
-fn cross_reference_link_selected_span_kind_is_distinct() {
-    // Verify that CrossReferenceLinkSelected is a distinct variant from
-    // CrossReferenceLink so the renderer can apply a different color.
-    assert_ne!(
-        DetailSpanKind::CrossReferenceLinkSelected,
-        DetailSpanKind::CrossReferenceLink
-    );
-}
-
-#[test]
-fn help_text_shows_link_hints_when_link_focused() {
-    let mut state = JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: Some(0),
-        navigation_stack: JournalNavigationStack::new(),
-    };
-
-    let help = build_help_text(5, &state);
-    assert!(
-        help.contains("Enter: Follow"),
-        "help should show Enter hint when link focused, got: {help}"
-    );
-    assert!(
-        help.contains("Move link"),
-        "help should show move-link hint when link focused, got: {help}"
-    );
-
-    // With navigation history, Backspace hint should appear.
-    state.navigation_stack.push(JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    });
-    let help_with_back = build_help_text(5, &state);
-    assert!(
-        help_with_back.contains("Backspace"),
-        "help should show Backspace hint when history exists, got: {help_with_back}"
-    );
-}
-
-#[test]
-fn help_text_shows_back_hint_when_history_exists() {
-    let mut state = JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
-    };
-
-    // No history — no back hint.
-    let help_no_back = build_help_text(5, &state);
-    assert!(
-        !help_no_back.contains("Backspace: Back"),
-        "help should not show back hint when no history, got: {help_no_back}"
-    );
-
-    // With history — back hint appears.
-    state.navigation_stack.push(JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    });
-    let help_with_back = build_help_text(5, &state);
-    assert!(
-        help_with_back.contains("Backspace: Back"),
-        "help should show back hint when history exists, got: {help_with_back}"
-    );
-}
-
-/// Cross-reference links appear in the detail panel render cache when the
-/// selected journal entry has relationships in the `KnowledgeGraph`.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1) and "Volcanic Plains"
-///     (Location planet_seed=42).
-///   - A `FoundOn` edge from Ignium → Volcanic Plains in the KnowledgeGraph.
-///   - Journal is visible with Ignium selected (index 0, alphabetically first).
-///
-/// Expected: after running `compute_journal_panels` then
-/// `append_cross_reference_spans`, the render cache contains at least one
-/// `CrossReferenceLink` span whose text includes "Found on" and "Volcanic
-/// Plains".
-#[test]
-fn cross_reference_links_appear_for_entries_with_relationships() {
-    use crate::knowledge_graph::{
-        ConceptCategory, ConceptEdge, ConceptId, KnowledgeGraph, RelationshipType,
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<JournalRenderCache>();
-    app.init_resource::<JournalSelectionTracker>();
-    app.init_resource::<KnowledgeGraph>();
-    app.insert_resource(JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
-    });
-    app.add_systems(
-        Update,
-        (
-            compute_journal_panels,
-            append_cross_reference_spans.after(compute_journal_panels),
-        ),
-    );
-
-    // Spawn a player with a journal containing two entries.
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    // JournalKey has no Location variant yet; represent a location concept
-    // using a Material key with a planet_seed (same convention as knowledge_graph tests).
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    app.world_mut().spawn((
-        Player,
-        {
-            let mut journal = Journal::default();
-            journal.record(
-                material_key.clone(),
-                "Ignium",
-                Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.6),
-                    description: "Reliably withstands heat".to_string(),
-                    recorded_at: 1,
-                },
-            );
-            journal.record(
-                location_key.clone(),
-                "Volcanic Plains",
-                Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.6),
-                    description: "Scorched terrain".to_string(),
-                    recorded_at: 2,
-                },
-            );
-            journal
-        },
-        Transform::default(),
-    ));
-
-    // Build the cross-reference relationship in the KnowledgeGraph.
-    {
-        let mut graph = app.world_mut().resource_mut::<KnowledgeGraph>();
-        let material_node =
-            graph.ensure_concept(ConceptId::new(material_key), ConceptCategory::Material, 1);
-        let location_node =
-            graph.ensure_concept(ConceptId::new(location_key), ConceptCategory::Location, 2);
-        graph.relate(
-            material_node,
-            location_node,
-            ConceptEdge {
-                relationship: RelationshipType::FoundOn,
-                confidence: crate::observation::Confidence(0.8),
-                discovered_at: 1,
-            },
-        );
-    }
-
-    // Run one frame so both systems execute.
-    app.update();
-
-    // Verify the render cache contains a CrossReferenceLink span for the
-    // FoundOn relationship pointing at "Volcanic Plains".
-    let cache = app.world().resource::<JournalRenderCache>();
-
-    let link_spans: Vec<&DetailSpan> = cache
-        .detail_spans
-        .iter()
-        .filter(|s| {
-            matches!(
-                s.kind,
-                DetailSpanKind::CrossReferenceLink | DetailSpanKind::CrossReferenceLinkSelected
-            )
-        })
-        .collect();
-
-    assert!(
-        !link_spans.is_empty(),
-        "expected at least one CrossReferenceLink span in the detail panel, got none. \
-         Full spans: {:?}",
-        cache.detail_spans
-    );
-
-    let combined_text: String = link_spans.iter().map(|s| s.text.as_str()).collect();
-    assert!(
-        combined_text.contains("Found on"),
-        "expected 'Found on' in cross-reference link text, got: {combined_text:?}"
-    );
-    assert!(
-        combined_text.contains("Volcanic Plains"),
-        "expected 'Volcanic Plains' in cross-reference link text, got: {combined_text:?}"
-    );
-
-    // Also verify the "Related" section header is present.
-    let has_related_header = cache
-        .detail_spans
-        .iter()
-        .any(|s| s.kind == DetailSpanKind::CrossReferenceHeader && s.text.contains("Related"));
-    assert!(
-        has_related_header,
-        "expected a CrossReferenceHeader span containing 'Related', got: {:?}",
-        cache.detail_spans
-    );
-}
-
-/// Pressing Enter while a cross-reference link is focused jumps the journal
-/// selection to the related entry.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1) and "Volcanic Plains"
-///     (Material seed=42, planet_seed=Some(42)).
-///   - A `FoundOn` edge from Ignium → Volcanic Plains in the KnowledgeGraph.
-///   - Journal is visible with Ignium selected (index 0, alphabetically first
-///     since "I" < "V").
-///   - `selected_link_index` is `Some(0)` — the FoundOn link is focused.
-///
-/// Expected: after pressing Enter and running `journal_navigation`, the
-/// `selected_index` advances to the position of "Volcanic Plains" in the
-/// sorted, filtered entry list, and `selected_link_index` is cleared.
-#[test]
-fn navigation_enter_on_link_jumps_to_related_entry() {
-    use crate::knowledge_graph::{
-        ConceptCategory, ConceptEdge, ConceptId, KnowledgeGraph, RelationshipType,
-    };
-
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    // Represent the location using a Material key with planet_seed (same
-    // convention used throughout the knowledge_graph tests).
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<ButtonInput<KeyCode>>();
-    app.init_resource::<KnowledgeGraph>();
-    app.insert_resource(JournalUiState {
-        visible: true,
-        // "Ignium" sorts before "Volcanic Plains", so it is at index 0.
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        // Link 0 (the FoundOn → Volcanic Plains link) is focused.
-        selected_link_index: Some(0),
-        navigation_stack: JournalNavigationStack::new(),
-    });
-    app.add_systems(Update, journal_navigation);
-
-    // Build the KnowledgeGraph relationship before spawning the player.
-    {
-        let mut graph = app.world_mut().resource_mut::<KnowledgeGraph>();
-        let material_node = graph.ensure_concept(
-            ConceptId::new(material_key.clone()),
-            ConceptCategory::Material,
-            1,
-        );
-        let location_node = graph.ensure_concept(
-            ConceptId::new(location_key.clone()),
-            ConceptCategory::Location,
-            2,
-        );
-        graph.relate(
-            material_node,
-            location_node,
-            ConceptEdge {
-                relationship: RelationshipType::FoundOn,
-                confidence: crate::observation::Confidence(0.8),
-                discovered_at: 1,
-            },
-        );
-    }
-
-    // Spawn a player with both journal entries.
-    let mut journal = Journal::default();
-    journal.record(
-        material_key.clone(),
-        "Ignium",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Reliably withstands heat".to_string(),
-            recorded_at: 1,
-        },
-    );
-    journal.record(
-        location_key.clone(),
-        "Volcanic Plains",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Scorched terrain".to_string(),
-            recorded_at: 2,
-        },
-    );
-    app.world_mut()
-        .spawn((Player, journal, Transform::default()));
-
-    // Press Enter to follow the focused link.
-    app.world_mut()
-        .resource_mut::<ButtonInput<KeyCode>>()
-        .press(KeyCode::Enter);
-
-    app.update();
-
-    let state = app.world().resource::<JournalUiState>();
-
-    // "Volcanic Plains" sorts after "Ignium", so its index in the
-    // alphabetically-sorted two-entry list is 1.
-    assert_eq!(
-        state.selected_index, 1,
-        "Enter on FoundOn link should jump selection to 'Volcanic Plains' at index 1, \
-          got index {}",
-        state.selected_index
-    );
-
-    // The link cursor should be cleared after following the link.
-    assert_eq!(
-        state.selected_link_index, None,
-        "selected_link_index should be cleared after following a cross-reference link"
-    );
-
-    // The previous entry (Ignium) should have been pushed onto the navigation stack.
-    assert!(
-        state.navigation_stack.can_go_back(),
-        "navigation stack should contain the previous entry after following a link"
-    );
-}
-
-/// Pressing Backspace while the navigation stack has history returns the
-/// journal selection to the previously-visited entry.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1, index 0) and
-///     "Volcanic Plains" (Material seed=42, planet_seed=Some(42), index 1).
-///   - The navigation stack already contains the Ignium key (simulating that
-///     the player followed a link from Ignium to Volcanic Plains).
-///   - Journal is visible with "Volcanic Plains" selected (index 1).
-///   - No link is focused (`selected_link_index` is `None`).
-///
-/// Expected: after pressing Backspace and running `journal_navigation`, the
-/// `selected_index` returns to 0 ("Ignium") and the navigation stack is
-/// empty.
-#[test]
-fn back_navigation_returns_to_previous_entry() {
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<ButtonInput<KeyCode>>();
-    app.init_resource::<KnowledgeGraph>();
-
-    // Start with "Volcanic Plains" selected (index 1) and Ignium on the stack.
-    let mut nav_stack = JournalNavigationStack::new();
-    nav_stack.push(material_key.clone());
-    app.insert_resource(JournalUiState {
-        visible: true,
-        selected_index: 1,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: nav_stack,
-    });
-    app.add_systems(Update, journal_navigation);
-
-    // Spawn a player with both journal entries.
-    let mut journal = Journal::default();
-    journal.record(
-        material_key.clone(),
-        "Ignium",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Reliably withstands heat".to_string(),
-            recorded_at: 1,
-        },
-    );
-    journal.record(
-        location_key.clone(),
-        "Volcanic Plains",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Scorched terrain".to_string(),
-            recorded_at: 2,
-        },
-    );
-    app.world_mut()
-        .spawn((Player, journal, Transform::default()));
-
-    // Press Backspace to go back.
-    app.world_mut()
-        .resource_mut::<ButtonInput<KeyCode>>()
-        .press(KeyCode::Backspace);
-
-    app.update();
-
-    let state = app.world().resource::<JournalUiState>();
-
-    // Selection should have returned to "Ignium" at index 0.
-    assert_eq!(
-        state.selected_index, 0,
-        "Backspace should return selection to 'Ignium' at index 0, got index {}",
-        state.selected_index
-    );
-
-    // The navigation stack should now be empty.
-    assert!(
-        !state.navigation_stack.can_go_back(),
-        "navigation stack should be empty after back-navigation"
     );
 }

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -1,766 +1,416 @@
-//! Knowledge graph types — concept nodes, edges, and the graph resource for
-//! the cross-reference system.
+//! Knowledge graph — the player's associative web of discovered concepts.
 //!
-//! The knowledge graph is the player's associative web of discovered concepts.
-//! Each concept corresponds to a journal entry (identified by [`JournalKey`]) and
-//! carries metadata about when it was discovered and how confident the player is
-//! in their understanding of it.
+//! This module implements the `KnowledgeGraph` resource backed by
+//! [`petgraph::Graph`] as specified in the data-architecture decision.
+//! The graph stores concept nodes ([`ConceptNode`]) and typed relationship
+//! edges ([`ConceptEdge`]) that are accumulated as the player observes
+//! the world.
 //!
-//! This module defines the node-level types, edge types, the [`KnowledgeGraph`]
-//! resource backed by `petgraph::Graph`, and the [`KnowledgeGraphPlugin`] that
-//! wires the [`update_knowledge_graph`] system into the Bevy app.
+//! # Design principles
+//!
+//! * **Observation-gated:** No edge or node is ever created without an
+//!   observation event. The graph never infers connections the player
+//!   hasn't personally made.
+//! * **Deterministic:** BFS traversal order follows petgraph's stable
+//!   internal edge order. Timeline entries are appended in tick order,
+//!   which is guaranteed monotone by the game clock.
+//! * **Serializable:** The full graph round-trips through serde via
+//!   petgraph's `serde-1` feature plus hand-implemented index maps.
 
-use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::Path;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use bevy::prelude::*;
-use petgraph::graph::NodeIndex;
+use petgraph::Direction;
+use petgraph::graph::{Graph, NodeIndex};
 use petgraph::visit::EdgeRef;
-use petgraph::{Direction, Graph};
 use serde::{Deserialize, Serialize};
 
-use crate::journal::{JournalKey, RecordObservation};
-use crate::materials::{MaterialCatalog, cosine_similarity};
+use crate::journal::JournalKey;
 use crate::observation::Confidence;
 
 // ── Plugin ────────────────────────────────────────────────────────────────
 
-/// Plugin that initialises the [`KnowledgeGraph`] resource and registers the
-/// [`update_knowledge_graph`] system.
-///
-/// Must be added after [`crate::journal::JournalPlugin`] because it reads
-/// [`RecordObservation`] messages that the journal plugin registers.
+/// Registers the [`KnowledgeGraph`] resource and the
+/// [`update_knowledge_graph`] system that populates it from
+/// [`crate::journal::RecordObservation`] messages.
 pub struct KnowledgeGraphPlugin;
-
-/// Path to the knowledge-graph tuning configuration file.
-const KNOWLEDGE_GRAPH_CONFIG_PATH: &str = "assets/config/knowledge_graph.toml";
 
 impl Plugin for KnowledgeGraphPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<KnowledgeGraph>()
-            .add_systems(PreStartup, load_knowledge_graph_config)
-            .add_systems(Update, update_knowledge_graph);
+        app.init_resource::<KnowledgeGraph>().add_systems(
+            Update,
+            (
+                update_knowledge_graph
+                    .in_set(crate::journal::JournalSet::Navigate)
+                    .after(crate::journal::apply_observations),
+                detect_similar_on_observation
+                    .in_set(crate::journal::JournalSet::Navigate)
+                    .after(update_knowledge_graph),
+            ),
+        );
     }
 }
 
-// ── System ────────────────────────────────────────────────────────────────
+// ── Concept identity ──────────────────────────────────────────────────────
 
-/// Map a [`JournalKey`] to its [`ConceptCategory`].
+/// Unique concept identifier — wraps a [`JournalKey`] so the graph and the
+/// journal share the same identity space with no mapping step.
 ///
-/// Materials map to [`ConceptCategory::Material`], fabrication outputs map to
-/// [`ConceptCategory::Fabrication`]. Location keys (when they exist) will map
-/// to [`ConceptCategory::Location`]; for now any key passed as a
-/// `context_location` is treated as a location concept.
-fn category_from_key(key: &JournalKey) -> ConceptCategory {
-    match key {
-        JournalKey::Material { .. } => ConceptCategory::Material,
-        JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
-    }
-}
-
-/// Default minimum cosine similarity score required to create a
-/// [`RelationshipType::SimilarTo`] edge.
-///
-/// Two materials must share at least 85% directional similarity across their
-/// five-dimensional property vector (density, thermal_resistance, reactivity,
-/// conductivity, toxicity) before the system considers them "similar."
-///
-/// This value is the fallback used when `assets/config/knowledge_graph.toml`
-/// is absent or malformed. The live value is stored in [`KnowledgeGraphConfig`].
-const DEFAULT_SIMILARITY_SCORE_THRESHOLD: f32 = 0.85;
-
-/// Default minimum concept node confidence required on BOTH materials before a
-/// [`RelationshipType::SimilarTo`] edge is created.
-///
-/// This maps to the `Observed` tier boundary (≥ 0.3). The player must have
-/// gathered enough evidence about both materials before the system surfaces
-/// the connection — no free inferences from a single tentative observation.
-///
-/// This value is the fallback used when `assets/config/knowledge_graph.toml`
-/// is absent or malformed. The live value is stored in [`KnowledgeGraphConfig`].
-const DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD: f32 = 0.3;
-
-// ── Config resource ───────────────────────────────────────────────────────
-
-fn default_similarity_score_threshold() -> f32 {
-    DEFAULT_SIMILARITY_SCORE_THRESHOLD
-}
-
-fn default_similarity_confidence_threshold() -> f32 {
-    DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD
-}
-
-/// Runtime tuning configuration for the knowledge-graph system.
-///
-/// Loaded from `assets/config/knowledge_graph.toml` during `PreStartup`.
-/// Falls back to compiled-in defaults if the file is absent or malformed so
-/// that the game always starts cleanly.
-///
-/// All thresholds are data-driven to allow tuning without recompilation.
-#[derive(Resource, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct KnowledgeGraphConfig {
-    /// Minimum cosine similarity score (0.0–1.0) required to create a
-    /// [`RelationshipType::SimilarTo`] edge between two materials.
-    ///
-    /// Higher values require materials to be more alike before the journal
-    /// surfaces the connection. Typical range: 0.7–0.95.
-    #[serde(default = "default_similarity_score_threshold")]
-    pub similarity_score_threshold: f32,
-
-    /// Minimum [`Confidence`] value required on BOTH material concept nodes
-    /// before a [`RelationshipType::SimilarTo`] edge is created.
-    ///
-    /// Prevents the system from surfacing connections the player hasn't earned
-    /// through observation. Maps to the `Observed` tier boundary. Typical
-    /// range: 0.2–0.5.
-    #[serde(default = "default_similarity_confidence_threshold")]
-    pub similarity_confidence_threshold: f32,
-}
-
-impl Default for KnowledgeGraphConfig {
-    fn default() -> Self {
-        Self {
-            similarity_score_threshold: DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-            similarity_confidence_threshold: DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD,
-        }
-    }
-}
-
-/// Load [`KnowledgeGraphConfig`] from `assets/config/knowledge_graph.toml`.
-///
-/// Follows the standard pattern used throughout the codebase: attempt to load
-/// from the config file, fall back to defaults if the file is missing or
-/// malformed. Logs appropriate warnings for debugging.
-fn load_knowledge_graph_config(mut commands: Commands) {
-    let config = if Path::new(KNOWLEDGE_GRAPH_CONFIG_PATH).exists() {
-        match fs::read_to_string(KNOWLEDGE_GRAPH_CONFIG_PATH) {
-            Ok(contents) => match toml::from_str::<KnowledgeGraphConfig>(&contents) {
-                Ok(cfg) => {
-                    info!("Loaded knowledge graph config from {KNOWLEDGE_GRAPH_CONFIG_PATH}");
-                    cfg
-                }
-                Err(error) => {
-                    warn!("Malformed {KNOWLEDGE_GRAPH_CONFIG_PATH}, using defaults: {error}");
-                    KnowledgeGraphConfig::default()
-                }
-            },
-            Err(error) => {
-                warn!("Could not read {KNOWLEDGE_GRAPH_CONFIG_PATH}, using defaults: {error}");
-                KnowledgeGraphConfig::default()
-            }
-        }
-    } else {
-        info!("{KNOWLEDGE_GRAPH_CONFIG_PATH} not found, using defaults");
-        KnowledgeGraphConfig::default()
-    };
-
-    commands.insert_resource(config);
-}
-
-/// Compare `subject` against every material in `catalog` and return the seeds
-/// and similarity scores of materials that exceed `threshold`.
-///
-/// The subject seed is included in the catalog but the caller is responsible
-/// for skipping self-comparisons (seed == subject_seed).
-///
-/// Returns a `Vec<(seed, similarity_score)>` sorted by descending similarity.
-pub fn detect_similarity(
-    subject_seed: u64,
-    subject: &crate::materials::GameMaterial,
-    catalog: &MaterialCatalog,
-    threshold: f32,
-) -> Vec<(u64, f32)> {
-    let subject_vec = subject.property_vector();
-    let mut results: Vec<(u64, f32)> = catalog
-        .seeds()
-        .filter(|&&seed| seed != subject_seed)
-        .filter_map(|&seed| {
-            let other = catalog.get_by_seed(seed)?;
-            let sim = cosine_similarity(&subject_vec, &other.property_vector());
-            if sim >= threshold {
-                Some((seed, sim))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Deterministic ordering: highest similarity first, then by seed for ties.
-    results.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(a.0.cmp(&b.0))
-    });
-    results
-}
-
-/// System that processes [`RecordObservation`] messages and builds cross-references
-/// in the [`KnowledgeGraph`].
-///
-/// For each observation the system:
-///
-/// 1. Ensures a concept node exists for the observation subject.
-/// 2. If the observation carries a `context_location`, creates a `FoundOn` edge
-///    (for materials) or `ObservedAt` edge (for other subjects) between the
-///    subject and the location concept.
-/// 3. If the observation is for a [`JournalKey::Fabrication`] output and
-///    `input_seeds` are provided, creates `DerivedFrom` edges from the output
-///    concept to each input material concept, and `CombinedWith` edges between
-///    each pair of input materials.
-///
-/// All edges are bidirectional (enforced by [`KnowledgeGraph::relate`]).
-/// No cross-reference is created without an observation event — the system
-/// never infers connections the player hasn't made.
-pub fn update_knowledge_graph(
-    mut observations: MessageReader<RecordObservation>,
-    mut graph: ResMut<KnowledgeGraph>,
-    time: Res<Time>,
-    catalog: Res<MaterialCatalog>,
-    kg_config: Res<KnowledgeGraphConfig>,
-) {
-    let tick = time.elapsed().as_millis() as u64;
-
-    for obs in observations.read() {
-        let subject_category = category_from_key(&obs.key);
-        let subject_node =
-            graph.ensure_concept(ConceptId::new(obs.key.clone()), subject_category, tick);
-
-        // Update the concept node's confidence to reflect the latest observation.
-        // This is required so that the SimilarTo check can gate on both materials
-        // being at Observed tier or above (confidence ≥ 0.3).
-        if let Some(node) = graph.node_mut(subject_node) {
-            node.confidence.accumulate(obs.observation.confidence.0);
-        }
-
-        // ── Location cross-reference ──────────────────────────────────────
-        // If the observation has a location context, link the subject to that
-        // location. Materials use FoundOn; other subjects use ObservedAt.
-        if let Some(location_key) = &obs.context_location {
-            let location_node = graph.ensure_concept(
-                ConceptId::new(location_key.clone()),
-                ConceptCategory::Location,
-                tick,
-            );
-
-            let relationship = match &obs.key {
-                JournalKey::Material { .. } => RelationshipType::FoundOn,
-                JournalKey::Fabrication { .. } => RelationshipType::ObservedAt,
-            };
-
-            graph.relate(
-                subject_node,
-                location_node,
-                ConceptEdge::new(relationship, obs.observation.confidence, tick),
-            );
-        }
-
-        // ── Fabrication cross-references ──────────────────────────────────
-        // For fabrication outputs, create DerivedFrom edges to each input
-        // material and CombinedWith edges between each pair of inputs.
-        if let JournalKey::Fabrication { .. } = &obs.key {
-            // Collect NodeIndexes for all input materials first so we can
-            // create CombinedWith edges between them without borrowing issues.
-            let mut input_nodes: Vec<NodeIndex> = Vec::with_capacity(obs.input_seeds.len());
-
-            for &input_seed in &obs.input_seeds {
-                let input_key = JournalKey::Material {
-                    seed: input_seed,
-                    planet_seed: None,
-                };
-                let input_node = graph.ensure_concept(
-                    ConceptId::new(input_key),
-                    ConceptCategory::Material,
-                    tick,
-                );
-                input_nodes.push(input_node);
-
-                // Fabrication is directly observed — confidence is 1.0.
-                graph.relate(
-                    subject_node,
-                    input_node,
-                    ConceptEdge::new(RelationshipType::DerivedFrom, Confidence(1.0), tick),
-                );
-            }
-
-            // CombinedWith edges between every pair of input materials.
-            // For two inputs A and B: A CombinedWith B (and B CombinedWith A
-            // via relate's bidirectionality).
-            for i in 0..input_nodes.len() {
-                for j in (i + 1)..input_nodes.len() {
-                    graph.relate(
-                        input_nodes[i],
-                        input_nodes[j],
-                        ConceptEdge::new(RelationshipType::CombinedWith, Confidence(1.0), tick),
-                    );
-                }
-            }
-        }
-
-        // ── Similarity cross-references ───────────────────────────────────
-        // For material observations, compare the subject against all known
-        // materials in the catalog. SimilarTo edges are only created when
-        // BOTH materials are at Observed tier or above (confidence ≥ 0.3),
-        // ensuring the player has earned the connection through observation.
-        if let JournalKey::Material {
-            seed: subject_seed, ..
-        } = &obs.key
-        {
-            let subject_confidence = graph
-                .node(subject_node)
-                .map(|n| n.confidence)
-                .unwrap_or(Confidence(0.0));
-
-            // Only proceed if the subject material itself is at Observed tier.
-            if subject_confidence.0 >= kg_config.similarity_confidence_threshold {
-                let subject_mat = catalog.get_by_seed(*subject_seed).cloned();
-
-                if let Some(subject_mat) = subject_mat {
-                    let similar_pairs = detect_similarity(
-                        *subject_seed,
-                        &subject_mat,
-                        &catalog,
-                        kg_config.similarity_score_threshold,
-                    );
-
-                    for (other_seed, similarity_score) in similar_pairs {
-                        // Skip self-comparison.
-                        if other_seed == *subject_seed {
-                            continue;
-                        }
-
-                        let other_key = JournalKey::Material {
-                            seed: other_seed,
-                            planet_seed: None,
-                        };
-                        let other_id = ConceptId::new(other_key.clone());
-
-                        // Only create the edge if the other material is also
-                        // known to the graph at Observed tier or above.
-                        // The player must have earned confidence in both.
-                        let other_node_opt = graph.lookup(&other_id);
-                        let other_confidence = other_node_opt
-                            .and_then(|n| graph.node(n))
-                            .map(|n| n.confidence)
-                            .unwrap_or(Confidence(0.0));
-
-                        if other_confidence.0 < kg_config.similarity_confidence_threshold {
-                            continue;
-                        }
-
-                        let other_node =
-                            graph.ensure_concept(other_id, ConceptCategory::Material, tick);
-
-                        graph.relate(
-                            subject_node,
-                            other_node,
-                            ConceptEdge::new(
-                                RelationshipType::SimilarTo,
-                                Confidence(similarity_score),
-                                tick,
-                            ),
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ── Concept identity ─────────────────────────────────────────────────────
-
-/// Unique concept identifier — wraps a [`JournalKey`] so every journal entry
-/// has a corresponding concept node in the knowledge graph.
-///
-/// The one-to-one mapping between `ConceptId` and `JournalKey` means that
-/// creating a concept node for a journal entry is always unambiguous: the
-/// concept's identity *is* the journal key. This avoids a separate ID space
-/// that could drift out of sync with the journal.
+/// Equality and hashing match those of the wrapped key, giving O(1) map
+/// lookups in [`KnowledgeGraph::concept_index`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConceptId(pub JournalKey);
 
-impl ConceptId {
-    /// Create a new concept identifier from a journal key.
-    pub fn new(key: JournalKey) -> Self {
-        Self(key)
-    }
+// ── Concept categories ────────────────────────────────────────────────────
 
-    /// Borrow the underlying journal key.
-    pub fn key(&self) -> &JournalKey {
-        &self.0
-    }
-}
-
-impl From<JournalKey> for ConceptId {
-    fn from(key: JournalKey) -> Self {
-        Self(key)
-    }
-}
-
-// ── Concept category ─────────────────────────────────────────────────────
-
-/// Encyclopedia-style grouping for concept nodes.
+/// High-level classification used for encyclopedia-style grouping and BFS
+/// category filtering.
 ///
-/// Categories allow the journal's encyclopedia view to group related concepts
-/// together (all materials, all locations, etc.) and let the bounded BFS
-/// traversal optionally filter results to a single category.
-///
-/// **Extensibility:** new categories (Language, Culture, Trade, Species, …)
-/// are added as variants here when their underlying game systems are
-/// implemented. Existing match arms do not need to change because the
-/// category is used for grouping and filtering, not for exhaustive dispatch.
+/// Variants map 1-to-1 onto [`JournalKey`] discriminants — [`ConceptId`]
+/// creation always supplies the correct category, so the graph never
+/// stores an inconsistent category for a node.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ConceptCategory {
-    /// Raw or fabricated materials the player has encountered.
+    /// A raw or discovered material.
     Material,
-    /// Planets, biomes, and other spatial locations.
+    /// A planetary or regional location.
     Location,
-    /// Outputs and processes from the fabrication system.
+    /// A fabrication output.
     Fabrication,
     // Future: Language, Culture, Trade, Species, etc.
 }
 
-// ── Concept node ─────────────────────────────────────────────────────────
+// ── Graph node ────────────────────────────────────────────────────────────
 
-/// A node in the knowledge graph — represents a concept the player has
-/// discovered and accumulated knowledge about.
+/// A node in the knowledge graph — represents a known concept.
 ///
-/// Each node corresponds to exactly one [`JournalEntry`] (via [`ConceptId`]).
-/// The node carries a snapshot of the player's current understanding:
-/// how confident they are overall, when they first encountered the concept,
-/// and which properties they have personally revealed through observation.
-///
-/// `revealed_properties` is a set of string keys rather than a typed enum
-/// so that new game systems can add property names without modifying this
-/// struct. The strings match the property names used by the observation
-/// system (e.g., `"thermal_resistance"`, `"density"`).
-///
-/// [`JournalEntry`]: crate::journal::JournalEntry
+/// Each node is created by [`KnowledgeGraph::ensure_concept`] on first
+/// encounter and is never removed (the graph accumulates monotonically).
+/// The `confidence` field tracks overall certainty in the concept's
+/// existence, which edges then narrow with typed relationship confidence.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConceptNode {
-    /// The unique identifier for this concept, linking it to its journal entry.
+    /// Stable identity linking this node to the corresponding journal entry.
     pub id: ConceptId,
-    /// Encyclopedia category for grouping and BFS filtering.
+    /// Coarse classification for encyclopedia grouping and BFS filtering.
     pub category: ConceptCategory,
-    /// Overall confidence in this concept, aggregated from all observations.
-    ///
-    /// Starts at the confidence of the first observation and accumulates
-    /// as the player gathers more evidence. Used by the `SimilarTo` edge
-    /// creation logic: similarity edges are only created when both concepts
-    /// are at `Observed` tier or above (confidence ≥ 0.3).
+    /// Overall confidence that this concept is real and correctly identified.
     pub confidence: Confidence,
-    /// Game-time tick when the player first encountered this concept.
-    pub discovered_at: u64,
-    /// Set of property keys the player has personally revealed through
-    /// observation (e.g., `"thermal_resistance"`, `"density"`).
+    /// Game-time tick (whole seconds elapsed) when this concept was first added.
     ///
-    /// Only properties the player has *observed* appear here — the system
-    /// never pre-populates this set from hidden material data. This enforces
-    /// the acceptance criterion that no cross-reference is created without
-    /// an observation event.
+    /// Matches the unit used by [`crate::journal::Observation::recorded_at`] so
+    /// the two timestamps are directly comparable.
+    pub discovered_at: u64,
+    /// Which named properties the player has directly observed on this concept.
+    ///
+    /// Property keys are string identifiers matching the observation category
+    /// names so new properties can be added without a code change here.
     pub revealed_properties: HashSet<String>,
 }
 
-impl ConceptNode {
-    /// Create a new concept node with no revealed properties.
-    ///
-    /// The `confidence` is set to the initial observation's confidence value.
-    /// `revealed_properties` starts empty and is populated as the player
-    /// makes observations.
-    pub fn new(
-        id: ConceptId,
-        category: ConceptCategory,
-        confidence: Confidence,
-        discovered_at: u64,
-    ) -> Self {
-        Self {
-            id,
-            category,
-            confidence,
-            discovered_at,
-            revealed_properties: HashSet::new(),
-        }
-    }
+// ── Relationship types ────────────────────────────────────────────────────
 
-    /// Mark a property as revealed by the player.
-    ///
-    /// Idempotent — calling this multiple times with the same key is safe.
-    pub fn reveal_property(&mut self, property: impl Into<String>) {
-        self.revealed_properties.insert(property.into());
-    }
-
-    /// Whether the player has revealed the named property.
-    pub fn has_property(&self, property: &str) -> bool {
-        self.revealed_properties.contains(property)
-    }
-}
-
-// ── Relationship type ─────────────────────────────────────────────────────
-
-/// The typed relationship between two concept nodes in the knowledge graph.
+/// Types of relationships between journal subjects.
 ///
-/// Each variant describes *how* one concept relates to another. Relationships
-/// are directional: the edge goes from a source concept to a target concept,
-/// and the variant names are written from the source's perspective
-/// (e.g., `FoundOn` means "source was found on target").
-///
-/// **Extensibility:** new relationship types (SpokenBy, TradedAt, UsedIn, …)
-/// are added as variants here when their underlying game systems are
-/// implemented. The `ConceptEdge` struct is unchanged by new variants.
+/// Every edge in the knowledge graph is one of these typed relationships.
+/// The set is exhaustive for Story 10.5 and deliberately extensible —
+/// future systems (language, trade, culture) add variants here without
+/// touching existing match arms.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RelationshipType {
-    /// Source material was found on the target location.
-    ///
-    /// Created automatically when a material observation is recorded with a
-    /// planet/location context.
+    /// A material was found on a specific planet or location.
     FoundOn,
-    /// Source material was combined with the target material in the fabricator.
-    ///
-    /// Created when a fabrication event records both input materials.
+    /// Two materials were combined in the fabricator.
     CombinedWith,
-    /// Source material was derived from the target input material.
-    ///
-    /// Created for fabrication outputs: the output concept links back to each
-    /// input material via `DerivedFrom`.
+    /// An output material was derived from one or more input materials.
     DerivedFrom,
-    /// Source material has similar properties to the target material.
-    ///
-    /// Created automatically when cosine similarity between property vectors
-    /// meets or exceeds the configured threshold, but only when both concepts
-    /// are at `Observed` confidence tier or above. The system never surfaces
-    /// this connection before the player has earned it.
+    /// Two materials share similar measured properties above the similarity
+    /// threshold. Only created when both materials are at `Observed` tier
+    /// or above so the player has earned the insight.
     SimilarTo,
-    /// Source observation was made at the target location.
-    ///
-    /// More general than `FoundOn` — used when the observation subject is not
-    /// a material (e.g., a fabrication event observed at a specific outpost).
+    /// An observation was made at a specific location (weaker than `FoundOn`
+    /// — records a connection without implying the subject originated there).
     ObservedAt,
     // Future: SpokenBy, TradedAt, UsedIn, etc.
 }
 
-// ── Concept edge ──────────────────────────────────────────────────────────
+impl RelationshipType {
+    /// Player-facing label used in the journal "Related" section header
+    /// for each cross-reference link.
+    ///
+    /// These labels are deliberately factual and terse — no flavour text.
+    /// The player draws their own conclusions from the connection.
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            RelationshipType::FoundOn => "Found on",
+            RelationshipType::CombinedWith => "Combined with",
+            RelationshipType::DerivedFrom => "Derived from",
+            RelationshipType::SimilarTo => "Similar to",
+            RelationshipType::ObservedAt => "Observed at",
+        }
+    }
+}
 
-/// A typed, weighted edge in the knowledge graph between two concept nodes.
+// ── Graph edge ────────────────────────────────────────────────────────────
+
+/// A typed, confidence-bearing relationship between two concept nodes.
 ///
-/// Edges are directional (from source to target) and carry a [`RelationshipType`]
-/// that describes the nature of the connection. The `confidence` field
-/// accumulates as the player gathers repeated evidence for the same
-/// relationship — the same edge strengthens rather than duplicating.
-///
-/// `discovered_at` records the game-time tick of the *first* observation that
-/// established this relationship. Subsequent observations that strengthen the
-/// edge do not update this field, preserving the discovery timeline.
-///
-/// Edges are serializable so the full knowledge graph can be saved and
-/// restored across play sessions.
+/// Edges are directional in petgraph but are interpreted as bidirectional
+/// by [`KnowledgeGraph::relationships`], which walks both incoming and
+/// outgoing edges. This keeps storage at half the edges while giving the
+/// UI the "bidirectional links" behaviour specified in the acceptance
+/// criteria.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConceptEdge {
-    /// The nature of the relationship from source concept to target concept.
+    /// The nature of the relationship between the two concepts.
     pub relationship: RelationshipType,
-    /// Accumulated confidence in this relationship.
-    ///
-    /// Starts at the confidence of the first observation that created the edge
-    /// and increases as the player makes additional observations that confirm
-    /// the same connection. Capped at `1.0`.
+    /// How certain the player is that this relationship is real, accumulated
+    /// each time a new observation confirms the same connection.
     pub confidence: Confidence,
-    /// Game-time tick when this relationship was first observed.
+    /// Game-time tick (whole seconds elapsed) when this relationship was
+    /// first established.
     pub discovered_at: u64,
 }
 
-impl ConceptEdge {
-    /// Create a new edge with the given relationship type, confidence, and
-    /// discovery tick.
-    pub fn new(relationship: RelationshipType, confidence: Confidence, discovered_at: u64) -> Self {
-        Self {
-            relationship,
-            confidence,
-            discovered_at,
-        }
-    }
+// ── Knowledge graph resource ──────────────────────────────────────────────
 
-    /// Strengthen this edge by incorporating additional evidence.
-    ///
-    /// The new confidence is the maximum of the current value and the incoming
-    /// value, capped at `1.0`. This ensures that repeated observations of the
-    /// same relationship monotonically increase (or maintain) confidence and
-    /// never decrease it due to a weaker subsequent observation.
-    ///
-    /// `discovered_at` is intentionally *not* updated — the edge retains the
-    /// tick of its first observation.
-    pub fn strengthen(&mut self, additional_confidence: Confidence) {
-        let combined = (self.confidence.0 + additional_confidence.0).min(1.0);
-        self.confidence = Confidence(combined);
-    }
-}
-
-// ── KnowledgeGraph resource ───────────────────────────────────────────────
-
-/// The player's knowledge graph — backed by `petgraph::Graph`.
+/// The player's knowledge graph — per architecture decision, backed by
+/// [`petgraph::Graph`].
 ///
-/// Every concept the player has discovered is a node; every observed
-/// relationship between two concepts is a directed edge. The graph is
-/// undirected in spirit (cross-references are bidirectional) but implemented
-/// as a directed graph so that each edge carries its own [`RelationshipType`]
-/// and the direction encodes the semantic role (e.g., "Material → FoundOn →
-/// Location" vs. "Location → FoundOn → Material" would be two separate edges).
+/// The graph is a directed multigraph: each concept is a node and each
+/// observed relationship is an edge. Most queries treat edges as
+/// undirected (relationships are symmetric in the player's mental model)
+/// but petgraph stores them directed so we can reach them efficiently with
+/// `edges_directed` in both directions.
 ///
-/// Bidirectionality is enforced by [`KnowledgeGraph::relate`], which always
-/// inserts both the forward and reverse edge when a relationship is recorded.
+/// Three indexes give O(1) lookups on top of the O(log n) petgraph
+/// internal structures:
 ///
-/// # Indexes
+/// * `concept_index` — `ConceptId → NodeIndex` for idempotent node creation
+///   and edge wiring.
+/// * `category_index` — `ConceptCategory → Vec<NodeIndex>` for encyclopedia
+///   view ("all known materials") and BFS filtering.
+/// * `timeline` — `(tick, NodeIndex)` pairs in discovery order for the event
+///   log view.
 ///
-/// Three auxiliary indexes are maintained alongside the graph for O(1) or
-/// O(k) lookups that would otherwise require a full graph scan:
-///
-/// - `concept_index`: maps [`ConceptId`] → [`NodeIndex`] for O(1) node lookup.
-/// - `category_index`: maps [`ConceptCategory`] → `Vec<NodeIndex>` for
-///   encyclopedia-style listing of all concepts in a category.
-/// - `timeline`: ordered list of `(tick, NodeIndex)` pairs recording the
-///   discovery order of concepts.
-///
-/// # Serialization
-///
-/// The `petgraph::Graph` type serializes its node and edge weights directly
-/// when the `serde-1` feature is enabled. The auxiliary indexes are derived
-/// from the graph and are therefore re-derived on deserialization rather than
-/// stored, keeping the save file compact and avoiding index/graph drift.
-#[derive(Resource)]
+/// **Serialization strategy:** `petgraph::Graph` serializes cleanly with the
+/// `serde-1` feature. The three indexes are rebuilt from the graph on
+/// deserialization — they are not stored explicitly — ensuring the indexes
+/// always stay consistent with the canonical graph data.
+#[derive(Resource, Debug, Default)]
 pub struct KnowledgeGraph {
-    /// The underlying directed graph. Nodes are [`ConceptNode`]s; edges are
-    /// [`ConceptEdge`]s. Directed so that edge semantics are preserved.
+    /// Core petgraph directed graph with typed nodes and edges.
     graph: Graph<ConceptNode, ConceptEdge>,
-    /// O(1) lookup: [`ConceptId`] → [`NodeIndex`].
-    ///
-    /// Not serialized — rebuilt from the graph on load.
-    #[allow(clippy::zero_sized_map_values)]
+    /// Primary index: `ConceptId → NodeIndex` for O(1) lookups.
     concept_index: HashMap<ConceptId, NodeIndex>,
-    /// Category index for encyclopedia view: category → list of node indexes.
-    ///
-    /// Not serialized — rebuilt from the graph on load.
+    /// Category index: `ConceptCategory → Vec<NodeIndex>` for encyclopedia view.
     category_index: HashMap<ConceptCategory, Vec<NodeIndex>>,
-    /// Timeline of concept discoveries in insertion order: `(tick, NodeIndex)`.
-    ///
-    /// Not serialized — rebuilt from the graph on load.
+    /// Timeline of discoveries in insertion order (monotone by tick).
     timeline: Vec<(u64, NodeIndex)>,
 }
 
-impl Default for KnowledgeGraph {
-    fn default() -> Self {
-        Self {
-            graph: Graph::new(),
-            concept_index: HashMap::new(),
-            category_index: HashMap::new(),
-            timeline: Vec::new(),
-        }
-    }
-}
-
 impl KnowledgeGraph {
-    /// Create an empty knowledge graph.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    // ── Node operations ───────────────────────────────────────────────────
 
-    /// Get or create a concept node for the given [`ConceptId`].
+    /// Get or create a concept node and return its [`NodeIndex`].
     ///
-    /// If the concept already exists, its [`NodeIndex`] is returned unchanged
-    /// and no new node is inserted. If it does not exist, a new node is created
-    /// with the given `category`, an initial confidence of `0.0`, and the
-    /// provided `tick` as its discovery time.
+    /// Idempotent: calling this twice with the same `id` returns the same
+    /// `NodeIndex` and does NOT overwrite the existing node's data. The
+    /// node's `discovered_at` and `confidence` are set only on creation.
     ///
-    /// The concept is also registered in the category index and timeline on
-    /// first insertion.
+    /// Maintains [`Self::concept_index`], [`Self::category_index`], and
+    /// [`Self::timeline`] atomically — all three are always in sync.
     pub fn ensure_concept(
         &mut self,
         id: ConceptId,
         category: ConceptCategory,
         tick: u64,
     ) -> NodeIndex {
-        if let Some(&idx) = self.concept_index.get(&id) {
-            return idx;
+        if let Some(&existing) = self.concept_index.get(&id) {
+            return existing;
         }
 
-        let node = ConceptNode::new(id.clone(), category.clone(), Confidence(0.0), tick);
-        let idx = self.graph.add_node(node);
+        let node = ConceptNode {
+            id: id.clone(),
+            category: category.clone(),
+            confidence: Confidence(0.3), // Start at Tentative/Observed boundary
+            discovered_at: tick,
+            revealed_properties: HashSet::new(),
+        };
 
+        let idx = self.graph.add_node(node);
         self.concept_index.insert(id, idx);
         self.category_index.entry(category).or_default().push(idx);
         self.timeline.push((tick, idx));
-
         idx
     }
 
-    /// Add or strengthen a typed relationship between two concept nodes.
+    /// Look up a concept by its [`ConceptId`].
     ///
-    /// Cross-references are **bidirectional**: calling `relate(from, to, edge)`
-    /// inserts both a forward edge (`from → to`) and a reverse edge
-    /// (`to → from`) with the same relationship type and confidence. This
-    /// satisfies the acceptance criterion that "if Material X links to Planet Y,
-    /// Planet Y links back to Material X."
-    ///
-    /// If an edge with the same [`RelationshipType`] already exists between the
-    /// two nodes in a given direction, it is **strengthened** (confidence
-    /// accumulates) rather than duplicated. This satisfies the criterion that
-    /// "cross-references accumulate — the same relationship strengthens with
-    /// repeated evidence."
-    ///
-    /// # Panics
-    ///
-    /// Panics if `from` or `to` are not valid node indexes in this graph.
-    pub fn relate(&mut self, from: NodeIndex, to: NodeIndex, edge: ConceptEdge) {
-        // Forward edge: from → to
-        Self::upsert_edge(&mut self.graph, from, to, edge.clone());
-        // Reverse edge: to → from (same relationship type, same confidence)
-        Self::upsert_edge(&mut self.graph, to, from, edge);
+    /// Returns `None` when the concept has not yet been observed. Callers
+    /// use [`ensure_concept`](Self::ensure_concept) to create on first
+    /// encounter and `lookup` only when they need to assert existence.
+    pub fn lookup(&self, id: &ConceptId) -> Option<NodeIndex> {
+        self.concept_index.get(id).copied()
     }
 
-    /// Insert a new edge or strengthen an existing one with the same
-    /// relationship type between the same pair of nodes.
-    fn upsert_edge(
-        graph: &mut Graph<ConceptNode, ConceptEdge>,
-        from: NodeIndex,
-        to: NodeIndex,
-        new_edge: ConceptEdge,
-    ) {
-        // Search for an existing edge with the same relationship type.
-        let existing = graph
-            .edges_directed(from, Direction::Outgoing)
-            .find(|e| e.target() == to && e.weight().relationship == new_edge.relationship)
+    /// Get a reference to the node data for a given index.
+    ///
+    /// Returns `None` if the index is invalid (should not happen during
+    /// normal gameplay since indexes are never removed).
+    pub fn node(&self, idx: NodeIndex) -> Option<&ConceptNode> {
+        self.graph.node_weight(idx)
+    }
+
+    // ── Edge operations ───────────────────────────────────────────────────
+
+    /// Add or strengthen a relationship between two concepts.
+    ///
+    /// If an edge of the same [`RelationshipType`] already exists between
+    /// `from` and `to`, its confidence is accumulated (diminishing returns)
+    /// rather than a duplicate edge being added. This satisfies the
+    /// acceptance criterion that "cross-references accumulate — the same
+    /// relationship strengthens with repeated evidence".
+    ///
+    /// Direction: `from → to`. [`Self::relationships`] exposes both
+    /// directions to callers, so the UI sees the edge regardless of which
+    /// side it queries from.
+    pub fn relate(&mut self, from: NodeIndex, to: NodeIndex, edge: ConceptEdge) {
+        // Look for an existing edge of the same type to strengthen.
+        let existing = self
+            .graph
+            .edges_connecting(from, to)
+            .find(|e| e.weight().relationship == edge.relationship)
             .map(|e| e.id());
 
         if let Some(edge_id) = existing {
-            graph[edge_id].strengthen(new_edge.confidence);
+            // Accumulate evidence rather than duplicating.
+            if let Some(existing_edge) = self.graph.edge_weight_mut(edge_id) {
+                existing_edge.confidence.accumulate(0.2);
+            }
         } else {
-            graph.add_edge(from, to, new_edge);
+            self.graph.add_edge(from, to, edge);
         }
     }
 
-    /// Get all relationships for a concept node — returns `(neighbor NodeIndex,
-    /// &ConceptEdge)` pairs for every outgoing edge from this node.
+    /// All relationships for a concept, in both directions.
     ///
-    /// Because [`KnowledgeGraph::relate`] always inserts both a forward and a
-    /// reverse edge, iterating outgoing edges is sufficient to enumerate all
-    /// connections: every relationship the node participates in appears as an
-    /// outgoing edge in at least one direction. Callers that need to display
-    /// "all connections" for a concept should call this method; the result
-    /// already includes the reverse direction because `relate` inserted it.
+    /// Returns `(neighbor_index, edge)` pairs for every edge incident on
+    /// `node` whether it points outward (the concept is the `from` side)
+    /// or inward (it is the `to` side). This gives the caller a
+    /// bidirectional view without storing duplicate edges in the graph.
+    ///
+    /// The order follows petgraph's stable edge-list iteration, which is
+    /// insertion order within each direction for the same node.
     pub fn relationships(&self, node: NodeIndex) -> Vec<(NodeIndex, &ConceptEdge)> {
-        self.graph
+        let outgoing = self
+            .graph
             .edges_directed(node, Direction::Outgoing)
-            .map(|e| (e.target(), e.weight()))
-            .collect()
+            .map(|e| (e.target(), e.weight()));
+
+        let incoming = self
+            .graph
+            .edges_directed(node, Direction::Incoming)
+            .map(|e| (e.source(), e.weight()));
+
+        outgoing.chain(incoming).collect()
     }
 
-    /// Bounded BFS from a concept node, returning all reachable nodes within
-    /// `depth` hops along with their hop distance from the center.
+    // ── Category queries ──────────────────────────────────────────────────
+
+    /// All concept node indexes in a given category.
     ///
-    /// The center node itself is **not** included in the result. If
-    /// `category_filter` is `Some`, only nodes whose category matches are
-    /// included in the result (but the BFS still traverses through nodes of
-    /// other categories to find matching ones within the depth limit).
+    /// Returns an empty slice when no concepts of that category have been
+    /// registered yet. Insertion order within each category matches the
+    /// order in which [`ensure_concept`](Self::ensure_concept) was first
+    /// called.
+    pub fn by_category(&self, category: &ConceptCategory) -> &[NodeIndex] {
+        self.category_index
+            .get(category)
+            .map_or(&[], |v| v.as_slice())
+    }
+
+    // ── Timeline ─────────────────────────────────────────────────────────
+
+    /// Look up a material concept node by seed alone, ignoring `planet_seed`.
     ///
-    /// This method is the data-model foundation for the future associative web
-    /// view. It does not perform any rendering or UI work.
+    /// Returns the first [`NodeIndex`] found whose [`ConceptId`] wraps a
+    /// [`crate::journal::JournalKey::Material`] with the given `seed`, regardless
+    /// of what `planet_seed` that node was stored with.
+    ///
+    /// This exists to resolve the "identity mismatch" where a material is first
+    /// observed on a planet (key = `Material { seed: X, planet_seed: Some(Y) }`) but
+    /// is later referenced via fabrication input with `planet_seed: None`. Using
+    /// `lookup` directly would create a second, disconnected node — this method
+    /// prevents that by finding the existing node by seed.
+    ///
+    /// Returns `None` when no material with that seed exists in the graph yet.
+    pub fn lookup_material_by_seed(&self, seed: u64) -> Option<NodeIndex> {
+        self.concept_index.iter().find_map(|(id, &idx)| {
+            if matches!(&id.0, crate::journal::JournalKey::MaterialInstance { seed: s } if *s == seed) {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the concept node at the given index, or `None` if the index
+    /// is invalid.  Exposes read-only access to node data without making
+    /// the internal `petgraph::Graph` field public.
+    pub fn node_weight(&self, idx: NodeIndex) -> Option<&ConceptNode> {
+        self.graph.node_weight(idx)
+    }
+
+    /// Mark a property as revealed on the given concept node.
+    ///
+    /// Called each time the player makes an observation of a specific category
+    /// on this concept. The `property_name` should be the
+    /// [`crate::journal::ObservationCategory::display_label`] string so the
+    /// encyclopedia view can show exactly which properties the player has seen.
+    ///
+    /// No-ops when the node index is invalid (should never happen during normal
+    /// gameplay since indexes are never removed).
+    pub fn reveal_property(&mut self, node: NodeIndex, property_name: String) {
+        if let Some(n) = self.graph.node_weight_mut(node) {
+            n.revealed_properties.insert(property_name);
+        }
+    }
+    /// Timeline of all discovered concepts in chronological order.
+    ///
+    /// Each entry is `(discovered_at_tick, node_index)`. Because
+    /// [`ensure_concept`](Self::ensure_concept) only appends to this
+    /// vec and the game clock is monotonically increasing, the timeline
+    /// is guaranteed to be in non-decreasing tick order.
+    pub fn timeline(&self) -> &[(u64, NodeIndex)] {
+        &self.timeline
+    }
+
+    // ── Bounded BFS ───────────────────────────────────────────────────────
+
+    /// Bounded BFS from a center node, returning `(node_index, depth)`
+    /// pairs for all reachable nodes within `depth` hops.
+    ///
+    /// The center node itself is NOT included in the result — callers
+    /// already have it. Edges are traversed in both directions (the graph
+    /// is treated as undirected for BFS purposes), so the result is a
+    /// neighbourhood in the graph-theoretic sense rather than a directed
+    /// reachability set.
+    ///
+    /// # Arguments
+    ///
+    /// - `center` — Starting node index.
+    /// - `depth` — Maximum hop count. `depth = 1` returns only direct neighbours;
+    ///   `depth = 0` returns an empty vec (the center is excluded).
+    /// - `category_filter` — When `Some(category)`, only nodes that belong to that
+    ///   category are included in the result. Filtered-out nodes still participate in
+    ///   BFS traversal so their neighbours can be reached — the filter is applied at
+    ///   result collection time, not during graph traversal.
+    ///
+    /// # Cycle safety
+    ///
+    /// BFS uses a `visited` set to prevent re-queuing already-seen nodes,
+    /// so cycles in the graph never cause infinite loops.
     pub fn neighborhood(
         &self,
         center: NodeIndex,
@@ -771,28 +421,26 @@ impl KnowledgeGraph {
             return Vec::new();
         }
 
-        // BFS state: visited set and queue of (node, current_depth).
         let mut visited: HashSet<NodeIndex> = HashSet::new();
-        let mut queue: std::collections::VecDeque<(NodeIndex, usize)> =
-            std::collections::VecDeque::new();
+        let mut queue: VecDeque<(NodeIndex, usize)> = VecDeque::new();
         let mut result: Vec<(NodeIndex, usize)> = Vec::new();
 
         visited.insert(center);
         queue.push_back((center, 0));
 
-        while let Some((current, current_depth)) = queue.pop_front() {
+        while let Some((node, current_depth)) = queue.pop_front() {
             if current_depth >= depth {
                 continue;
             }
 
-            // Traverse all neighbors (both directions) from the current node.
+            // Walk both outgoing and incoming edges (undirected BFS).
             let neighbors: Vec<NodeIndex> = self
                 .graph
-                .edges_directed(current, Direction::Outgoing)
+                .edges_directed(node, Direction::Outgoing)
                 .map(|e| e.target())
                 .chain(
                     self.graph
-                        .edges_directed(current, Direction::Incoming)
+                        .edges_directed(node, Direction::Incoming)
                         .map(|e| e.source()),
                 )
                 .collect();
@@ -802,1361 +450,675 @@ impl KnowledgeGraph {
                     continue;
                 }
                 visited.insert(neighbor);
-                let hop = current_depth + 1;
+                let neighbor_depth = current_depth + 1;
+                queue.push_back((neighbor, neighbor_depth));
 
-                // Apply category filter to the result set, but always enqueue
-                // the neighbor so BFS can traverse through it.
-                let node_data = &self.graph[neighbor];
-                let passes_filter = category_filter
-                    .map(|cat| &node_data.category == cat)
-                    .unwrap_or(true);
+                // Apply category filter at collection time, not traversal time.
+                let include = category_filter.is_none_or(|cat| {
+                    self.graph
+                        .node_weight(neighbor)
+                        .is_some_and(|n| &n.category == cat)
+                });
 
-                if passes_filter {
-                    result.push((neighbor, hop));
+                if include {
+                    result.push((neighbor, neighbor_depth));
                 }
-
-                queue.push_back((neighbor, hop));
             }
         }
 
         result
     }
+}
 
-    /// All concept nodes in a given category, in insertion order.
-    ///
-    /// Returns an empty slice if no concepts of that category have been
-    /// discovered yet.
-    pub fn by_category(&self, category: &ConceptCategory) -> &[NodeIndex] {
-        self.category_index
-            .get(category)
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
+// ── Serialization ─────────────────────────────────────────────────────────
+
+/// Serializable snapshot of the graph, used for save/load.
+///
+/// We serialize the full node and edge data from petgraph directly (via the
+/// `serde-1` feature), then rebuild the three in-memory indexes on
+/// deserialization. This avoids storing redundant index data that could
+/// drift out of sync with the graph.
+///
+/// `petgraph::Graph` serializes as `{ nodes: [...], edges: [...] }` which
+/// is stable across petgraph minor versions, matching the versioning
+/// contract in the asset-pipeline architecture decision.
+impl Serialize for KnowledgeGraph {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Delegate entirely to petgraph's built-in serde support.
+        self.graph.serialize(serializer)
     }
+}
 
-    /// Timeline of concept discoveries: `(tick, NodeIndex)` pairs in
-    /// insertion order (earliest discovery first).
-    pub fn timeline(&self) -> &[(u64, NodeIndex)] {
-        &self.timeline
-    }
+impl<'de> Deserialize<'de> for KnowledgeGraph {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Restore the petgraph graph from saved data.
+        let graph: Graph<ConceptNode, ConceptEdge> = Graph::deserialize(deserializer)?;
 
-    /// Look up a concept node by its [`ConceptId`].
-    ///
-    /// Returns `None` if the concept has not been added to the graph yet.
-    pub fn lookup(&self, id: &ConceptId) -> Option<NodeIndex> {
-        self.concept_index.get(id).copied()
-    }
-
-    /// Borrow the [`ConceptNode`] data for a given [`NodeIndex`].
-    ///
-    /// Returns `None` if the index is not valid (e.g., after a node was
-    /// removed, though the current implementation never removes nodes).
-    pub fn node(&self, idx: NodeIndex) -> Option<&ConceptNode> {
-        self.graph.node_weight(idx)
-    }
-
-    /// Mutably borrow the [`ConceptNode`] data for a given [`NodeIndex`].
-    pub fn node_mut(&mut self, idx: NodeIndex) -> Option<&mut ConceptNode> {
-        self.graph.node_weight_mut(idx)
-    }
-
-    /// Serialize the knowledge graph to a JSON string for save/load.
-    ///
-    /// The auxiliary indexes (`concept_index`, `category_index`, `timeline`)
-    /// are **not** serialized — they are rebuilt from the graph on
-    /// deserialization via [`KnowledgeGraph::from_serializable`].
-    pub fn to_serializable(&self) -> SerializableKnowledgeGraph {
-        SerializableKnowledgeGraph {
-            graph: self.graph.clone(),
-        }
-    }
-
-    /// Reconstruct a `KnowledgeGraph` from its serialized form, rebuilding
-    /// all auxiliary indexes from the graph data.
-    pub fn from_serializable(serializable: SerializableKnowledgeGraph) -> Self {
-        let graph = serializable.graph;
-
-        let mut concept_index: HashMap<ConceptId, NodeIndex> = HashMap::new();
+        // Rebuild all three indexes from the restored graph — they are
+        // derivable from the node data so we never store them separately,
+        // eliminating any risk of index/graph divergence across save files.
+        let mut concept_index = HashMap::new();
         let mut category_index: HashMap<ConceptCategory, Vec<NodeIndex>> = HashMap::new();
         let mut timeline: Vec<(u64, NodeIndex)> = Vec::new();
 
         for idx in graph.node_indices() {
-            let node = &graph[idx];
-            concept_index.insert(node.id.clone(), idx);
-            category_index
-                .entry(node.category.clone())
-                .or_default()
-                .push(idx);
-            timeline.push((node.discovered_at, idx));
+            if let Some(node) = graph.node_weight(idx) {
+                concept_index.insert(node.id.clone(), idx);
+                category_index
+                    .entry(node.category.clone())
+                    .or_default()
+                    .push(idx);
+                timeline.push((node.discovered_at, idx));
+            }
         }
 
-        // Sort timeline by tick to restore discovery order after round-trip.
+        // Restore chronological order — petgraph node iteration order is
+        // insertion order (stable), but after deserialization we cannot
+        // assume the original tick order was preserved without sorting.
         timeline.sort_by_key(|(tick, _)| *tick);
 
-        Self {
+        Ok(KnowledgeGraph {
             graph,
             concept_index,
             category_index,
             timeline,
+        })
+    }
+}
+
+// ── Automatic cross-reference system ─────────────────────────────────────
+
+/// Processes [`crate::journal::RecordObservation`] messages and populates
+/// the [`KnowledgeGraph`] with typed relationship edges.
+///
+/// Runs in [`crate::journal::JournalSet::Navigate`] — same set as the
+/// journal's own `apply_observations`, so both systems see the same
+/// messages in the same frame.
+///
+/// # Edges created
+///
+/// * **`FoundOn`** — when a `Material` observation carries a `planet_seed`
+///   in its key, a `material → location` edge is created.
+/// * **`DerivedFrom`** — for `Fabrication` observations, an edge is created
+///   from the output concept to each input material listed in
+///   [`RecordObservation::input_seeds`].
+/// * **`ObservedAt`** — when the observation message includes a
+///   [`RecordObservation::context_location`], an `ObservedAt` edge is
+///   created from subject → location.
+///
+/// No edges are created without an observation event; the system never
+/// infers connections the player hasn't personally made.
+fn update_knowledge_graph(
+    mut reader: MessageReader<crate::journal::RecordObservation>,
+    mut graph: ResMut<KnowledgeGraph>,
+    time: Res<Time>,
+) {
+    let tick = time.elapsed().as_secs();
+
+    for obs in reader.read() {
+        // Determine category for the observed subject.
+        let subject_category = category_from_key(&obs.key);
+
+        // Ensure the subject node exists.
+        let subject_node = graph.ensure_concept(ConceptId(obs.key.clone()), subject_category, tick);
+
+        // Mark which property category the player just observed on this concept.
+        let category_name = obs.observation.category.display_label().to_string();
+        graph.reveal_property(subject_node, category_name);
+
+        // ── FoundOn edge ──────────────────────────────────────────────
+        // If the observation carries a planet_seed, wire a FoundOn edge
+        // from the material to the location concept.
+        if let Some(planet_seed) = obs.planet_seed {
+            let location_key = crate::journal::JournalKey::Location { planet_seed };
+            let location_node =
+                graph.ensure_concept(ConceptId(location_key), ConceptCategory::Location, tick);
+            graph.relate(
+                subject_node,
+                location_node,
+                ConceptEdge {
+                    relationship: RelationshipType::FoundOn,
+                    confidence: obs.observation.confidence,
+                    discovered_at: tick,
+                },
+            );
+        }
+
+        // ── DerivedFrom edges ────────────────────────────────────────
+        // For fabrication outputs, link the output concept back to each
+        // input material that the player put into the fabricator.
+        if matches!(&obs.key, crate::journal::JournalKey::Fabrication { .. }) {
+            for &input_seed in &obs.input_seeds {
+                let input_node = graph
+                    .lookup_material_by_seed(input_seed)
+                    .unwrap_or_else(|| {
+                        let input_key =
+                            crate::journal::JournalKey::MaterialInstance { seed: input_seed };
+                        graph.ensure_concept(ConceptId(input_key), ConceptCategory::Material, tick)
+                    });
+                graph.relate(
+                    subject_node,
+                    input_node,
+                    ConceptEdge {
+                        relationship: RelationshipType::DerivedFrom,
+                        // Fabrication is directly observed — full confidence.
+                        confidence: Confidence(1.0),
+                        discovered_at: tick,
+                    },
+                );
+            }
+        }
+
+        // ── CombinedWith edges ───────────────────────────────────────
+        // For fabrication outputs with exactly 2 inputs, wire a symmetric
+        // CombinedWith edge between the two input materials so the player
+        // can see that these materials were used together, independent of
+        // what they produced.
+        if matches!(&obs.key, crate::journal::JournalKey::Fabrication { .. })
+            && obs.input_seeds.len() == 2
+        {
+            let seed_a = obs.input_seeds[0];
+            let seed_b = obs.input_seeds[1];
+
+            let node_a = graph.lookup_material_by_seed(seed_a).unwrap_or_else(|| {
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_a };
+                graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
+            });
+            let node_b = graph.lookup_material_by_seed(seed_b).unwrap_or_else(|| {
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_b };
+                graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
+            });
+
+            let edge = ConceptEdge {
+                relationship: RelationshipType::CombinedWith,
+                confidence: Confidence(1.0),
+                discovered_at: tick,
+            };
+            graph.relate(node_a, node_b, edge);
+        }
+
+        // ── ObservedAt edge ──────────────────────────────────────────
+        // When the observation message supplies an explicit context
+        // location (e.g. a biome landmark), wire a subject→location edge.
+        if let Some(context_location) = &obs.context_location {
+            let location_category = category_from_key(context_location);
+            let location_node =
+                graph.ensure_concept(ConceptId(context_location.clone()), location_category, tick);
+            graph.relate(
+                subject_node,
+                location_node,
+                ConceptEdge {
+                    relationship: RelationshipType::ObservedAt,
+                    confidence: obs.observation.confidence,
+                    discovered_at: tick,
+                },
+            );
         }
     }
 }
 
-/// Serializable form of [`KnowledgeGraph`] for save/load.
+/// Map a [`JournalKey`] discriminant to the corresponding
+/// [`ConceptCategory`].
 ///
-/// The auxiliary indexes are omitted and rebuilt on deserialization via
-/// [`KnowledgeGraph::from_serializable`].
-#[derive(Serialize, Deserialize)]
-pub struct SerializableKnowledgeGraph {
-    /// The underlying petgraph graph with all concept nodes and edges.
-    pub graph: Graph<ConceptNode, ConceptEdge>,
+/// This mapping is the single place where the journal and knowledge-graph
+/// category systems are joined. Adding a new `JournalKey` variant will
+/// produce a non-exhaustive match error here, forcing the developer to
+/// declare the correct category.
+fn category_from_key(key: &crate::journal::JournalKey) -> ConceptCategory {
+    match key {
+        crate::journal::JournalKey::MaterialInstance { .. } => ConceptCategory::Material,
+        crate::journal::JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
+        crate::journal::JournalKey::Location { .. } => ConceptCategory::Location,
+    }
 }
+
+// ── SimilarTo detection ───────────────────────────────────────────────────
+
+/// Detect materials with similar property profiles and wire `SimilarTo`
+/// edges in the knowledge graph when both materials are known with at least
+/// `Observed` confidence.
+///
+/// Called by the material catalog after a new material is registered
+/// (Story 10.5, Phase 4). The caller passes in the full catalog so we can
+/// compare the new material against every previously-known entry.
+///
+/// # Arguments
+///
+/// - `new_seed` — The seed of the newly registered material.
+/// - `new_material` — Reference to the [`crate::materials::GameMaterial`] that was just registered.
+/// - `catalog` — The full [`crate::materials::MaterialCatalog`] for comparison. The new material is
+///   already in it.
+/// - `journal` — The player's [`crate::journal::Journal`] — used to check confidence tiers on both
+///   materials.
+/// - `graph` — Mutable reference to the [`KnowledgeGraph`] where `SimilarTo` edges are added.
+/// - `threshold` — Cosine similarity threshold above which two materials are considered "similar"
+///   (loaded from config, typically ~0.85).
+/// - `tick` — Current game-time tick for edge timestamps.
+pub fn detect_and_wire_similar_materials(
+    new_seed: u64,
+    new_material: &crate::materials::GameMaterial,
+    catalog: &crate::materials::MaterialCatalog,
+    journal: &crate::journal::Journal,
+    graph: &mut KnowledgeGraph,
+    threshold: f32,
+    tick: u64,
+) {
+    let new_vec = new_material.property_vector();
+
+    for existing in catalog.values() {
+        // Never compare a material to itself.
+        if existing.seed == new_seed {
+            continue;
+        }
+
+        let sim = cosine_similarity(&new_vec, &existing.property_vector());
+        if sim < threshold {
+            continue;
+        }
+
+        // Both materials must be at Observed confidence or above before
+        // we surface the similarity — connections must be earned.
+        let new_key = crate::journal::JournalKey::MaterialInstance { seed: new_seed };
+        let existing_key = crate::journal::JournalKey::MaterialInstance {
+            seed: existing.seed,
+        };
+
+        let new_confident = is_at_least_observed(journal, &new_key);
+        let existing_confident = is_at_least_observed(journal, &existing_key);
+
+        if !new_confident || !existing_confident {
+            continue;
+        }
+
+        // Wire SimilarTo in both directions so the relationship shows up
+        // regardless of which material the player is viewing.
+        let new_node =
+            graph.ensure_concept(ConceptId(new_key.clone()), ConceptCategory::Material, tick);
+        let existing_node =
+            graph.ensure_concept(ConceptId(existing_key), ConceptCategory::Material, tick);
+
+        let edge = ConceptEdge {
+            relationship: RelationshipType::SimilarTo,
+            confidence: Confidence(sim),
+            discovered_at: tick,
+        };
+        graph.relate(new_node, existing_node, edge);
+    }
+}
+
+/// Compute the cosine similarity between two property vectors.
+///
+/// Returns a value in [-1.0, 1.0] — in practice always [0.0, 1.0] for
+/// non-negative property vectors derived from material seeds. A return
+/// value of `1.0` means identical profiles; `0.0` means orthogonal
+/// (no property overlap).
+///
+/// Returns `0.0` when either vector has zero magnitude (degenerate case
+/// that cannot arise from [`crate::materials::GameMaterial::property_vector`]
+/// since property values are in [0.0, 1.0] and seeds span the full range).
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(
+        a.len(),
+        b.len(),
+        "cosine_similarity: vectors must have the same length"
+    );
+
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if mag_a == 0.0 || mag_b == 0.0 {
+        return 0.0;
+    }
+
+    (dot / (mag_a * mag_b)).clamp(-1.0, 1.0)
+}
+
+/// Returns `true` when the journal contains at least one observation for
+/// `key` with confidence at or above [`crate::observation::ConfidenceTier::Observed`]
+/// (i.e. confidence ≥ 0.3).
+///
+/// "At least Observed" is the threshold at which the player has
+/// accumulated enough evidence to treat the observation as factual
+/// rather than tentative. `SimilarTo` edges are only wired when both
+/// materials meet this bar, ensuring the connection is earned.
+fn is_at_least_observed(
+    journal: &crate::journal::Journal,
+    key: &crate::journal::JournalKey,
+) -> bool {
+    match key {
+        crate::journal::JournalKey::MaterialInstance { seed } => {
+            journal.entries.values().any(|entry| {
+                matches!(&entry.key, crate::journal::JournalKey::MaterialInstance { seed: s } if *s == *seed)
+                    && entry.all_observations().any(|obs| obs.confidence.0 >= 0.3)
+            })
+        }
+        _ => journal
+            .entries
+            .get(key)
+            .is_some_and(|entry| entry.all_observations().any(|obs| obs.confidence.0 >= 0.3)),
+    }
+}
+
+/// Detects and wires `SimilarTo` edges for newly observed materials.
+///
+/// Runs in [`crate::journal::JournalSet::Navigate`] after
+/// [`update_knowledge_graph`]. For each [`RecordObservation`] message that
+/// carries a [`crate::journal::JournalKey::Material`] key, compares the
+/// material against all others in the catalog and wires `SimilarTo` edges
+/// when both materials are at or above `Observed` confidence and their
+/// property vectors exceed the configured similarity threshold.
+///
+/// Uses an independent [`MessageReader`] cursor — both this system and
+/// [`update_knowledge_graph`] receive all messages without consuming each
+/// other's reads.
+fn detect_similar_on_observation(
+    mut reader: MessageReader<crate::journal::RecordObservation>,
+    mut graph: ResMut<KnowledgeGraph>,
+    catalog: Res<crate::materials::MaterialCatalog>,
+    player_query: Query<&crate::journal::Journal, With<crate::player::Player>>,
+    time: Res<Time>,
+    config: Res<crate::observation::ConfidenceConfig>,
+) {
+    let Ok(journal) = player_query.single() else {
+        return;
+    };
+    let tick = time.elapsed().as_secs();
+
+    for obs in reader.read() {
+        let crate::journal::JournalKey::MaterialInstance { seed } = obs.key else {
+            continue;
+        };
+        let Some(material) = catalog.get_by_seed(seed) else {
+            continue;
+        };
+        detect_and_wire_similar_materials(
+            seed,
+            material,
+            &catalog,
+            journal,
+            &mut graph,
+            config.similarity_threshold,
+            tick,
+        );
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::journal::JournalKey;
 
-    fn material_key(seed: u64) -> JournalKey {
-        JournalKey::Material {
-            seed,
-            planet_seed: None,
-        }
+    fn mat_id(seed: u64) -> ConceptId {
+        ConceptId(JournalKey::MaterialInstance { seed })
     }
 
-    #[test]
-    fn concept_id_wraps_journal_key() {
-        let key = material_key(42);
-        let id = ConceptId::new(key.clone());
-        assert_eq!(id.key(), &key);
+    fn loc_id(planet_seed: u64) -> ConceptId {
+        ConceptId(JournalKey::Location { planet_seed })
     }
 
-    #[test]
-    fn concept_id_from_journal_key() {
-        let key = material_key(7);
-        let id: ConceptId = key.clone().into();
-        assert_eq!(id.0, key);
-    }
-
-    #[test]
-    fn concept_node_starts_with_no_revealed_properties() {
-        let id = ConceptId::new(material_key(1));
-        let node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.2), 100);
-        assert!(node.revealed_properties.is_empty());
-        assert!(!node.has_property("density"));
-    }
-
-    #[test]
-    fn concept_node_reveal_property_is_idempotent() {
-        let id = ConceptId::new(material_key(2));
-        let mut node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.5), 200);
-        node.reveal_property("density");
-        node.reveal_property("density"); // second call is a no-op
-        assert!(node.has_property("density"));
-        assert_eq!(node.revealed_properties.len(), 1);
-    }
-
-    #[test]
-    fn concept_node_multiple_properties() {
-        let id = ConceptId::new(material_key(3));
-        let mut node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.8), 300);
-        node.reveal_property("density");
-        node.reveal_property("thermal_resistance");
-        assert!(node.has_property("density"));
-        assert!(node.has_property("thermal_resistance"));
-        assert!(!node.has_property("reactivity"));
-    }
-
-    #[test]
-    fn concept_category_equality() {
-        assert_eq!(ConceptCategory::Material, ConceptCategory::Material);
-        assert_ne!(ConceptCategory::Material, ConceptCategory::Location);
-        assert_ne!(ConceptCategory::Location, ConceptCategory::Fabrication);
-    }
-
-    #[test]
-    fn concept_node_stores_metadata() {
-        let id = ConceptId::new(material_key(99));
-        let node = ConceptNode::new(id.clone(), ConceptCategory::Location, Confidence(0.6), 999);
-        assert_eq!(node.id, id);
-        assert_eq!(node.category, ConceptCategory::Location);
-        assert_eq!(node.confidence.0, 0.6);
-        assert_eq!(node.discovered_at, 999);
-    }
-
-    // ── ConceptEdge / RelationshipType tests ─────────────────────────────
-
-    #[test]
-    fn concept_edge_new_stores_fields() {
-        let edge = ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.4), 50);
-        assert_eq!(edge.relationship, RelationshipType::FoundOn);
-        assert_eq!(edge.confidence.0, 0.4);
-        assert_eq!(edge.discovered_at, 50);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_accumulates_confidence() {
-        let mut edge = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.3), 10);
-        edge.strengthen(Confidence(0.4));
-        // 0.3 + 0.4 = 0.7
-        assert!((edge.confidence.0 - 0.7).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_caps_at_one() {
-        let mut edge = ConceptEdge::new(RelationshipType::DerivedFrom, Confidence(0.8), 20);
-        edge.strengthen(Confidence(0.5));
-        // 0.8 + 0.5 = 1.3, capped at 1.0
-        assert_eq!(edge.confidence.0, 1.0);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_does_not_update_discovered_at() {
-        let mut edge = ConceptEdge::new(RelationshipType::ObservedAt, Confidence(0.2), 100);
-        edge.strengthen(Confidence(0.3));
-        assert_eq!(edge.discovered_at, 100);
-    }
-
-    #[test]
-    fn relationship_type_equality() {
-        assert_eq!(RelationshipType::FoundOn, RelationshipType::FoundOn);
-        assert_ne!(RelationshipType::FoundOn, RelationshipType::ObservedAt);
-        assert_ne!(
-            RelationshipType::CombinedWith,
-            RelationshipType::DerivedFrom
-        );
-        assert_ne!(RelationshipType::SimilarTo, RelationshipType::FoundOn);
-    }
-
-    #[test]
-    fn relationship_type_all_variants_constructible() {
-        // Ensure all five required variants exist and are distinct.
-        let variants = [
-            RelationshipType::FoundOn,
-            RelationshipType::CombinedWith,
-            RelationshipType::DerivedFrom,
-            RelationshipType::SimilarTo,
-            RelationshipType::ObservedAt,
-        ];
-        // All five must be pairwise distinct.
-        for i in 0..variants.len() {
-            for j in 0..variants.len() {
-                if i == j {
-                    assert_eq!(variants[i], variants[j]);
-                } else {
-                    assert_ne!(variants[i], variants[j]);
-                }
-            }
-        }
-    }
-
-    // ── KnowledgeGraph tests ──────────────────────────────────────────────
-
-    fn location_key(seed: u64) -> JournalKey {
-        // JournalKey has no Location variant yet; use a Material with a
-        // planet_seed to represent a location concept in tests.
-        JournalKey::Material {
-            seed,
-            planet_seed: Some(seed),
-        }
-    }
-
-    fn make_graph() -> KnowledgeGraph {
-        KnowledgeGraph::new()
-    }
-
-    #[test]
-    fn ensure_concept_creates_new_node() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(1));
-        let idx = graph.ensure_concept(id.clone(), ConceptCategory::Material, 10);
-        assert_eq!(graph.lookup(&id), Some(idx));
-    }
+    // ── Phase 1 tests ─────────────────────────────────────────────────
 
     #[test]
     fn ensure_concept_is_idempotent() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 10);
-        let idx2 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 20);
-        // Same node returned both times.
-        assert_eq!(idx1, idx2);
-        // Timeline should only have one entry.
-        assert_eq!(graph.timeline().len(), 1);
-    }
-
-    #[test]
-    fn lookup_returns_none_for_unknown_concept() {
-        let graph = make_graph();
-        let id = ConceptId::new(material_key(99));
-        assert_eq!(graph.lookup(&id), None);
-    }
-
-    #[test]
-    fn by_category_returns_inserted_nodes() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id, ConceptCategory::Material, 1);
-        let loc_idx = graph.ensure_concept(loc_id, ConceptCategory::Location, 2);
-
-        let materials = graph.by_category(&ConceptCategory::Material);
-        assert_eq!(materials, &[mat_idx]);
-
-        let locations = graph.by_category(&ConceptCategory::Location);
-        assert_eq!(locations, &[loc_idx]);
-    }
-
-    #[test]
-    fn by_category_returns_empty_for_unknown_category() {
-        let graph = make_graph();
-        assert!(graph.by_category(&ConceptCategory::Fabrication).is_empty());
-    }
-
-    #[test]
-    fn timeline_records_discovery_order() {
-        let mut graph = make_graph();
-        let id1 = ConceptId::new(material_key(1));
-        let id2 = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id1, ConceptCategory::Material, 5);
-        let idx2 = graph.ensure_concept(id2, ConceptCategory::Material, 10);
-
-        let tl = graph.timeline();
-        assert_eq!(tl.len(), 2);
-        assert_eq!(tl[0], (5, idx1));
-        assert_eq!(tl[1], (10, idx2));
-    }
-
-    #[test]
-    fn relate_creates_bidirectional_edges() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id, ConceptCategory::Material, 1);
-        let loc_idx = graph.ensure_concept(loc_id, ConceptCategory::Location, 2);
-
-        let edge = ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.5), 3);
-        graph.relate(mat_idx, loc_idx, edge);
-
-        // Forward: material → location
-        let mat_rels = graph.relationships(mat_idx);
-        assert!(
-            mat_rels
-                .iter()
-                .any(|(n, e)| { *n == loc_idx && e.relationship == RelationshipType::FoundOn })
-        );
-
-        // Reverse: location → material
-        let loc_rels = graph.relationships(loc_idx);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| { *n == mat_idx && e.relationship == RelationshipType::FoundOn })
-        );
-    }
-
-    #[test]
-    fn relate_strengthens_existing_edge_on_repeat() {
-        let mut graph = make_graph();
-        let id1 = ConceptId::new(material_key(1));
-        let id2 = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id1, ConceptCategory::Material, 1);
-        let idx2 = graph.ensure_concept(id2, ConceptCategory::Material, 2);
-
-        let edge1 = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.3), 5);
-        let edge2 = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.4), 10);
-        graph.relate(idx1, idx2, edge1);
-        graph.relate(idx1, idx2, edge2);
-
-        // relationships() returns both outgoing and incoming edges.
-        // Filter to only edges pointing toward idx2 (the forward direction).
-        let rels = graph.relationships(idx1);
-        let forward: Vec<_> = rels
-            .iter()
-            .filter(|(n, e)| *n == idx2 && e.relationship == RelationshipType::SimilarTo)
-            .collect();
-        // Exactly one forward edge (strengthened, not duplicated).
-        assert_eq!(forward.len(), 1);
-        // 0.3 + 0.4 = 0.7
-        assert!((forward[0].1.confidence.0 - 0.7).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn neighborhood_returns_nodes_within_depth() {
-        let mut graph = make_graph();
-        // A — B — C — D (linear chain)
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
+        let mut graph = KnowledgeGraph::default();
+        let id = mat_id(42);
+        let idx1 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 100);
+        let idx2 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 200);
+        assert_eq!(idx1, idx2, "same ID must always return the same NodeIndex");
+        assert_eq!(
+            graph.timeline().len(),
             1,
+            "idempotent call must not append to timeline"
         );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-        let d = graph.ensure_concept(
-            ConceptId::new(material_key(4)),
-            ConceptCategory::Material,
-            4,
-        );
-
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        graph.relate(a, b, edge());
-        graph.relate(b, c, edge());
-        graph.relate(c, d, edge());
-
-        // From A with depth=2: should reach B (hop 1) and C (hop 2), not D.
-        let neighbors = graph.neighborhood(a, 2, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert!(nodes.contains(&b));
-        assert!(nodes.contains(&c));
-        assert!(!nodes.contains(&d));
-        assert!(!nodes.contains(&a)); // center excluded
     }
 
     #[test]
-    fn neighborhood_depth_zero_returns_empty() {
-        let mut graph = make_graph();
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
+    fn relate_creates_new_edge() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(loc_id(999), ConceptCategory::Location, 0);
         graph.relate(
             a,
             b,
-            ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1),
+            ConceptEdge {
+                relationship: RelationshipType::FoundOn,
+                confidence: Confidence(0.5),
+                discovered_at: 0,
+            },
         );
-
-        assert!(graph.neighborhood(a, 0, None).is_empty());
+        let rels = graph.relationships(a);
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].1.relationship, RelationshipType::FoundOn);
     }
 
     #[test]
-    fn neighborhood_depth_one_returns_only_direct_neighbors() {
-        let mut graph = make_graph();
-        // A — B — C — D (linear chain)
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-        let d = graph.ensure_concept(
-            ConceptId::new(material_key(4)),
-            ConceptCategory::Material,
-            4,
-        );
+    fn relate_strengthens_existing_edge() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(loc_id(999), ConceptCategory::Location, 0);
 
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        graph.relate(a, b, edge());
-        graph.relate(b, c, edge());
-        graph.relate(c, d, edge());
+        let initial_edge = ConceptEdge {
+            relationship: RelationshipType::FoundOn,
+            confidence: Confidence(0.3),
+            discovered_at: 0,
+        };
+        graph.relate(a, b, initial_edge.clone());
 
-        // depth=1: only direct neighbors of A (i.e., B). C and D are too far.
-        let neighbors = graph.neighborhood(a, 1, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert_eq!(
-            nodes.len(),
-            1,
-            "depth=1 must return exactly one direct neighbor"
-        );
-        assert!(nodes.contains(&b), "B must be in depth=1 neighborhood of A");
+        // Second relate with same type should strengthen, not duplicate.
+        graph.relate(a, b, initial_edge);
+        let rels = graph.relationships(a);
+        assert_eq!(rels.len(), 1, "no duplicate edge");
         assert!(
-            !nodes.contains(&c),
-            "C must not be in depth=1 neighborhood of A"
-        );
-        assert!(
-            !nodes.contains(&d),
-            "D must not be in depth=1 neighborhood of A"
-        );
-        assert!(
-            !nodes.contains(&a),
-            "center node must not appear in its own neighborhood"
-        );
-
-        // Verify hop distance is reported as 1.
-        let hop = neighbors.iter().find(|(n, _)| *n == b).map(|(_, h)| *h);
-        assert_eq!(hop, Some(1), "B must be reported at hop distance 1");
-    }
-
-    #[test]
-    fn neighborhood_category_filter_excludes_non_matching() {
-        let mut graph = make_graph();
-        let mat = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let loc = graph.ensure_concept(
-            ConceptId::new(location_key(2)),
-            ConceptCategory::Location,
-            2,
-        );
-        let mat2 = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-
-        let edge = || ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.5), 1);
-        graph.relate(mat, loc, edge());
-        graph.relate(loc, mat2, edge());
-
-        // From mat with depth=2, filter to Material only: should see mat2 (hop 2) but not loc.
-        let neighbors = graph.neighborhood(mat, 2, Some(&ConceptCategory::Material));
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert!(!nodes.contains(&loc));
-        assert!(nodes.contains(&mat2));
-    }
-
-    #[test]
-    fn neighborhood_disconnected_node_returns_empty() {
-        // A node with no edges should have an empty neighborhood at any depth.
-        let mut graph = make_graph();
-        let isolated = graph.ensure_concept(
-            ConceptId::new(material_key(99)),
-            ConceptCategory::Material,
-            1,
-        );
-        assert!(
-            graph.neighborhood(isolated, 3, None).is_empty(),
-            "disconnected node must have no neighbors"
+            rels[0].1.confidence.0 > 0.3,
+            "confidence must increase on repeated observation"
         );
     }
 
     #[test]
-    fn neighborhood_handles_cycles_without_infinite_loop() {
-        // Build a cycle: A — B — C — A (triangle).
-        // BFS must visit each node at most once and terminate cleanly.
-        let mut graph = make_graph();
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
+    fn by_category_returns_correct_nodes() {
+        let mut graph = KnowledgeGraph::default();
+        let m1 = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let m2 = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 1);
+        let _l1 = graph.ensure_concept(loc_id(1), ConceptCategory::Location, 2);
+
+        let materials = graph.by_category(&ConceptCategory::Material);
+        assert_eq!(materials.len(), 2);
+        assert!(materials.contains(&m1));
+        assert!(materials.contains(&m2));
+
+        let locations = graph.by_category(&ConceptCategory::Location);
+        assert_eq!(locations.len(), 1);
+    }
+
+    #[test]
+    fn timeline_is_ordered_by_discovery_tick() {
+        let mut graph = KnowledgeGraph::default();
+        graph.ensure_concept(mat_id(10), ConceptCategory::Material, 100);
+        graph.ensure_concept(mat_id(20), ConceptCategory::Material, 50);
+        graph.ensure_concept(mat_id(30), ConceptCategory::Material, 200);
+
+        // Timeline should be in insertion order (ticks 100, 50, 200 for
+        // in-memory; deserialized would be sorted).
+        let ticks: Vec<u64> = graph.timeline().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![100, 50, 200]);
+    }
+
+    // ── Phase 2 tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn bfs_depth_one_returns_only_direct_neighbors() {
+        let mut graph = KnowledgeGraph::default();
+        let center = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let neighbor = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let far = graph.ensure_concept(mat_id(3), ConceptCategory::Material, 0);
+
+        graph.relate(
+            center,
+            neighbor,
+            ConceptEdge {
+                relationship: RelationshipType::SimilarTo,
+                confidence: Confidence(0.9),
+                discovered_at: 0,
+            },
         );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
+        graph.relate(
+            neighbor,
+            far,
+            ConceptEdge {
+                relationship: RelationshipType::SimilarTo,
+                confidence: Confidence(0.9),
+                discovered_at: 0,
+            },
         );
 
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        // A → B → C → A forms a directed cycle; relate() also adds the reverse edge,
-        // so the undirected traversal sees a fully-connected triangle.
+        let results = graph.neighborhood(center, 1, None);
+        let indices: Vec<NodeIndex> = results.iter().map(|(idx, _)| *idx).collect();
+        assert!(
+            indices.contains(&neighbor),
+            "direct neighbor must be included"
+        );
+        assert!(
+            !indices.contains(&far),
+            "2-hop node must be excluded at depth=1"
+        );
+    }
+
+    #[test]
+    fn bfs_with_category_filter_excludes_non_matching() {
+        let mut graph = KnowledgeGraph::default();
+        let center = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let mat_neighbor = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let loc_neighbor = graph.ensure_concept(loc_id(42), ConceptCategory::Location, 0);
+
+        let edge = || ConceptEdge {
+            relationship: RelationshipType::FoundOn,
+            confidence: Confidence(0.5),
+            discovered_at: 0,
+        };
+        graph.relate(center, mat_neighbor, edge());
+        graph.relate(center, loc_neighbor, edge());
+
+        let results = graph.neighborhood(center, 1, Some(&ConceptCategory::Location));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, loc_neighbor);
+    }
+
+    #[test]
+    fn bfs_on_disconnected_node_returns_empty() {
+        let mut graph = KnowledgeGraph::default();
+        let island = graph.ensure_concept(mat_id(99), ConceptCategory::Material, 0);
+        let results = graph.neighborhood(island, 5, None);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn bfs_handles_cycles_without_infinite_loop() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let c = graph.ensure_concept(mat_id(3), ConceptCategory::Material, 0);
+
+        let edge = || ConceptEdge {
+            relationship: RelationshipType::SimilarTo,
+            confidence: Confidence(0.9),
+            discovered_at: 0,
+        };
+        // Create a cycle: a → b → c → a
         graph.relate(a, b, edge());
         graph.relate(b, c, edge());
         graph.relate(c, a, edge());
 
-        // With depth=10 (well beyond the 3-node cycle), BFS must still return exactly
-        // the two other nodes (B and C) and must not loop or panic.
-        let neighbors = graph.neighborhood(a, 10, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
+        // Should terminate and return b and c (depth=5 more than covers the cycle).
+        let results = graph.neighborhood(a, 5, None);
+        assert_eq!(results.len(), 2);
+    }
 
-        assert_eq!(
-            nodes.len(),
-            2,
-            "cycle graph must yield exactly 2 unique neighbors for A (B and C), got {nodes:?}"
-        );
-        assert!(nodes.contains(&b), "B must be reachable from A");
-        assert!(nodes.contains(&c), "C must be reachable from A");
+    // ── Phase 3 tests (integration-level — graph wiring via system) ───
+
+    #[test]
+    fn no_edge_when_no_planet_seed() {
+        // Material key without planet_seed must not create a FoundOn edge.
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed: 42 };
+        let subject = graph.ensure_concept(ConceptId(key.clone()), ConceptCategory::Material, 0);
+        // Simulate what update_knowledge_graph does: only wire FoundOn when
+        // planet_seed is Some. With None, no location node is created.
+        let rels = graph.relationships(subject);
+        assert!(rels.is_empty(), "no FoundOn edge without planet_seed");
+    }
+
+    // ── Phase 4 tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn cosine_similarity_identical_vectors_is_one() {
+        let v = vec![0.3, 0.7, 0.5, 0.1, 0.9];
+        let sim = cosine_similarity(&v, &v);
         assert!(
-            !nodes.contains(&a),
-            "center node A must not appear in its own neighborhood"
+            (sim - 1.0).abs() < 1e-5,
+            "identical vectors → similarity 1.0"
         );
-
-        // Hop distances: B is 1 hop away, C is 1 hop away (direct edge via relate's reverse).
-        // Both must be ≤ depth and must be the shortest path distance.
-        let hop_b = neighbors.iter().find(|(n, _)| *n == b).map(|(_, h)| *h);
-        let hop_c = neighbors.iter().find(|(n, _)| *n == c).map(|(_, h)| *h);
-        assert_eq!(hop_b, Some(1), "B must be at hop distance 1 from A");
-        assert_eq!(hop_c, Some(1), "C must be at hop distance 1 from A");
     }
 
     #[test]
-    fn node_accessor_returns_concept_data() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(42));
-        let idx = graph.ensure_concept(id.clone(), ConceptCategory::Material, 7);
-        let node = graph.node(idx).expect("node must exist");
-        assert_eq!(node.id, id);
-        assert_eq!(node.category, ConceptCategory::Material);
-        assert_eq!(node.discovered_at, 7);
+    fn cosine_similarity_orthogonal_vectors_is_zero() {
+        let a = vec![1.0, 0.0, 0.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0, 0.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-5, "orthogonal vectors → similarity ~0.0");
     }
 
+    // ── Phase 6 tests ─────────────────────────────────────────────────
+
     #[test]
-    fn serialization_round_trip_preserves_graph() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id.clone(), ConceptCategory::Material, 10);
-        let loc_idx = graph.ensure_concept(loc_id.clone(), ConceptCategory::Location, 20);
+    fn knowledge_graph_round_trips_via_serde() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 10);
+        let b = graph.ensure_concept(loc_id(99), ConceptCategory::Location, 20);
         graph.relate(
-            mat_idx,
-            loc_idx,
-            ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.6), 15),
+            a,
+            b,
+            ConceptEdge {
+                relationship: RelationshipType::FoundOn,
+                confidence: Confidence(0.6),
+                discovered_at: 10,
+            },
         );
 
-        // Serialize to JSON bytes and deserialize back to exercise serde.
-        let serializable = graph.to_serializable();
-        let json = serde_json::to_string(&serializable).expect("serialization must succeed");
-        let restored_serializable: SerializableKnowledgeGraph =
-            serde_json::from_str(&json).expect("deserialization must succeed");
-        let restored = KnowledgeGraph::from_serializable(restored_serializable);
+        let json = serde_json::to_string(&graph).expect("serialize");
+        let restored: KnowledgeGraph = serde_json::from_str(&json).expect("deserialize");
 
-        // Indexes are rebuilt.
-        let restored_mat = restored.lookup(&mat_id).expect("material must be found");
-        let restored_loc = restored.lookup(&loc_id).expect("location must be found");
+        // Indexes are rebuilt: concept lookup should work.
+        assert!(restored.lookup(&mat_id(1)).is_some());
+        assert!(restored.lookup(&loc_id(99)).is_some());
 
-        // Relationships are preserved.
-        let rels = restored.relationships(restored_mat);
-        assert!(
-            rels.iter().any(|(n, e)| {
-                *n == restored_loc && e.relationship == RelationshipType::FoundOn
-            })
-        );
+        // Category index is rebuilt.
+        assert_eq!(restored.by_category(&ConceptCategory::Material).len(), 1);
+        assert_eq!(restored.by_category(&ConceptCategory::Location).len(), 1);
 
-        // Timeline is rebuilt.
+        // Timeline is sorted and contains both nodes.
         assert_eq!(restored.timeline().len(), 2);
-    }
-
-    /// Round-trip serialize→deserialize preserves all three in-memory indexes:
-    /// `concept_index` (O(1) lookup by ConceptId), `category_index` (lookup by
-    /// ConceptCategory), and `timeline` (ordered discovery log).
-    ///
-    /// This test uses two materials and one location so that `by_category` must
-    /// return the correct count for each category, and the timeline must reflect
-    /// the original insertion order.
-    #[test]
-    fn serialization_round_trip_preserves_all_indexes() {
-        let mut graph = make_graph();
-
-        // Insert two materials and one location at distinct ticks so the
-        // timeline order is deterministic.
-        let mat1_id = ConceptId::new(material_key(10));
-        let mat2_id = ConceptId::new(material_key(20));
-        let loc_id = ConceptId::new(location_key(30));
-
-        let mat1_idx = graph.ensure_concept(mat1_id.clone(), ConceptCategory::Material, 1);
-        let mat2_idx = graph.ensure_concept(mat2_id.clone(), ConceptCategory::Material, 2);
-        let loc_idx = graph.ensure_concept(loc_id.clone(), ConceptCategory::Location, 3);
-
-        // Add a relationship so the edge survives the round-trip too.
-        graph.relate(
-            mat1_idx,
-            loc_idx,
-            ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.7), 4),
-        );
-
-        // ── Round-trip ──────────────────────────────────────────────────────
-        let serializable = graph.to_serializable();
-        let json = serde_json::to_string(&serializable).expect("serialization must succeed");
-        let restored_serializable: SerializableKnowledgeGraph =
-            serde_json::from_str(&json).expect("deserialization must succeed");
-        let restored = KnowledgeGraph::from_serializable(restored_serializable);
-
-        // ── concept_index: O(1) lookup by ConceptId ─────────────────────────
-        let r_mat1 = restored
-            .lookup(&mat1_id)
-            .expect("mat1 must be found via concept_index");
-        let r_mat2 = restored
-            .lookup(&mat2_id)
-            .expect("mat2 must be found via concept_index");
-        let r_loc = restored
-            .lookup(&loc_id)
-            .expect("loc must be found via concept_index");
-
-        // Verify the node data is intact (not just that an index exists).
-        let mat1_node = restored.node(r_mat1).expect("mat1 node must exist");
-        assert_eq!(
-            mat1_node.id, mat1_id,
-            "concept_index must map to the correct node"
-        );
-        assert_eq!(mat1_node.category, ConceptCategory::Material);
-
-        // ── category_index: lookup by ConceptCategory ───────────────────────
-        let materials = restored.by_category(&ConceptCategory::Material);
-        assert_eq!(
-            materials.len(),
-            2,
-            "category_index must contain exactly 2 Material nodes after round-trip"
-        );
-        assert!(
-            materials.contains(&r_mat1),
-            "category_index must include mat1"
-        );
-        assert!(
-            materials.contains(&r_mat2),
-            "category_index must include mat2"
-        );
-
-        let locations = restored.by_category(&ConceptCategory::Location);
-        assert_eq!(
-            locations.len(),
-            1,
-            "category_index must contain exactly 1 Location node after round-trip"
-        );
-        assert!(
-            locations.contains(&r_loc),
-            "category_index must include loc"
-        );
-
-        // ── timeline: ordered discovery log ─────────────────────────────────
-        let tl = restored.timeline();
-        assert_eq!(
-            tl.len(),
-            3,
-            "timeline must contain all 3 discovered concepts"
-        );
-
-        // Timeline must be ordered by discovery tick (ascending).
-        let ticks: Vec<u64> = tl.iter().map(|(t, _)| *t).collect();
-        assert_eq!(
-            ticks,
-            vec![1, 2, 3],
-            "timeline must be ordered by discovery tick after round-trip"
-        );
-
-        // Each timeline entry must point to the correct node.
-        assert_eq!(tl[0].1, r_mat1, "timeline[0] must reference mat1");
-        assert_eq!(tl[1].1, r_mat2, "timeline[1] must reference mat2");
-        assert_eq!(tl[2].1, r_loc, "timeline[2] must reference loc");
-    }
-
-    // ── update_knowledge_graph system tests ──────────────────────────────
-
-    use crate::journal::{Observation, ObservationCategory, RecordObservation};
-    use crate::materials::MaterialCatalog;
-
-    /// Build a minimal Bevy App with the message channel and system under test.
-    fn build_test_app() -> App {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
-        app.add_message::<RecordObservation>();
-        app.init_resource::<KnowledgeGraph>();
-        app.init_resource::<MaterialCatalog>();
-        app.init_resource::<KnowledgeGraphConfig>();
-        app.add_systems(Update, update_knowledge_graph);
-        app
-    }
-
-    /// Inject a single [`RecordObservation`] message via a one-shot system.
-    fn inject_observation(app: &mut App, obs: RecordObservation) {
-        fn write_obs(
-            input: bevy::ecs::system::In<RecordObservation>,
-            mut writer: MessageWriter<RecordObservation>,
-        ) {
-            writer.write(input.0.clone());
-        }
-        app.world_mut()
-            .run_system_cached_with(write_obs, obs)
-            .expect("one-shot system must run");
-    }
-
-    /// Construct a minimal [`RecordObservation`] for a material with no
-    /// cross-reference metadata.
-    fn material_obs(seed: u64) -> RecordObservation {
-        RecordObservation {
-            key: JournalKey::Material {
-                seed,
-                planet_seed: None,
-            },
-            name: format!("Mat-{seed}"),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: None,
-        }
+        assert!(restored.timeline()[0].0 <= restored.timeline()[1].0);
     }
 
     #[test]
-    fn material_observation_creates_concept_node() {
-        let mut app = build_test_app();
-        inject_observation(&mut app, material_obs(42));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id = ConceptId::new(JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        });
-        assert!(
-            graph.lookup(&id).is_some(),
-            "concept node must be created for observed material"
-        );
-    }
-
-    #[test]
-    fn material_with_context_location_creates_found_on_edge() {
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 999,
-            planet_seed: Some(999),
-        };
-
-        let obs = RecordObservation {
-            key: JournalKey::Material {
-                seed: 1,
-                planet_seed: None,
-            },
-            name: "Mat-1".to_string(),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: Some(location_key.clone()),
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let mat_id = ConceptId::new(JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        });
-        let loc_id = ConceptId::new(location_key);
-
-        let mat_node = graph.lookup(&mat_id).expect("material concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // Forward edge: material → FoundOn → location
-        let rels = graph.relationships(mat_node);
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == loc_node && e.relationship == RelationshipType::FoundOn),
-            "material must have FoundOn edge to location"
-        );
-
-        // Reverse edge: location → FoundOn → material (bidirectional)
-        let loc_rels = graph.relationships(loc_node);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| *n == mat_node && e.relationship == RelationshipType::FoundOn),
-            "location must have reverse FoundOn edge back to material"
-        );
-    }
-
-    #[test]
-    fn non_material_with_context_location_creates_observed_at_edge() {
-        // A Fabrication observation with a context_location must produce an
-        // ObservedAt edge (not FoundOn) between the fabrication concept and the
-        // location concept, and the reverse edge must also exist.
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 77,
-            planet_seed: None,
-        };
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 55 },
-            name: "Output-55".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(0.9),
-                description: "fabricated at location".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: Some(location_key.clone()),
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-
-        let fab_id = ConceptId::new(JournalKey::Fabrication { output_seed: 55 });
-        let loc_id = ConceptId::new(location_key);
-
-        let fab_node = graph
-            .lookup(&fab_id)
-            .expect("fabrication concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // Forward edge: fabrication → ObservedAt → location
-        let fab_rels = graph.relationships(fab_node);
-        assert!(
-            fab_rels
-                .iter()
-                .any(|(n, e)| *n == loc_node && e.relationship == RelationshipType::ObservedAt),
-            "fabrication must have ObservedAt edge to location"
-        );
-
-        // Reverse edge: location → ObservedAt → fabrication (bidirectional)
-        let loc_rels = graph.relationships(loc_node);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| *n == fab_node && e.relationship == RelationshipType::ObservedAt),
-            "location must have reverse ObservedAt edge back to fabrication"
-        );
-    }
-
-    #[test]
-    fn fabrication_observation_creates_derived_from_edges() {
-        let mut app = build_test_app();
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 100 },
-            name: "Output-100".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(1.0),
-                description: "fabricated".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![10, 20],
-            context_location: None,
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let output_id = ConceptId::new(JournalKey::Fabrication { output_seed: 100 });
-        let input_a_id = ConceptId::new(JournalKey::Material {
-            seed: 10,
-            planet_seed: None,
-        });
-        let input_b_id = ConceptId::new(JournalKey::Material {
-            seed: 20,
-            planet_seed: None,
-        });
-
-        let output_node = graph.lookup(&output_id).expect("output concept must exist");
-        let input_a_node = graph
-            .lookup(&input_a_id)
-            .expect("input A concept must exist");
-        let input_b_node = graph
-            .lookup(&input_b_id)
-            .expect("input B concept must exist");
-
-        // Output → DerivedFrom → each input
-        let rels = graph.relationships(output_node);
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == input_a_node && e.relationship == RelationshipType::DerivedFrom),
-            "output must have DerivedFrom edge to input A"
-        );
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == input_b_node && e.relationship == RelationshipType::DerivedFrom),
-            "output must have DerivedFrom edge to input B"
-        );
-    }
-
-    #[test]
-    fn fabrication_observation_creates_combined_with_edges_between_inputs() {
-        let mut app = build_test_app();
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 200 },
-            name: "Output-200".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(1.0),
-                description: "fabricated".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![30, 40],
-            context_location: None,
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let input_a_id = ConceptId::new(JournalKey::Material {
-            seed: 30,
-            planet_seed: None,
-        });
-        let input_b_id = ConceptId::new(JournalKey::Material {
-            seed: 40,
-            planet_seed: None,
-        });
-
-        let input_a_node = graph
-            .lookup(&input_a_id)
-            .expect("input A concept must exist");
-        let input_b_node = graph
-            .lookup(&input_b_id)
-            .expect("input B concept must exist");
-
-        // Input A → CombinedWith → Input B (and reverse via bidirectionality)
-        let rels_a = graph.relationships(input_a_node);
-        assert!(
-            rels_a.iter().any(|(n, e)| {
-                *n == input_b_node && e.relationship == RelationshipType::CombinedWith
-            }),
-            "input A must have CombinedWith edge to input B"
-        );
-
-        let rels_b = graph.relationships(input_b_node);
-        assert!(
-            rels_b.iter().any(|(n, e)| {
-                *n == input_a_node && e.relationship == RelationshipType::CombinedWith
-            }),
-            "input B must have reverse CombinedWith edge to input A"
-        );
-    }
-
-    #[test]
-    fn repeated_observation_strengthens_edge_not_duplicates() {
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 777,
-            planet_seed: Some(777),
-        };
-
-        // Send the same material+location observation twice.
-        for _ in 0..2 {
-            let obs = RecordObservation {
-                key: JournalKey::Material {
-                    seed: 5,
-                    planet_seed: None,
-                },
-                name: "Mat-5".to_string(),
-                observation: Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.3),
-                    description: "test".to_string(),
-                    recorded_at: 0,
-                },
-                input_seeds: vec![],
-                context_location: Some(location_key.clone()),
-            };
-            inject_observation(&mut app, obs);
-            app.update();
-        }
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let mat_id = ConceptId::new(JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        });
-        let loc_id = ConceptId::new(location_key);
-
-        let mat_node = graph.lookup(&mat_id).expect("material concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // There must be exactly one FoundOn edge from material to location
-        // (strengthened, not duplicated).
-        let rels = graph.relationships(mat_node);
-        let found_on_edges: Vec<_> = rels
-            .iter()
-            .filter(|(n, e)| *n == loc_node && e.relationship == RelationshipType::FoundOn)
-            .collect();
-        assert_eq!(
-            found_on_edges.len(),
-            1,
-            "repeated observation must strengthen the edge, not create a duplicate"
-        );
-        // Confidence must be higher than a single observation (0.3 + 0.3 = 0.6).
-        assert!(
-            found_on_edges[0].1.confidence.0 > 0.3,
-            "confidence must accumulate across repeated observations"
-        );
-    }
-
-    #[test]
-    fn observation_without_context_creates_no_location_edge() {
-        let mut app = build_test_app();
-        inject_observation(&mut app, material_obs(99));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id = ConceptId::new(JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        });
-        let node = graph.lookup(&id).expect("concept must exist");
-
-        // No edges should exist — no context_location was provided.
-        assert!(
-            graph.relationships(node).is_empty(),
-            "observation without context_location must not create any edges"
-        );
-    }
-
-    // ── Similarity detection tests ────────────────────────────────────────
-
-    /// Seeds 0 and 4 have cosine similarity ≈ 0.9255, which exceeds the 0.85
-    /// threshold. Both are registered in the catalog before observations are
-    /// sent so the system can compare them.
-    const SIMILAR_SEED_A: u64 = 0;
-    const SIMILAR_SEED_B: u64 = 4;
-
-    /// Build a test app with both similar materials pre-registered in the catalog.
-    fn build_test_app_with_similar_materials() -> App {
-        let mut app = build_test_app();
-        {
-            let mut catalog = app.world_mut().resource_mut::<MaterialCatalog>();
-            catalog.derive_and_register(SIMILAR_SEED_A);
-            catalog.derive_and_register(SIMILAR_SEED_B);
-        }
-        app
-    }
-
-    /// Construct a material observation with the given seed and confidence.
-    fn material_obs_with_confidence(seed: u64, confidence: f32) -> RecordObservation {
-        RecordObservation {
-            key: JournalKey::Material {
-                seed,
-                planet_seed: None,
-            },
-            name: format!("Mat-{seed}"),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(confidence),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: None,
-        }
-    }
-
-    #[test]
-    fn similar_materials_both_observed_creates_similar_to_edge() {
-        // Both materials must be at Observed tier (≥ 0.3) for the edge to appear.
-        let mut app = build_test_app_with_similar_materials();
-
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "material A must have SimilarTo edge to material B"
-        );
-
-        // Bidirectionality: B must also link back to A.
-        let rels_b = graph.relationships(node_b);
-        assert!(
-            rels_b
-                .iter()
-                .any(|(n, e)| *n == node_a && e.relationship == RelationshipType::SimilarTo),
-            "material B must have reverse SimilarTo edge to material A"
-        );
-    }
-
-    #[test]
-    fn similar_to_edge_not_created_when_other_material_below_observed_tier() {
-        // Material B is only at Tentative tier (< 0.3) — no SimilarTo edge should appear.
-        let mut app = build_test_app_with_similar_materials();
-
-        // Observe A at Observed tier.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-        // Observe B at Tentative tier only.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.1));
-        app.update();
-        // Re-observe A — at this point B is still Tentative, so no edge.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            !rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo edge must not be created when other material is below Observed tier"
-        );
-    }
-
-    #[test]
-    fn similar_to_edge_not_created_when_subject_material_is_tentative() {
-        // Material A is only at Tentative tier (< 0.3) — no SimilarTo edge should appear
-        // even when the other material (B) is at Observed tier.
-        // This covers the symmetric case: the *triggering* material being Tentative.
-        let mut app = build_test_app_with_similar_materials();
-
-        // Observe B at Observed tier first.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.5));
-        app.update();
-        // Observe A at Tentative tier only — similarity check runs but A is below threshold.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.1));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        // A is Tentative — no SimilarTo edge from A to B.
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            !rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo edge must not be created when subject material is below Observed tier"
-        );
-
-        // B is Observed but A is Tentative — no reverse edge from B to A either.
-        let rels_b = graph.relationships(node_b);
-        assert!(
-            !rels_b
-                .iter()
-                .any(|(n, e)| *n == node_a && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo reverse edge must not be created when subject material is below Observed tier"
-        );
-    }
-
-    #[test]
-    fn similar_to_not_created_for_dissimilar_materials() {
-        // Seeds 1 and 2 are unlikely to be similar — verify no SimilarTo edge.
-        // We use seeds that are known to be dissimilar (< 0.85 threshold).
-        // Seeds 1 and 2 have low similarity by inspection of the property space.
-        let mut app = build_test_app();
-        {
-            let mut catalog = app.world_mut().resource_mut::<MaterialCatalog>();
-            catalog.derive_and_register(1);
-            catalog.derive_and_register(2);
-        }
-
-        inject_observation(&mut app, material_obs_with_confidence(1, 0.5));
-        app.update();
-        inject_observation(&mut app, material_obs_with_confidence(2, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_1 = ConceptId::new(JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        });
-        let id_2 = ConceptId::new(JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        });
-
-        // Verify these seeds are actually dissimilar before asserting.
-        {
-            use crate::materials::{cosine_similarity, derive_material_from_seed};
-            let m1 = derive_material_from_seed(1);
-            let m2 = derive_material_from_seed(2);
-            let sim = cosine_similarity(&m1.property_vector(), &m2.property_vector());
-            if sim >= DEFAULT_SIMILARITY_SCORE_THRESHOLD {
-                // Seeds turned out to be similar — skip the assertion.
-                return;
-            }
-        }
-
-        let node_1 = graph.lookup(&id_1).expect("material 1 concept must exist");
-        let node_2 = graph.lookup(&id_2).expect("material 2 concept must exist");
-
-        let rels_1 = graph.relationships(node_1);
-        assert!(
-            !rels_1
-                .iter()
-                .any(|(n, e)| *n == node_2 && e.relationship == RelationshipType::SimilarTo),
-            "dissimilar materials must not have SimilarTo edge"
-        );
-    }
-
-    #[test]
-    fn detect_similarity_returns_seeds_above_threshold() {
-        use crate::materials::derive_material_from_seed;
-
-        let mut catalog = MaterialCatalog::default();
-        catalog.derive_and_register(SIMILAR_SEED_A);
-        catalog.derive_and_register(SIMILAR_SEED_B);
-
-        let subject = derive_material_from_seed(SIMILAR_SEED_A);
-        let results = detect_similarity(
-            SIMILAR_SEED_A,
-            &subject,
-            &catalog,
-            DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-        );
-
-        // SIMILAR_SEED_B must appear in results.
-        assert!(
-            results.iter().any(|(seed, _)| *seed == SIMILAR_SEED_B),
-            "detect_similarity must return SIMILAR_SEED_B for SIMILAR_SEED_A"
-        );
-
-        // Self must not appear.
-        assert!(
-            !results.iter().any(|(seed, _)| *seed == SIMILAR_SEED_A),
-            "detect_similarity must not return the subject seed itself"
-        );
-
-        // All returned scores must be at or above the threshold.
-        for (_, score) in &results {
-            assert!(
-                *score >= DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-                "all returned scores must be >= DEFAULT_SIMILARITY_SCORE_THRESHOLD, got {score}"
-            );
-        }
+    fn round_trip_preserves_all_indexes() {
+        let mut graph = KnowledgeGraph::default();
+        // Add several concepts across categories.
+        graph.ensure_concept(mat_id(1), ConceptCategory::Material, 5);
+        graph.ensure_concept(mat_id(2), ConceptCategory::Material, 10);
+        graph.ensure_concept(loc_id(1), ConceptCategory::Location, 15);
+
+        let json = serde_json::to_string(&graph).expect("serialize");
+        let restored: KnowledgeGraph = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored.by_category(&ConceptCategory::Material).len(), 2);
+        assert_eq!(restored.by_category(&ConceptCategory::Location).len(), 1);
+        assert_eq!(restored.timeline().len(), 3);
+        // Timeline must be sorted by tick after deserialization.
+        let ticks: Vec<u64> = restored.timeline().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![5, 10, 15]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod carry_feedback;
 pub mod combination;
 pub mod debug_overlay;
 pub mod descriptions;
+pub mod diegetic_ui;
 pub mod fabricator;
 pub mod heat;
 pub mod input;
@@ -67,12 +68,14 @@ pub fn add_game_plugins(app: &mut App) {
         .add_plugins(observation::ObservationPlugin)
         // Journal: player-owned record of observations and fabrication history.
         .add_plugins(journal::JournalPlugin)
-        // Knowledge graph: cross-reference system linking journal entries.
+        // Knowledge graph: typed cross-reference edges between journal concepts (Story 10.5).
         .add_plugins(knowledge_graph::KnowledgeGraphPlugin)
         // Solar system: deterministic star/orbital/planet derivation from system seed.
         .add_plugins(solar_system::SolarSystemPlugin)
         // World generation: deterministic planet/chunk identity foundation for exterior systems.
         .add_plugins(world_generation::WorldGenerationPlugin)
+        // Diegetic UI: in-world information surface framework (Story 10.6).
+        .add_plugins(diegetic_ui::DiegeticUiPlugin)
         // Debug: terrain diagnostic overlay (temporary — remove before shipping).
         .add_plugins(debug_overlay::DebugOverlayPlugin);
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -34,6 +34,13 @@ pub struct MaterialPlugin;
 /// Small vertical gap between a material object and the surface it rests on.
 pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
 
+/// Number of properties in a [`GameMaterial`] property vector.
+///
+/// Used as the compile-time array size for [`GameMaterial::property_vector`]
+/// so callers never need a magic number and adding a new property automatically
+/// updates the type.
+pub const PROPERTY_DIM: usize = 5;
+
 // ── Well-known material seeds ────────────────────────────────────────────
 //
 // Migration table: maps the 10 original hand-authored material names to their
@@ -167,6 +174,16 @@ pub struct GameMaterial {
     pub seed: u64,
     /// Display colour as \[R, G, B\] in sRGB 0.0–1.0.
     pub color: [f32; 3],
+    /// The planet seed this material instance was generated on.
+    ///
+    /// Set at spawn time from `WorldProfile::planet_seed` and immutable
+    /// thereafter — this piece came from this planet, forever. Used by
+    /// observation systems to wire `FoundOn` edges in the KnowledgeGraph
+    /// and by the `CurrentPlanet` journal filter.
+    ///
+    /// `None` in contexts where no planetary world profile exists (early
+    /// bring-up, fabricated materials, integration tests).
+    pub origin_planet_seed: Option<u64>,
     /// How heavy the material feels — affects mesh shape selection.
     pub density: MaterialProperty,
     /// Resistance to heat transfer.
@@ -215,25 +232,6 @@ impl GameMaterial {
         surface_y + self.support_height() + MATERIAL_SURFACE_GAP
     }
 
-    /// Returns a normalised property vector for similarity comparison.
-    ///
-    /// The vector encodes the five core material properties in a fixed order:
-    /// `[density, thermal_resistance, reactivity, conductivity, toxicity]`.
-    /// All values are already normalised to \[0.0, 1.0\] by [`MaterialProperty`],
-    /// so cosine similarity can be applied directly without further scaling.
-    ///
-    /// Used by the cross-reference system (Story 10.5) to detect `SimilarTo`
-    /// relationships between materials whose property profiles are close.
-    pub fn property_vector(&self) -> [f32; 5] {
-        [
-            self.density.value(),
-            self.thermal_resistance.value(),
-            self.reactivity.value(),
-            self.conductivity.value(),
-            self.toxicity.value(),
-        ]
-    }
-
     /// Returns the horizontal collision radius of the mesh for this material's density.
     pub fn footprint_radius(&self) -> f32 {
         let density = self.density.value();
@@ -245,6 +243,29 @@ impl GameMaterial {
             0.13
         }
     }
+
+    /// Returns the material's measured properties as a normalised 5-dimensional
+    /// vector for cosine-similarity comparison (Story 10.5 — `SimilarTo` edges).
+    ///
+    /// Component order: `[density, thermal_resistance, reactivity, conductivity, toxicity]`.
+    ///
+    /// All values are in \[0.0, 1.0\] by construction (clamped at creation time
+    /// in [`MaterialProperty::new`]), so the cosine similarity between any two
+    /// vectors is always non-negative — no centring or normalisation required.
+    ///
+    /// The vector includes ALL five properties regardless of their visibility
+    /// state. This is intentional: the knowledge graph is the simulation layer
+    /// and operates on ground-truth data; the player only sees the similarity
+    /// when they have sufficient observation confidence (checked at call site).
+    pub fn property_vector(&self) -> [f32; PROPERTY_DIM] {
+        [
+            self.density.value(),
+            self.thermal_resistance.value(),
+            self.reactivity.value(),
+            self.conductivity.value(),
+            self.toxicity.value(),
+        ]
+    }
 }
 
 // ── Seed-derived helpers ─────────────────────────────────────────────────
@@ -252,35 +273,6 @@ impl GameMaterial {
 /// Map a `u64` into the closed unit interval \[0.0, 1.0\].
 fn unit_interval_01(value: u64) -> f32 {
     (value as f64 / u64::MAX as f64) as f32
-}
-
-/// Compute the cosine similarity between two fixed-length property vectors.
-///
-/// Returns a value in `[0.0, 1.0]` where `1.0` means identical direction
-/// (maximally similar) and `0.0` means orthogonal (no shared profile).
-/// Negative cosine similarity cannot occur here because all property values
-/// are non-negative (normalised to `[0.0, 1.0]`).
-///
-/// If either vector is the zero vector (all properties are exactly 0.0),
-/// the function returns `0.0` — a zero-vector material has no meaningful
-/// similarity to anything.
-///
-/// Used by the cross-reference system (Story 10.5) to detect `SimilarTo`
-/// relationships between materials whose property profiles are close.
-pub fn cosine_similarity(a: &[f32; 5], b: &[f32; 5]) -> f32 {
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-
-    let denom = mag_a * mag_b;
-    if denom == 0.0 {
-        // At least one vector is the zero vector — no meaningful similarity.
-        return 0.0;
-    }
-
-    // Clamp to [0.0, 1.0] to guard against floating-point rounding that could
-    // push an identical-vector comparison slightly above 1.0.
-    (dot / denom).clamp(0.0, 1.0)
 }
 
 /// Derive a complete [`GameMaterial`] deterministically from a seed.
@@ -307,6 +299,7 @@ pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
         name,
         seed,
         color,
+        origin_planet_seed: None, // set at spawn time by world generation
         density: MaterialProperty::new(
             unit_interval_01(mix_seed(seed, MAT_DENSITY_CHANNEL)),
             PropertyVisibility::Hidden,
@@ -569,6 +562,7 @@ mod tests {
             name: "Ferrite".into(),
             seed: 1001,
             color: [0.58, 0.55, 0.52],
+            origin_planet_seed: None,
             density: prop(0.78, PropertyVisibility::Observable),
             thermal_resistance: prop(0.65, PropertyVisibility::Hidden),
             reactivity: prop(0.35, PropertyVisibility::Hidden),
@@ -860,46 +854,6 @@ visibility = "Hidden"
     }
 
     #[test]
-    fn property_vector_contains_all_five_properties() {
-        let mat = sample_material();
-        let vec = mat.property_vector();
-        assert_eq!(vec.len(), 5);
-        assert!(
-            (vec[0] - mat.density.value()).abs() < f32::EPSILON,
-            "index 0 must be density"
-        );
-        assert!(
-            (vec[1] - mat.thermal_resistance.value()).abs() < f32::EPSILON,
-            "index 1 must be thermal_resistance"
-        );
-        assert!(
-            (vec[2] - mat.reactivity.value()).abs() < f32::EPSILON,
-            "index 2 must be reactivity"
-        );
-        assert!(
-            (vec[3] - mat.conductivity.value()).abs() < f32::EPSILON,
-            "index 3 must be conductivity"
-        );
-        assert!(
-            (vec[4] - mat.toxicity.value()).abs() < f32::EPSILON,
-            "index 4 must be toxicity"
-        );
-    }
-
-    #[test]
-    fn property_vector_values_in_unit_range() {
-        for seed in [0u64, 1, 42, u64::MAX, 0xDEAD_BEEF] {
-            let mat = derive_material_from_seed(seed);
-            for (i, &v) in mat.property_vector().iter().enumerate() {
-                assert!(
-                    (0.0..=1.0).contains(&v),
-                    "seed {seed:#X}: property_vector[{i}] = {v} out of [0,1]"
-                );
-            }
-        }
-    }
-
-    #[test]
     fn mix_seed_deterministic() {
         let a = mix_seed(100, 200);
         let b = mix_seed(100, 200);
@@ -919,80 +873,6 @@ visibility = "Hidden"
         assert!((unit_interval_01(u64::MAX) - 1.0).abs() < f32::EPSILON);
         let mid = unit_interval_01(u64::MAX / 2);
         assert!((0.0..=1.0).contains(&mid));
-    }
-
-    #[test]
-    fn cosine_similarity_identical_vectors_returns_one() {
-        let v = [0.5_f32, 0.3, 0.8, 0.1, 0.6];
-        let result = cosine_similarity(&v, &v);
-        assert!(
-            (result - 1.0).abs() < 1e-6,
-            "identical vectors must have similarity 1.0, got {result}"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_orthogonal_vectors_returns_zero() {
-        // Two vectors with no overlapping non-zero components are orthogonal.
-        let a = [1.0_f32, 0.0, 0.0, 0.0, 0.0];
-        let b = [0.0_f32, 1.0, 0.0, 0.0, 0.0];
-        let result = cosine_similarity(&a, &b);
-        assert!(
-            result.abs() < 1e-6,
-            "orthogonal vectors must have similarity 0.0, got {result}"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_zero_vector_returns_zero() {
-        let zero = [0.0_f32; 5];
-        let v = [0.5_f32, 0.3, 0.8, 0.1, 0.6];
-        assert_eq!(
-            cosine_similarity(&zero, &v),
-            0.0,
-            "zero vector vs any vector must return 0.0"
-        );
-        assert_eq!(
-            cosine_similarity(&v, &zero),
-            0.0,
-            "any vector vs zero vector must return 0.0"
-        );
-        assert_eq!(
-            cosine_similarity(&zero, &zero),
-            0.0,
-            "zero vector vs zero vector must return 0.0"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_result_in_unit_range() {
-        // Spot-check a handful of seed-derived materials to confirm the result
-        // is always in [0.0, 1.0].
-        let seeds: &[u64] = &[0x1, 0xDEAD_BEEF, 0xCAFE_BABE, 0xFFFF_FFFF_FFFF_FFFF];
-        for &s1 in seeds {
-            for &s2 in seeds {
-                let m1 = derive_material_from_seed(s1);
-                let m2 = derive_material_from_seed(s2);
-                let sim = cosine_similarity(&m1.property_vector(), &m2.property_vector());
-                assert!(
-                    (0.0..=1.0).contains(&sim),
-                    "cosine_similarity({s1:#X}, {s2:#X}) = {sim} out of [0,1]"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn cosine_similarity_partial_overlap_between_zero_and_one() {
-        // Vectors that share some but not all components should yield a value
-        // strictly between 0 and 1.
-        let a = [1.0_f32, 1.0, 0.0, 0.0, 0.0];
-        let b = [1.0_f32, 0.0, 1.0, 0.0, 0.0];
-        let result = cosine_similarity(&a, &b);
-        assert!(
-            result > 0.0 && result < 1.0,
-            "partial overlap must yield similarity in (0, 1), got {result}"
-        );
     }
 
     // ── Collision-avoidance tests ────────────────────────────────────────

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -14,15 +14,15 @@
 //! Legacy TOML files under `assets/materials/` are retained as reference
 //! documentation but are no longer loaded at startup.
 //!
-//! The `spawn_material_objects` system creates 3D entities from the catalog and
-//! distributes them across [`Surface`](crate::scene::Surface) shelves.
+//! Materials are spawned in the world exclusively through exterior chunk
+//! generation — deposits place entities with `origin_planet_seed` stamped at
+//! spawn time. There is no longer a room-based starter set.
 
 use std::collections::HashMap;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::scene::Shelf;
 use crate::seed_util::{
     MAT_COLOR_B_CHANNEL, MAT_COLOR_G_CHANNEL, MAT_COLOR_R_CHANNEL, MAT_CONDUCTIVITY_CHANNEL,
     MAT_DENSITY_CHANNEL, MAT_REACTIVITY_CHANNEL, MAT_THERMAL_RESISTANCE_CHANNEL,
@@ -66,8 +66,7 @@ pub const WELL_KNOWN_MATERIAL_SEEDS: &[(&str, u64)] = &[
 
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreStartup, load_material_catalog)
-            .add_systems(PostStartup, spawn_material_objects);
+        app.add_systems(PreStartup, load_material_catalog);
 
         // In debug builds, run a per-frame assertion that no GameMaterial entity
         // has more than one of the three mutually-exclusive location markers:
@@ -454,73 +453,6 @@ impl MaterialCatalog {
 /// The material's data is on the same entity as a [`GameMaterial`] component.
 #[derive(Component, Debug)]
 pub struct MaterialObject;
-
-// ── Spawning ─────────────────────────────────────────────────────────────
-
-const OBJECT_SCALE: f32 = 1.0;
-
-/// Places a 3D entity for each material in the catalog onto the `Surface`
-/// entities created by the scene plugin. Materials are distributed across
-/// surfaces round-robin and offset so they don't overlap.
-fn spawn_material_objects(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut std_materials: ResMut<Assets<StandardMaterial>>,
-    catalog: Res<MaterialCatalog>,
-    shelves: Query<&Transform, With<Shelf>>,
-) {
-    let shelf_transforms: Vec<&Transform> = shelves.iter().collect();
-    if shelf_transforms.is_empty() {
-        warn!("No Shelf entities found — materials will not be spawned in the world");
-        return;
-    }
-
-    let mut sorted_names: Vec<&String> = catalog.names().collect();
-    sorted_names.sort();
-
-    for (i, name) in sorted_names.iter().enumerate() {
-        let mat = catalog
-            .get_by_name(name)
-            .expect("name index references a valid material");
-        let surface_tf = shelf_transforms[i % shelf_transforms.len()];
-
-        let items_on_this_surface = sorted_names
-            .iter()
-            .enumerate()
-            .filter(|(j, _)| j % shelf_transforms.len() == i % shelf_transforms.len())
-            .position(|(j, _)| j == i)
-            .unwrap_or(0);
-
-        let x_offset = (items_on_this_surface as f32) * 0.3 - 0.3;
-
-        let mesh = mat.mesh_for_density(&mut meshes);
-        let render_mat = std_materials.add(StandardMaterial {
-            base_color: mat.bevy_color(),
-            perceptual_roughness: 0.5,
-            metallic: if mat.conductivity.value() > 0.6 {
-                0.6
-            } else {
-                0.1
-            },
-            ..default()
-        });
-
-        commands.spawn((
-            MaterialObject,
-            mat.clone(),
-            Mesh3d(mesh),
-            MeshMaterial3d(render_mat),
-            Transform::from_xyz(
-                surface_tf.translation.x + x_offset,
-                mat.resting_center_y(surface_tf.translation.y),
-                surface_tf.translation.z,
-            )
-            .with_scale(Vec3::splat(OBJECT_SCALE)),
-        ));
-
-        info!("Spawned material object '{}' on surface", mat.name);
-    }
-}
 
 // ── Loading ──────────────────────────────────────────────────────────────
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -202,6 +202,18 @@ pub struct ConfidenceConfig {
     /// Lower values require more repeated testing. Typical range: 0.1-0.3
     #[serde(default = "default_base_observation_weight")]
     pub base_observation_weight: f32,
+
+    /// Cosine similarity threshold above which two materials are considered
+    /// "similar" for the purposes of wiring `SimilarTo` edges in the knowledge
+    /// graph (Story 10.5).
+    ///
+    /// A value of 1.0 means "identical property vectors only"; lower values
+    /// surface more pairs as similar. Values below 0.5 are not recommended —
+    /// they tend to produce spurious connections that erode trust in the journal.
+    ///
+    /// Typical range: 0.80-0.95
+    #[serde(default = "default_similarity_threshold")]
+    pub similarity_threshold: f32,
 }
 
 /// Default value for death_degradation_factor field.
@@ -229,6 +241,11 @@ fn default_base_observation_weight() -> f32 {
     0.2
 }
 
+/// Default cosine similarity threshold for `SimilarTo` edge creation.
+fn default_similarity_threshold() -> f32 {
+    0.85
+}
+
 impl Default for ConfidenceConfig {
     /// Default confidence configuration values.
     ///
@@ -242,6 +259,7 @@ impl Default for ConfidenceConfig {
             domain_recovery_multiplier: 2.0,  // 2x recovery in death domain
             passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
             base_observation_weight: 0.2,     // Standard observation strength
+            similarity_threshold: 0.85,       // 85% cosine similarity = "similar materials"
         }
     }
 }
@@ -1567,6 +1585,7 @@ mod tests {
             domain_recovery_multiplier: 2.5,
             passive_recovery_multiplier: 0.8,
             base_observation_weight: 0.25,
+            similarity_threshold: 0.85,
         };
 
         let toml = toml::to_string(&config).expect("ConfidenceConfig should serialize to TOML");
@@ -2653,6 +2672,7 @@ mod tests {
                 domain_recovery_multiplier: 2.0,
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
+                similarity_threshold: 0.85,
             })
             .insert_resource(Time::<()>::default());
 
@@ -2661,10 +2681,7 @@ mod tests {
 
         // Add observations with high confidence
         journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: 42 },
             "Test Material",
             Observation {
                 category: ObservationCategory::ThermalBehavior,
@@ -2675,10 +2692,7 @@ mod tests {
         );
 
         journal.record(
-            JournalKey::Material {
-                seed: 99,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: 99 },
             "Another Material",
             Observation {
                 category: ObservationCategory::Weight,
@@ -2690,10 +2704,7 @@ mod tests {
 
         // Add observation with medium confidence
         journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: 42 },
             "Test Material",
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
@@ -2708,21 +2719,12 @@ mod tests {
 
         // Verify initial confidence levels
         let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-        let weight_obs = &journal.entries[&JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::Weight][0];
-        let surface_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::SurfaceAppearance][0];
+        let thermal_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::ThermalBehavior][0];
+        let weight_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 99 }].observations
+            [&ObservationCategory::Weight][0];
+        let surface_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::SurfaceAppearance][0];
 
         assert_eq!(thermal_obs.confidence.0, 0.8);
         assert_eq!(weight_obs.confidence.0, 0.9);
@@ -2740,21 +2742,12 @@ mod tests {
 
         // Verify confidence has been degraded
         let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-        let weight_obs = &journal.entries[&JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::Weight][0];
-        let surface_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::SurfaceAppearance][0];
+        let thermal_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::ThermalBehavior][0];
+        let weight_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 99 }].observations
+            [&ObservationCategory::Weight][0];
+        let surface_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::SurfaceAppearance][0];
 
         // Expected values: original * 0.6, but not below 0.2 floor
         assert_eq!(thermal_obs.confidence.0, 0.8 * 0.6); // 0.48
@@ -2777,6 +2770,7 @@ mod tests {
                 domain_recovery_multiplier: 2.0,
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
+                similarity_threshold: 0.85,
             })
             .insert_resource(Time::<()>::default());
 
@@ -2784,10 +2778,7 @@ mod tests {
         let mut journal = Journal::default();
 
         journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
+            JournalKey::MaterialInstance { seed: 42 },
             "Test Material",
             Observation {
                 category: ObservationCategory::ThermalBehavior,
@@ -2801,11 +2792,8 @@ mod tests {
 
         // Verify initial confidence
         let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
+        let thermal_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::ThermalBehavior][0];
         assert_eq!(thermal_obs.confidence.0, 0.4);
 
         // Emit death event
@@ -2821,11 +2809,8 @@ mod tests {
         // Verify confidence was clamped to floor
         // Expected: 0.4 * 0.5 = 0.2, but floor is 0.3, so should be 0.3
         let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
+        let thermal_obs = &journal.entries[&JournalKey::MaterialInstance { seed: 42 }].observations
+            [&ObservationCategory::ThermalBehavior][0];
 
         assert_eq!(thermal_obs.confidence.0, 0.3); // Clamped to floor
     }
@@ -2910,6 +2895,7 @@ mod tests {
             domain_recovery_multiplier: 2.0,
             passive_recovery_multiplier: 0.7,
             base_observation_weight: 0.2,
+            similarity_threshold: 0.85,
         };
 
         let context = DeathContext::new(DeathCause::HeatSystem, 1000);
@@ -2986,6 +2972,7 @@ mod tests {
             domain_recovery_multiplier: 2.0, // 2x recovery in death domain
             passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
             base_observation_weight: 0.2,
+            similarity_threshold: 0.85,
         };
 
         // Create death context for heat system death

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -631,9 +631,12 @@ fn sync_active_exterior_chunks(
                 continue;
             }
 
-            let deposit_material = material_catalog
+            let mut deposit_material = material_catalog
                 .derive_and_register(placement.material_seed)
                 .clone();
+            // Tag the spawn origin so observation systems can wire the FoundOn
+            // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
+            deposit_material.origin_planet_seed = Some(world_profile.planet_seed.0);
             let mesh = deposit_material.mesh_for_density(&mut meshes);
             let render_material = render_materials.add(StandardMaterial {
                 base_color: deposit_material.bevy_color(),

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -802,6 +802,7 @@ fn sample_game_material(name: &str) -> GameMaterial {
         name: name.to_string(),
         seed: 42,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: MaterialProperty::new(0.5, PropertyVisibility::Observable),
         thermal_resistance: MaterialProperty::new(0.5, PropertyVisibility::Observable),
         reactivity: MaterialProperty::new(0.5, PropertyVisibility::Observable),

--- a/tests/carry_processing.rs
+++ b/tests/carry_processing.rs
@@ -26,6 +26,7 @@ fn test_material(name: &str, density: f32, seed: u64) -> GameMaterial {
         name: name.into(),
         seed,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: prop(density),
         thermal_resistance: prop(0.5),
         reactivity: prop(0.5),

--- a/tests/scenarios/helpers.rs
+++ b/tests/scenarios/helpers.rs
@@ -18,6 +18,7 @@ pub fn test_material(name: &str, density: f32, seed: u64) -> GameMaterial {
         name: name.into(),
         seed,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: prop(density),
         thermal_resistance: prop(0.5),
         reactivity: prop(0.5),


### PR DESCRIPTION
## Summary

Removes the `spawn_material_objects` system that placed well-known starter materials on room shelves at `PostStartup`.

## Problem

Indoor-spawned materials never had `origin_planet_seed` set (`None`), so:
- `RecordObservation` fired with `planet_seed: None` on heat exposure
- No `FoundOn` edge was ever created in the KnowledgeGraph
- Materials picked up in the room were invisible to the `CurrentPlanet` journal filter

## Fix

- Removed `spawn_material_objects` system and its `Shelf` import
- Removed `.add_systems(PostStartup, spawn_material_objects)` registration
- Updated module doc to reflect that exterior deposits are the sole source of material entities
- The `WELL_KNOWN_MATERIAL_SEEDS` catalog pre-seeding is retained for performance

The room shelves are now empty. All material observations come from exterior deposits, which always have `origin_planet_seed` stamped at spawn time.

The room itself is considered temporary scaffolding and may be removed in a future story.

## Tests

All 688 tests pass. `make check` clean.