### PR TITLE
feat: N.4 - combination rules keyed by material seed, not name

### DIFF
--- a/assets/config/combinations.toml
+++ b/assets/config/combinations.toml
@@ -1,8 +1,13 @@
-# Combination rules — maps material pairs to per-property rule sets.
+# Combination rules — maps material seed pairs to per-property rule sets.
 #
-# Each [[rules]] entry names two materials (order doesn't matter) and
-# specifies a rule for each property. Missing properties use the default
-# rule (Blend with equal weights).
+# Each [[rules]] entry identifies two materials by their generation seeds
+# and specifies a rule for each property. Order of seeds does not matter.
+# Missing properties use the default rule (Blend with equal weights).
+#
+# Seeds for well-known materials:
+#   1001 = Ferrite     1002 = Calcium    1003 = Sulfurite  1004 = Prismate
+#   1005 = Verdant     1006 = Osmium     1007 = Volatite   1008 = Cobaltine
+#   1009 = Silite      1010 = Phosphite
 #
 # Rule types:
 #   Blend { weight_a, weight_b }  — weighted average (predictable)
@@ -20,8 +25,8 @@ weight_b = 0.5
 # ── Specific pair rules ──────────────────────────────────────────────────
 
 [[rules]]
-material_a = "Ferrite"
-material_b = "Phosphite"
+material_seed_a = 1001  # Ferrite
+material_seed_b = 1010  # Phosphite
 density = { type = "Max" }
 thermal_resistance = { type = "Catalyze", multiplier = 1.4 }
 reactivity = { type = "Blend", weight_a = 0.7, weight_b = 0.3 }
@@ -29,8 +34,8 @@ conductivity = { type = "Min" }
 toxicity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
 
 [[rules]]
-material_a = "Volatite"
-material_b = "Calcium"
+material_seed_a = 1007  # Volatite
+material_seed_b = 1002  # Calcium
 density = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
 thermal_resistance = { type = "Min" }
 reactivity = { type = "Catalyze", multiplier = 1.6 }
@@ -38,8 +43,8 @@ conductivity = { type = "Blend", weight_a = 0.4, weight_b = 0.6 }
 toxicity = { type = "Max" }
 
 [[rules]]
-material_a = "Sulfurite"
-material_b = "Osmium"
+material_seed_a = 1003  # Sulfurite
+material_seed_b = 1006  # Osmium
 density = { type = "Inert" }
 thermal_resistance = { type = "Inert" }
 reactivity = { type = "Inert" }
@@ -47,8 +52,8 @@ conductivity = { type = "Inert" }
 toxicity = { type = "Inert" }
 
 [[rules]]
-material_a = "Cobaltine"
-material_b = "Verdant"
+material_seed_a = 1008  # Cobaltine
+material_seed_b = 1005  # Verdant
 density = { type = "Blend", weight_a = 0.3, weight_b = 0.7 }
 thermal_resistance = { type = "Max" }
 reactivity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
@@ -56,8 +61,8 @@ conductivity = { type = "Catalyze", multiplier = 1.3 }
 toxicity = { type = "Min" }
 
 [[rules]]
-material_a = "Silite"
-material_b = "Prismate"
+material_seed_a = 1009  # Silite
+material_seed_b = 1004  # Prismate
 density = { type = "Min" }
 thermal_resistance = { type = "Blend", weight_a = 0.6, weight_b = 0.4 }
 reactivity = { type = "Max" }

--- a/src/combination.rs
+++ b/src/combination.rs
@@ -132,10 +132,16 @@ struct CombinationFile {
     rules: Vec<PairRuleEntry>,
 }
 
+/// TOML schema for a single pair rule entry.
+///
+/// Uses `material_seed_a` / `material_seed_b` — the generation seeds that
+/// deterministically identify each material — rather than names. Names are
+/// query-time artefacts (classification or procedural); seeds are the stable
+/// ground-truth identity (Core Principle 6, Data Architecture ADR).
 #[derive(Debug, Deserialize)]
 struct PairRuleEntry {
-    material_a: String,
-    material_b: String,
+    material_seed_a: u64,
+    material_seed_b: u64,
     #[serde(default)]
     density: Option<PropertyRule>,
     #[serde(default)]
@@ -150,28 +156,32 @@ struct PairRuleEntry {
 
 // ── Resource ────────────────────────────────────────────────────────────
 
-/// Canonical key for a material pair — alphabetically sorted so (A,B) == (B,A).
-fn pair_key(a: &str, b: &str) -> (String, String) {
-    if a <= b {
-        (a.to_string(), b.to_string())
+/// Canonical key for a material pair — lower seed first so (A,B) == (B,A).
+fn pair_key(seed_a: u64, seed_b: u64) -> (u64, u64) {
+    if seed_a <= seed_b {
+        (seed_a, seed_b)
     } else {
-        (b.to_string(), a.to_string())
+        (seed_b, seed_a)
     }
 }
 
-/// Loaded combination rules, keyed by sorted material name pairs.
+/// Loaded combination rules, keyed by sorted material seed pairs.
+///
+/// Seeds are the stable ground-truth identity of a material — names are
+/// query-time artefacts that must never be used as storage keys (ADR).
 #[derive(Resource, Debug, Default)]
 pub struct CombinationRules {
     /// Fallback rule used when no pair-specific entry exists.
     pub default_rule: PropertyRule,
-    /// Per-pair overrides keyed by alphabetically sorted material name tuples.
-    pub pair_rules: HashMap<(String, String), PairRuleSet>,
+    /// Per-pair overrides keyed by `(min_seed, max_seed)` tuples.
+    pub pair_rules: HashMap<(u64, u64), PairRuleSet>,
 }
 
 impl CombinationRules {
-    /// Look up the rule set for a pair, falling back to the default for each property.
-    pub fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
-        let key = pair_key(name_a, name_b);
+    /// Look up the rule set for a pair by their generation seeds,
+    /// falling back to the default for each property.
+    pub fn rules_for(&self, seed_a: u64, seed_b: u64) -> PairRuleSet {
+        let key = pair_key(seed_a, seed_b);
         if let Some(rules) = self.pair_rules.get(&key) {
             rules.clone()
         } else {
@@ -200,7 +210,7 @@ fn load_combination_rules(mut commands: Commands) {
                     let mut pair_rules = HashMap::new();
 
                     for entry in file.rules {
-                        let key = pair_key(&entry.material_a, &entry.material_b);
+                        let key = pair_key(entry.material_seed_a, entry.material_seed_b);
                         let rule_set = PairRuleSet {
                             density: entry.density.unwrap_or_else(|| default.clone()),
                             thermal_resistance: entry
@@ -296,13 +306,13 @@ mod tests {
 
     #[test]
     fn pair_key_is_order_independent() {
-        assert_eq!(pair_key("Ferrite", "Silite"), pair_key("Silite", "Ferrite"));
+        assert_eq!(pair_key(1001, 1009), pair_key(1009, 1001));
     }
 
     #[test]
     fn rules_for_returns_default_for_unknown_pair() {
         let rules = CombinationRules::default();
-        let pair = rules.rules_for("Unknown", "Other");
+        let pair = rules.rules_for(9999, 8888);
         assert_eq!(pair.density, PropertyRule::default());
     }
 
@@ -321,8 +331,8 @@ weight_a = 0.5
 weight_b = 0.5
 
 [[rules]]
-material_a = "A"
-material_b = "B"
+material_seed_a = 1001
+material_seed_b = 1010
 density = { type = "Max" }
 thermal_resistance = { type = "Catalyze", multiplier = 1.3 }
 reactivity = { type = "Min" }

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -412,7 +412,7 @@ fn blend_color(a: &[f32; 3], b: &[f32; 3], catalytic: bool) -> [f32; 3] {
 // ── Main combine function ────────────────────────────────────────────────
 
 fn rule_combine(rules: &CombinationRules, a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
-    let pair_rules = rules.rules_for(&a.name, &b.name);
+    let pair_rules = rules.rules_for(a.seed, b.seed);
 
     let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);
     let name = procedural_name(combined_seed);
@@ -584,7 +584,7 @@ mod tests {
     fn catalytic_pair_shifts_color_hue() {
         let mut rules = default_rules();
         rules.pair_rules.insert(
-            ("Aaa".into(), "Bbb".into()),
+            (1, 2),
             PairRuleSet {
                 density: PropertyRule::Catalyze { multiplier: 1.5 },
                 thermal_resistance: PropertyRule::default(),
@@ -685,9 +685,7 @@ mod tests {
     #[test]
     fn inert_pair_produces_waste() {
         let mut rules = default_rules();
-        rules
-            .pair_rules
-            .insert(("Alpha".into(), "Beta".into()), PairRuleSet::all_inert());
+        rules.pair_rules.insert((1, 2), PairRuleSet::all_inert());
 
         let a = test_material("Alpha", 1, 0.8);
         let b = test_material("Beta", 2, 0.9);
@@ -727,7 +725,7 @@ mod tests {
     fn pair_order_independent() {
         let mut rules = default_rules();
         rules.pair_rules.insert(
-            ("Alpha".into(), "Beta".into()),
+            (1, 2),
             PairRuleSet {
                 density: PropertyRule::Max,
                 thermal_resistance: PropertyRule::Min,


### PR DESCRIPTION
Closes #390

- `CombinationRules.pair_rules` key changed from `(String, String)` to `(u64, u64)`
- `rules_for()` now takes seeds instead of names
- `combinations.toml` updated to use `material_seed_a` / `material_seed_b`
- `fabricator.rs` passes `a.seed, b.seed` instead of names
- No classification logic runs during world generation
- Material names in journal/inspect are classification-query-time only (from N.3)

698 tests pass, make check clean.