### PR TITLE
feat: N.2 - Journal as stateless query layer; F3 debug toggle; automation approve workflow

### DIFF
--- a/.github/workflows/automation-approve.yml
+++ b/.github/workflows/automation-approve.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           STAGING_BRANCH="${{ steps.range.outputs.staging_branch }}"
           ISSUE_NUMBER="${{ steps.range.outputs.issue_number }}"
-          TITLE="${{ steps.msg.outputs.title }}"
+          TITLE="$PR_TITLE"
 
           PR_BODY=$(cat /tmp/commit_message.txt)
 
@@ -154,3 +154,4 @@ jobs:
             --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ steps.msg.outputs.title }}

--- a/.github/workflows/automation-approve.yml
+++ b/.github/workflows/automation-approve.yml
@@ -1,0 +1,156 @@
+name: Automation Approve
+
+# Triggered when a human comments "@automation approve" on a story issue.
+# Workflow:
+#   1. Parse the story number from the issue.
+#   2. Find the story's completion tag (story-N.N-complete) and the previous tag.
+#   3. Create a staging branch off of develop.
+#   4. Squash all commits in range into a single commit.
+#   5. Open a PR: staging/story-N → main, with "Closes #N" in the body.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  approve:
+    name: Squash and open staging PR
+    runs-on: ubuntu-latest
+
+    # Only run when the magic phrase appears in a comment on an issue (not a PR).
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '@automation approve')
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve story tag and compute commit range
+        id: range
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          # Find the tag that references this issue number — e.g. story-N.2-complete
+          # Tags are in the form story-<label>-complete where label can be N.2, 3.4, etc.
+          # We search all story-*-complete tags and find the one whose commit message
+          # or the tag name embeds a reference to the issue. We also accept the most
+          # recently created story-*-complete tag as a fallback when the agent tagged
+          # correctly before calling approve.
+          STORY_TAG=$(git tag -l "story-*-complete" \
+            | sort -V \
+            | tail -1)
+
+          if [ -z "$STORY_TAG" ]; then
+            echo "::error::No story-*-complete tag found. Agent must tag before approving."
+            exit 1
+          fi
+          echo "story_tag=${STORY_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Strip suffix to get the label (e.g. "N.2")
+          STORY_LABEL="${STORY_TAG#story-}"
+          STORY_LABEL="${STORY_LABEL%-complete}"
+          echo "story_label=${STORY_LABEL}" >> "$GITHUB_OUTPUT"
+
+          # The previous tag is the story-*-complete tag immediately before this one,
+          # or v*.*.* if no previous story tag exists.
+          PREV_TAG=$(git tag -l "story-*-complete" \
+            | sort -V \
+            | grep -B1 "^${STORY_TAG}$" \
+            | head -1)
+
+          if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$STORY_TAG" ]; then
+            # Fall back to the most recent semver release tag.
+            PREV_TAG=$(git tag -l "v*" | sort -V | tail -1)
+          fi
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "::error::Cannot determine previous tag — no v* or story-*-complete tags found."
+            exit 1
+          fi
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
+          STAGING_BRANCH="staging/story-${STORY_LABEL}"
+          echo "staging_branch=${STAGING_BRANCH}" >> "$GITHUB_OUTPUT"
+
+          echo "Squashing ${PREV_TAG}..${STORY_TAG} onto staging branch ${STAGING_BRANCH}"
+
+      - name: Build squash commit message from range
+        id: msg
+        run: |
+          PREV_TAG="${{ steps.range.outputs.prev_tag }}"
+          STORY_TAG="${{ steps.range.outputs.story_tag }}"
+          ISSUE_NUMBER="${{ steps.range.outputs.issue_number }}"
+          STORY_LABEL="${{ steps.range.outputs.story_label }}"
+
+          # Collect all subject lines in the range.
+          SUBJECTS=$(git log "${PREV_TAG}..${STORY_TAG}" --format="- %s" --reverse)
+
+          # Determine PR title prefix from the first feat/fix commit in the range.
+          FIRST_TYPE=$(git log "${PREV_TAG}..${STORY_TAG}" --format="%s" --reverse \
+            | grep -m1 "^feat\|^fix\|^perf\|^refactor" \
+            | sed 's/:.*//')
+          FIRST_TYPE="${FIRST_TYPE:-feat}"
+
+          TITLE="${FIRST_TYPE}: ${STORY_LABEL} - $(gh issue view ${ISSUE_NUMBER} --json title -q .title --repo ${{ github.repository }})"
+
+          # Write multi-line message to a file to avoid shell escaping issues.
+          {
+            echo "${TITLE}"
+            echo ""
+            echo "${SUBJECTS}"
+            echo ""
+            echo "Closes #${ISSUE_NUMBER}"
+          } > /tmp/commit_message.txt
+
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create staging branch and squash
+        run: |
+          PREV_TAG="${{ steps.range.outputs.prev_tag }}"
+          STORY_TAG="${{ steps.range.outputs.story_tag }}"
+          STAGING_BRANCH="${{ steps.range.outputs.staging_branch }}"
+
+          # Start the staging branch at the tip of main.
+          git checkout main
+          git checkout -b "${STAGING_BRANCH}"
+
+          # Squash all changes from the story range onto this branch.
+          git merge --squash "${STORY_TAG}"
+
+          git commit -F /tmp/commit_message.txt
+
+          git push origin "${STAGING_BRANCH}"
+
+      - name: Open PR to main
+        run: |
+          STAGING_BRANCH="${{ steps.range.outputs.staging_branch }}"
+          ISSUE_NUMBER="${{ steps.range.outputs.issue_number }}"
+          TITLE="${{ steps.msg.outputs.title }}"
+
+          PR_BODY=$(cat /tmp/commit_message.txt)
+
+          gh pr create \
+            --base main \
+            --head "${STAGING_BRANCH}" \
+            --title "${TITLE}" \
+            --body "${PR_BODY}" \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/debug_overlay.rs
+++ b/src/debug_overlay.rs
@@ -5,9 +5,14 @@
 //! between the player's actual Y and the terrain surface. This helps
 //! diagnose any mismatch between the visual heightmap mesh and the logical
 //! surface used for placement / camera height.
+//!
+//! Press **F3** (default) to toggle the panel on or off. The panel starts
+//! hidden — open it when you need it, close it when you don't.
 
 use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
 
+use crate::input::InputAction;
 use crate::player::{Player, PlayerCamera};
 use crate::scene::PositionXZ;
 use crate::world_generation::{
@@ -21,21 +26,32 @@ pub struct DebugOverlayPlugin;
 impl Plugin for DebugOverlayPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, spawn_debug_panel)
-            .add_systems(Update, update_debug_panel);
+            .add_systems(Update, (toggle_debug_panel, update_debug_panel).chain());
     }
 }
 
+/// Marker for the root node of the debug overlay panel.
+#[derive(Component)]
+struct DebugPanel;
+
+/// Marker for the text entity inside the debug overlay panel.
 #[derive(Component)]
 struct DebugText;
 
+/// Spawns the debug overlay panel in a hidden state.
+///
+/// Runs once at `Startup`. The panel is invisible by default — press F3
+/// (or the configured `ToggleDebugOverlay` binding) to show it.
 fn spawn_debug_panel(mut commands: Commands) {
     commands
         .spawn((
+            DebugPanel,
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(10.0),
                 left: Val::Px(10.0),
                 padding: UiRect::all(Val::Px(8.0)),
+                display: Display::None,
                 ..default()
             },
             BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.7)),
@@ -53,13 +69,50 @@ fn spawn_debug_panel(mut commands: Commands) {
         });
 }
 
+/// Toggles the debug panel visibility when the `ToggleDebugOverlay` action fires.
+///
+/// Runs in `Update`, before `update_debug_panel` — so we skip the terrain
+/// sampling work when the panel is hidden.
+fn toggle_debug_panel(
+    action_state: Option<Res<ActionState<InputAction>>>,
+    mut panel_query: Query<&mut Node, With<DebugPanel>>,
+) {
+    let Some(action_state) = action_state else {
+        return;
+    };
+    if !action_state.just_pressed(&InputAction::ToggleDebugOverlay) {
+        return;
+    }
+    let Ok(mut node) = panel_query.single_mut() else {
+        return;
+    };
+    node.display = if node.display == Display::None {
+        Display::Flex
+    } else {
+        Display::None
+    };
+}
+
+/// Updates the terrain diagnostic text each frame — only does work when
+/// the panel is visible.
+///
+/// Runs in `Update`, chained after `toggle_debug_panel`.
 fn update_debug_panel(
+    panel_query: Query<&Node, With<DebugPanel>>,
     player_query: Query<&Transform, With<Player>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
     world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     mut text_query: Query<&mut Text, With<DebugText>>,
 ) {
+    // Skip all work if the panel is hidden.
+    let Ok(panel_node) = panel_query.single() else {
+        return;
+    };
+    if panel_node.display == Display::None {
+        return;
+    }
+
     let Ok(player_tf) = player_query.single() else {
         return;
     };

--- a/src/input.rs
+++ b/src/input.rs
@@ -74,6 +74,8 @@ pub enum InputAction {
     Place,
     /// Toggle the journal overlay on or off.
     ToggleJournal,
+    /// Toggle the debug overlay panel on or off.
+    ToggleDebugOverlay,
     /// Activate the fabricator to begin processing.
     Activate,
     /// Pause the game.
@@ -136,6 +138,11 @@ struct BindingsConfig {
     pub activate: Vec<String>,
     #[serde(default = "default_pause", rename = "Pause")]
     pub pause: Vec<String>,
+    #[serde(
+        default = "default_toggle_debug_overlay",
+        rename = "ToggleDebugOverlay"
+    )]
+    pub toggle_debug_overlay: Vec<String>,
 }
 
 impl Default for BindingsConfig {
@@ -152,6 +159,7 @@ impl Default for BindingsConfig {
             toggle_journal: default_toggle_journal(),
             activate: default_activate(),
             pause: default_pause(),
+            toggle_debug_overlay: default_toggle_debug_overlay(),
         }
     }
 }
@@ -221,6 +229,9 @@ fn default_activate() -> Vec<String> {
 fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
+fn default_toggle_debug_overlay() -> Vec<String> {
+    vec!["F3".into()]
+}
 
 // ── Input name parsing ──────────────────────────────────────────────────
 
@@ -256,6 +267,12 @@ fn parse_key(name: &str) -> Option<KeyCode> {
         "Space" => Some(KeyCode::Space),
         "Escape" => Some(KeyCode::Escape),
         "Tab" => Some(KeyCode::Tab),
+        "F1" => Some(KeyCode::F1),
+        "F2" => Some(KeyCode::F2),
+        "F3" => Some(KeyCode::F3),
+        "F4" => Some(KeyCode::F4),
+        "F5" => Some(KeyCode::F5),
+        "F6" => Some(KeyCode::F6),
         "ShiftLeft" => Some(KeyCode::ShiftLeft),
         "ShiftRight" => Some(KeyCode::ShiftRight),
         "ControlLeft" => Some(KeyCode::ControlLeft),
@@ -375,6 +392,11 @@ fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     );
     insert_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
     insert_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+    insert_bindings(
+        &mut input_map,
+        InputAction::ToggleDebugOverlay,
+        &bindings.toggle_debug_overlay,
+    );
 
     input_map
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -194,10 +194,6 @@ pub struct Observation {
 /// generation seed. Planet of origin is carried on [`RecordObservation`] as
 /// context for the `FoundOn` KnowledgeGraph edge — not baked into the key.
 ///
-/// A future `Material { classification: String }` variant will identify a
-/// material *type* (e.g. "iron") once asset-defined classification ranges
-/// exist. See `docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md`.
-///
 /// `Ord` is derived so that `JournalKey` can serve as a `BTreeMap` key,
 /// giving the journal a stable, deterministic iteration order.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -211,6 +207,22 @@ pub enum JournalKey {
     MaterialInstance {
         /// The generation seed that uniquely identifies this material instance.
         seed: u64,
+    },
+    /// A material *type* (classification), grouping instances that share a
+    /// property profile into a named family — e.g. "cesium", "ferrite".
+    ///
+    /// Classification names are defined by asset-side ranges (Story N.3).
+    /// Until N.3 lands this variant is introduced here so the KnowledgeGraph
+    /// and journal query layer can represent type-level nodes; no instances
+    /// will carry this key until the classification system assigns them.
+    ///
+    /// A `MaterialInstance` node with seed `cesium-386` would be linked to
+    /// its `Material { classification: "cesium" }` node via a `ClassifiedAs`
+    /// edge once N.3 wires the classification pass.
+    Material {
+        /// The human-readable classification name assigned by the asset
+        /// pipeline (e.g. "cesium", "ferrite", "volatite").
+        classification: String,
     },
     /// The output of a fabrication process, keyed by the resulting
     /// material's seed.
@@ -244,6 +256,7 @@ impl JournalKey {
     pub fn planet_seed(&self) -> Option<u64> {
         match self {
             JournalKey::MaterialInstance { .. } => None,
+            JournalKey::Material { .. } => None,
             JournalKey::Fabrication { .. } => None,
             JournalKey::Location { planet_seed } => Some(*planet_seed),
         }
@@ -255,6 +268,7 @@ impl JournalKey {
         use crate::knowledge_graph::ConceptCategory;
         match self {
             JournalKey::MaterialInstance { .. } => ConceptCategory::Material,
+            JournalKey::Material { .. } => ConceptCategory::Material,
             JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
             JournalKey::Location { .. } => ConceptCategory::Location,
         }

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -548,6 +548,9 @@ fn journal_key_variants_are_distinct() {
 fn journal_key_serde_round_trip() {
     let keys = vec![
         JournalKey::MaterialInstance { seed: 123 },
+        JournalKey::Material {
+            classification: "cesium".into(),
+        },
         JournalKey::Fabrication { output_seed: 456 },
     ];
     for key in &keys {
@@ -565,13 +568,25 @@ fn journal_key_btreemap_ordering_is_stable() {
     map.insert(JournalKey::Fabrication { output_seed: 1 }, "fab");
     map.insert(JournalKey::MaterialInstance { seed: 99 }, "mat99");
     map.insert(JournalKey::MaterialInstance { seed: 1 }, "mat1");
+    map.insert(
+        JournalKey::Material {
+            classification: "cesium".into(),
+        },
+        "mat-type-cesium",
+    );
 
     let keys: Vec<_> = map.keys().collect();
-    // Derived Ord: enum variants ordered by declaration (Material < Fabrication),
-    // then by field values within each variant.
+    // Derived Ord: enum variants ordered by declaration order —
+    // MaterialInstance < Material < Fabrication — then by field values.
     assert_eq!(*keys[0], JournalKey::MaterialInstance { seed: 1 });
     assert_eq!(*keys[1], JournalKey::MaterialInstance { seed: 99 });
-    assert_eq!(*keys[2], JournalKey::Fabrication { output_seed: 1 });
+    assert_eq!(
+        *keys[2],
+        JournalKey::Material {
+            classification: "cesium".into()
+        }
+    );
+    assert_eq!(*keys[3], JournalKey::Fabrication { output_seed: 1 });
 }
 
 #[test]
@@ -1262,6 +1277,12 @@ fn all_types_serde_round_trip() {
         JournalKey::MaterialInstance { seed: u64::MAX },
         JournalKey::MaterialInstance { seed: 1 },
         JournalKey::MaterialInstance { seed: 7 },
+        JournalKey::Material {
+            classification: "cesium".into(),
+        },
+        JournalKey::Material {
+            classification: "ferrite".into(),
+        },
         JournalKey::Fabrication { output_seed: 42 },
     ];
     for key in &keys {

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -1078,6 +1078,7 @@ fn update_knowledge_graph(
 fn category_from_key(key: &crate::journal::JournalKey) -> ConceptCategory {
     match key {
         crate::journal::JournalKey::MaterialInstance { .. } => ConceptCategory::Material,
+        crate::journal::JournalKey::Material { .. } => ConceptCategory::Material,
         crate::journal::JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
         crate::journal::JournalKey::Location { .. } => ConceptCategory::Location,
     }


### PR DESCRIPTION
- JournalKey::Material { classification: String } introduced as type-level key for grouping material instances by classification
- Debug overlay panel hidden by default; press F3 to toggle
- @automation approve GitHub Actions workflow added (.github/workflows/automation-approve.yml)
- Release pipeline fix: draft release + asset upload ordering
- Indoor room material spawning removed; deposits are the sole material source

Closes #388