### PR TITLE
feat: N.4 - combination rules keyed by material seed, not name

### DIFF
--- a/.github/workflows/automation-approve.yml
+++ b/.github/workflows/automation-approve.yml
@@ -1,0 +1,157 @@
+name: Automation Approve
+
+# Triggered when a human comments "@automation approve" on a story issue.
+# Workflow:
+#   1. Parse the story number from the issue.
+#   2. Find the story's completion tag (story-N.N-complete) and the previous tag.
+#   3. Create a staging branch off of develop.
+#   4. Squash all commits in range into a single commit.
+#   5. Open a PR: staging/story-N → main, with "Closes #N" in the body.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  approve:
+    name: Squash and open staging PR
+    runs-on: ubuntu-latest
+
+    # Only run when the magic phrase appears in a comment on an issue (not a PR).
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '@automation approve')
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve story tag and compute commit range
+        id: range
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          # Find the tag that references this issue number — e.g. story-N.2-complete
+          # Tags are in the form story-<label>-complete where label can be N.2, 3.4, etc.
+          # We search all story-*-complete tags and find the one whose commit message
+          # or the tag name embeds a reference to the issue. We also accept the most
+          # recently created story-*-complete tag as a fallback when the agent tagged
+          # correctly before calling approve.
+          STORY_TAG=$(git tag -l "story-*-complete" \
+            | sort -V \
+            | tail -1)
+
+          if [ -z "$STORY_TAG" ]; then
+            echo "::error::No story-*-complete tag found. Agent must tag before approving."
+            exit 1
+          fi
+          echo "story_tag=${STORY_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Strip suffix to get the label (e.g. "N.2")
+          STORY_LABEL="${STORY_TAG#story-}"
+          STORY_LABEL="${STORY_LABEL%-complete}"
+          echo "story_label=${STORY_LABEL}" >> "$GITHUB_OUTPUT"
+
+          # The previous tag is the story-*-complete tag immediately before this one,
+          # or v*.*.* if no previous story tag exists.
+          PREV_TAG=$(git tag -l "story-*-complete" \
+            | sort -V \
+            | grep -B1 "^${STORY_TAG}$" \
+            | head -1)
+
+          if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$STORY_TAG" ]; then
+            # Fall back to the most recent semver release tag.
+            PREV_TAG=$(git tag -l "v*" | sort -V | tail -1)
+          fi
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "::error::Cannot determine previous tag — no v* or story-*-complete tags found."
+            exit 1
+          fi
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
+          STAGING_BRANCH="staging/story-${STORY_LABEL}"
+          echo "staging_branch=${STAGING_BRANCH}" >> "$GITHUB_OUTPUT"
+
+          echo "Squashing ${PREV_TAG}..${STORY_TAG} onto staging branch ${STAGING_BRANCH}"
+
+      - name: Build squash commit message from range
+        id: msg
+        run: |
+          PREV_TAG="${{ steps.range.outputs.prev_tag }}"
+          STORY_TAG="${{ steps.range.outputs.story_tag }}"
+          ISSUE_NUMBER="${{ steps.range.outputs.issue_number }}"
+          STORY_LABEL="${{ steps.range.outputs.story_label }}"
+
+          # Collect all subject lines in the range.
+          SUBJECTS=$(git log "${PREV_TAG}..${STORY_TAG}" --format="- %s" --reverse)
+
+          # Determine PR title prefix from the first feat/fix commit in the range.
+          FIRST_TYPE=$(git log "${PREV_TAG}..${STORY_TAG}" --format="%s" --reverse \
+            | grep -m1 "^feat\|^fix\|^perf\|^refactor" \
+            | sed 's/:.*//')
+          FIRST_TYPE="${FIRST_TYPE:-feat}"
+
+          TITLE="${FIRST_TYPE}: ${STORY_LABEL} - $(gh issue view ${ISSUE_NUMBER} --json title -q .title --repo ${{ github.repository }})"
+
+          # Write multi-line message to a file to avoid shell escaping issues.
+          {
+            echo "${TITLE}"
+            echo ""
+            echo "${SUBJECTS}"
+            echo ""
+            echo "Closes #${ISSUE_NUMBER}"
+          } > /tmp/commit_message.txt
+
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create staging branch and squash
+        run: |
+          PREV_TAG="${{ steps.range.outputs.prev_tag }}"
+          STORY_TAG="${{ steps.range.outputs.story_tag }}"
+          STAGING_BRANCH="${{ steps.range.outputs.staging_branch }}"
+
+          # Start the staging branch at the tip of main.
+          git checkout main
+          git checkout -b "${STAGING_BRANCH}"
+
+          # Squash all changes from the story range onto this branch.
+          git merge --squash "${STORY_TAG}"
+
+          git commit -F /tmp/commit_message.txt
+
+          git push origin "${STAGING_BRANCH}"
+
+      - name: Open PR to main
+        run: |
+          STAGING_BRANCH="${{ steps.range.outputs.staging_branch }}"
+          ISSUE_NUMBER="${{ steps.range.outputs.issue_number }}"
+          TITLE="$PR_TITLE"
+
+          PR_BODY=$(cat /tmp/commit_message.txt)
+
+          gh pr create \
+            --base main \
+            --head "${STAGING_BRANCH}" \
+            --title "${TITLE}" \
+            --body "${PR_BODY}" \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ steps.msg.outputs.title }}

--- a/.github/workflows/release-game.yml
+++ b/.github/workflows/release-game.yml
@@ -201,4 +201,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ needs.semantic-release.outputs.new_release_version }}"
+          draft: false
           files: artifacts/*

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,6 +15,6 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    ["@semantic-release/github", { "draftRelease": true }]
   ]
 }

--- a/Agents.md
+++ b/Agents.md
@@ -57,13 +57,14 @@ The **authoritative source** for when to stop and ask vs when to proceed is `doc
 
 ## 4. Development Workflow
 
-Agents manage their own PRs and issue label state using `gh` and `gt` (Graphite) CLIs. **Status is tracked via `status:*` labels on GitHub Issues, not a project board.**
+Agents manage their own issue label state using the `gh` CLI. **Status is tracked via `status:*` labels on GitHub Issues, not a project board.**
 
 The full workflow (pick story → implement → PR → review) is documented in `docs/bmad/agent-workflow.md`. Key constraints:
 
 - Only one story in progress at a time
 - Agents must **never** close an issue or transition it to Done (automation handles this)
 - If blocked: move to `status:blocked`, cascade to dependents, pick next ready story. **Collaborate, don't decide.**
+- **Before committing or opening a PR:** re-read `docs/bmad/planning-artifacts/architecture/core-principles.md` and verify your changes do not violate any of the 10 principles. This is not optional. The principles are short — read them in full, not just the ones that seem relevant. An agent that skips this step and ships a violation has failed the task.
 
 ### Branch & PR Naming
 

--- a/assets/config/combinations.toml
+++ b/assets/config/combinations.toml
@@ -1,8 +1,13 @@
-# Combination rules — maps material pairs to per-property rule sets.
+# Combination rules — maps material seed pairs to per-property rule sets.
 #
-# Each [[rules]] entry names two materials (order doesn't matter) and
-# specifies a rule for each property. Missing properties use the default
-# rule (Blend with equal weights).
+# Each [[rules]] entry identifies two materials by their generation seeds
+# and specifies a rule for each property. Order of seeds does not matter.
+# Missing properties use the default rule (Blend with equal weights).
+#
+# Seeds for well-known materials:
+#   1001 = Ferrite     1002 = Calcium    1003 = Sulfurite  1004 = Prismate
+#   1005 = Verdant     1006 = Osmium     1007 = Volatite   1008 = Cobaltine
+#   1009 = Silite      1010 = Phosphite
 #
 # Rule types:
 #   Blend { weight_a, weight_b }  — weighted average (predictable)
@@ -20,8 +25,8 @@ weight_b = 0.5
 # ── Specific pair rules ──────────────────────────────────────────────────
 
 [[rules]]
-material_a = "Ferrite"
-material_b = "Phosphite"
+material_seed_a = 1001  # Ferrite
+material_seed_b = 1010  # Phosphite
 density = { type = "Max" }
 thermal_resistance = { type = "Catalyze", multiplier = 1.4 }
 reactivity = { type = "Blend", weight_a = 0.7, weight_b = 0.3 }
@@ -29,8 +34,8 @@ conductivity = { type = "Min" }
 toxicity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
 
 [[rules]]
-material_a = "Volatite"
-material_b = "Calcium"
+material_seed_a = 1007  # Volatite
+material_seed_b = 1002  # Calcium
 density = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
 thermal_resistance = { type = "Min" }
 reactivity = { type = "Catalyze", multiplier = 1.6 }
@@ -38,8 +43,8 @@ conductivity = { type = "Blend", weight_a = 0.4, weight_b = 0.6 }
 toxicity = { type = "Max" }
 
 [[rules]]
-material_a = "Sulfurite"
-material_b = "Osmium"
+material_seed_a = 1003  # Sulfurite
+material_seed_b = 1006  # Osmium
 density = { type = "Inert" }
 thermal_resistance = { type = "Inert" }
 reactivity = { type = "Inert" }
@@ -47,8 +52,8 @@ conductivity = { type = "Inert" }
 toxicity = { type = "Inert" }
 
 [[rules]]
-material_a = "Cobaltine"
-material_b = "Verdant"
+material_seed_a = 1008  # Cobaltine
+material_seed_b = 1005  # Verdant
 density = { type = "Blend", weight_a = 0.3, weight_b = 0.7 }
 thermal_resistance = { type = "Max" }
 reactivity = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
@@ -56,8 +61,8 @@ conductivity = { type = "Catalyze", multiplier = 1.3 }
 toxicity = { type = "Min" }
 
 [[rules]]
-material_a = "Silite"
-material_b = "Prismate"
+material_seed_a = 1009  # Silite
+material_seed_b = 1004  # Prismate
 density = { type = "Min" }
 thermal_resistance = { type = "Blend", weight_a = 0.6, weight_b = 0.4 }
 reactivity = { type = "Max" }

--- a/assets/materials/classifications.toml
+++ b/assets/materials/classifications.toml
@@ -1,0 +1,136 @@
+# Material classification ranges for the Journal query layer.
+#
+# Each entry defines a named material type and the property ranges that
+# an observed material instance must fall within to be classified as that type.
+# Ranges are inclusive: a value equal to min or max is inside the range.
+#
+# Properties used for classification: density (mapped from Weight observation)
+# and thermal_resistance (mapped from ThermalBehavior observation).
+# Reactivity, conductivity, and toxicity observation systems are not yet wired
+# (Story N.4+); their range fields are reserved for when those systems exist.
+#
+# All values are derived from derive_material_from_seed() output — NOT from
+# the legacy assets/materials/*.toml reference values (those pre-date the
+# seed-derivation pipeline).
+#
+# Classification is NEVER stored. It is computed at query time by comparing
+# the player's revealed property values against these ranges.
+# Do not add any "type" or "classification" field to entities, components,
+# or graph nodes — ever.
+#
+# Ranges were computed by:
+# 1. Running derive_material_from_seed() for each well-known seed
+# 2. Finding the density midpoint between adjacent materials in density-space
+# 3. Using thermal_resistance as the secondary discriminator where density
+#    ranges would otherwise overlap
+# 4. Verifying no two entries share an overlapping (density AND thermal) region
+
+[[classification]]
+name = "ferrite"
+display_name = "Ferrite"
+# Seed 1001: density=0.5086, thermal=0.4468
+[classification.density]
+min = 0.49
+max = 0.56
+[classification.thermal_resistance]
+min = 0.38
+max = 0.51
+
+[[classification]]
+name = "calcium"
+display_name = "Calcium"
+# Seed 1002: density=0.1400, thermal=0.7087
+[classification.density]
+min = 0.09
+max = 0.20
+[classification.thermal_resistance]
+min = 0.62
+max = 0.80
+
+[[classification]]
+name = "sulfurite"
+display_name = "Sulfurite"
+# Seed 1003: density=0.5963, thermal=0.7607
+[classification.density]
+min = 0.54
+max = 0.65
+[classification.thermal_resistance]
+min = 0.70
+max = 0.85
+
+[[classification]]
+name = "prismate"
+display_name = "Prismate"
+# Seed 1004: density=0.2062, thermal=0.4010
+[classification.density]
+min = 0.15
+max = 0.27
+[classification.thermal_resistance]
+min = 0.32
+max = 0.48
+
+[[classification]]
+name = "verdant"
+display_name = "Verdant"
+# Seed 1005: density=0.4676, thermal=0.4967
+[classification.density]
+min = 0.42
+max = 0.48
+[classification.thermal_resistance]
+min = 0.42
+max = 0.58
+
+[[classification]]
+name = "osmium"
+display_name = "Osmium"
+# Seed 1006: density=0.7249, thermal=0.5620
+[classification.density]
+min = 0.68
+max = 0.80
+[classification.thermal_resistance]
+min = 0.50
+max = 0.63
+
+[[classification]]
+name = "volatite"
+display_name = "Volatite"
+# Seed 1007: density=0.5882, thermal=0.2229
+[classification.density]
+min = 0.54
+max = 0.63
+[classification.thermal_resistance]
+min = 0.14
+max = 0.30
+
+[[classification]]
+name = "cobaltine"
+display_name = "Cobaltine"
+# Seed 1008: density=0.6320, thermal=0.4959
+[classification.density]
+min = 0.59
+max = 0.67
+[classification.thermal_resistance]
+min = 0.43
+max = 0.57
+
+[[classification]]
+name = "silite"
+display_name = "Silite"
+# Seed 1009: density=0.4503, thermal=0.1523
+[classification.density]
+min = 0.38
+max = 0.47
+[classification.thermal_resistance]
+min = 0.09
+max = 0.22
+
+[[classification]]
+name = "phosphite"
+display_name = "Phosphite"
+# Seed 1010: density=0.0542, thermal=0.8062
+[classification.density]
+min = 0.00
+max = 0.08
+[classification.thermal_resistance]
+min = 0.72
+max = 0.92

--- a/docs/bmad/agent-workflow-reference.md
+++ b/docs/bmad/agent-workflow-reference.md
@@ -4,33 +4,31 @@ _Reference tables and commands for the story workflow. Load this file when runni
 
 ---
 
-## In-Review Health Check (story ↔ PR linkage)
+## In-Review Health Check (story ↔ tag linkage)
 
-Run this check periodically (or when a story appears stuck in _In review_) to verify the close-link workflow is healthy:
+Run this check periodically (or when a story appears stuck in _In review_):
 
-1. List project items and identify stories currently in _In review_:
-   - `gh project item-list 1 --owner galamdring --format json`
-2. For each story issue `#N`, find referencing PRs:
-   - `gh pr list --state all --search "Closes #N" --repo galamdring/apeiron-cipher`
-3. Validate each matching PR:
-   - `gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body`
-4. Triage results:
-   - No referencing PR found -> fix PR body (`Closes #N`) or open the missing PR.
-   - PR not targeting `main` -> correct base to `main`.
-   - Dependency not merged yet -> keep _In review_ and retain `Depends on #X`.
-   - PR merged but issue still open -> manually investigate issue automation and board sync.
+1. List stories currently in _In review_:
+   - `gh issue list --label "status:in-review" --label "story" --json number,title --repo galamdring/apeiron-cipher`
+2. For each story issue `#N`, verify the tag exists on develop:
+   - `git tag --list "story-N.N-complete"`
+3. Triage:
+   - Tag missing → agent did not complete Step 4. Re-run tagging.
+   - Tag exists, no `@automation approve` comment → awaiting human playtest. Leave as-is.
+   - `@automation approve` posted but no staging PR → automation workflow may have failed. Check GitHub Actions logs.
+   - Staging PR open → awaiting human merge. Leave as-is.
+   - Staging PR merged but issue still open → investigate GitHub auto-close (`Closes #N` in PR body).
 
 ---
 
 ## Task Management
 
-**All task tracking uses GitHub Issues with labels as the state machine.** Status is tracked via `status:*` labels, not a GitHub Project board.
+**All task tracking uses GitHub Issues with labels as the state machine.** Status is tracked via `status:*` labels.
 
 - Epics are GitHub Issues labeled `epic` with stories linked via `epic-N` labels
 - Stories are GitHub Issues labeled `story` with full acceptance criteria, technical notes, dependency links, and implementation order in their body
 - Status flows via labels: `status:triage` → `status:backlog` → `status:ready` → `status:in-progress` → `status:in-review` → closed
 - Scoping flows via labels: `needs_refinement` → `in_scoping` → `sow_ready` → `stories_created`
-- n8n workflows respond to label changes via GitHub webhook events and manage automated transitions
 
 ### Label Taxonomy
 
@@ -46,8 +44,8 @@ Run this check periodically (or when a story appears stuck in _In review_) to ve
 | `status:backlog` | `#d4c5f9` | Classified, not yet ready |
 | `status:ready` | `#0e8a16` | Approved for work |
 | `status:in-progress` | `#1d76db` | Agent working |
-| `status:in-review` | `#5319e7` | PR up for review |
-| `status:blocked` | `#e11d48` | Blocked |
+| `status:in-review` | `#5319e7` | Tagged, awaiting human playtest |
+| `status:blocked` | `#e11d48` | Blocked, awaiting human input |
 | **Scoping Labels** | | |
 | `needs_refinement` | `#d876e3` | Needs initial AI pass |
 | `in_scoping` | `#c5def5` | Scoping conversation active |
@@ -61,7 +59,7 @@ Run this check periodically (or when a story appears stuck in _In review_) to ve
 ## Useful Commands
 
 ```bash
-# List all ready stories (sorted by implementation order in body)
+# List all ready stories
 gh issue list --label "status:ready" --label "story" --json number,title,body --repo galamdring/apeiron-cipher
 
 # List all stories for a specific epic
@@ -79,26 +77,21 @@ gh issue edit <N> --remove-label "status:in-progress" --add-label "status:blocke
 # View a specific story's acceptance criteria
 gh issue view <number> --repo galamdring/apeiron-cipher
 
-# Graphite: view the current stack
-gt log
+# Tag a completed story
+git tag story-N.N-complete
+git push origin develop --tags
 
-# Graphite: create a new stacked branch
-gt create <branch-name>
+# List all story tags
+git tag --list "story-*"
 
-# Graphite: submit all branches in the stack as PRs
-gt submit
+# Find the commit range between two story tags
+git log story-N.M-complete..story-N.N-complete --oneline
 
-# Graphite: rebase the stack after a change to a lower branch
-gt stack restack
-
-# Graphite: sync with remote (after a PR is merged on GitHub)
-gt stack sync
-
-# Find PRs that reference a story issue
-gh pr list --state all --search "Closes #<issue_number>" --repo galamdring/apeiron-cipher
+# View staging PRs
+gh pr list --state open --search "staging/" --repo galamdring/apeiron-cipher
 
 # Verify PR state/body
 gh pr view <pr_number> --json state,baseRefName,isDraft,mergedAt,body
 ```
 
-Last Updated: 2026-04-18
+Last Updated: 2026-05-13

--- a/docs/bmad/agent-workflow.md
+++ b/docs/bmad/agent-workflow.md
@@ -4,9 +4,19 @@ _This file contains the step-by-step workflow for the coding agent to implement 
 
 ---
 
-## Story Implementation Workflow
+## Branch and Release Model
 
-This is the mandatory workflow for implementing stories. Agents must follow these steps in order.
+- **`develop`** — the continuous stream of implementation work. All agent commits go here. CI runs on every push.
+- **`main`** — clean linear history of completed, playtested stories. Protected: no direct pushes. Merge only via PR.
+- **Story tags** — when a story is complete and passing CI, the agent tags the commit: `story-N.N-complete`. These are the playtest checkpoints.
+- **Staging branches** — created automatically by the `@automation approve` workflow (see Step 4). One per story, squashed, used solely as the PR source.
+- **Releases** — triggered automatically when a PR merges to `main`.
+
+**Why one story at a time:** Agents make architectural decisions that compound. A wrong assumption in story 3 becomes story 5's foundation. Keeping one story in progress at a time means bugs and drift are caught before the next story builds on them. This is a deliberate constraint, not a limitation.
+
+---
+
+## Story Implementation Workflow
 
 ### Step 1 — Pick a story
 
@@ -19,9 +29,10 @@ gh issue list --label "status:ready" --label "story" --json number,title,body --
 Read the issue body of each Ready story to find its _Implementation Order_ number. Pick the lowest-numbered story — that is the next story to implement.
 
 **Dependency validation:** Before picking a story, check its `Depends on: #N` declarations. For each dependency:
-- If the dependency issue is closed or has the `status:in-review` label, proceed — the code exists on its branch and can be stacked on.
-- If the dependency has any other status (`status:ready`, `status:in-progress`, `status:backlog`, `status:blocked`), skip this story and move to the next lowest-numbered Ready story.
-- If the dependency has an open PR, the agent stacks its branch on top of that PR's branch.
+- If the dependency issue is closed, proceed.
+- If the dependency has any other status, skip this story and move to the next lowest-numbered Ready story.
+
+Only one story should be In progress at a time.
 
 ### Step 2 — Move to In progress
 
@@ -31,17 +42,13 @@ Before writing any code, move the story to _In progress_:
 gh issue edit <N> --remove-label "status:ready" --add-label "status:in-progress" --repo galamdring/apeiron-cipher
 ```
 
-Only one story should be In progress at a time.
-
 ### Step 3 — Implement
 
-- Create a feature branch using Graphite so it stacks on the current branch:
+Ensure you are on `develop`:
 
 ```bash
-gt create epic-N/story-N.N-short-description
+git checkout develop
 ```
-
-If the previous story's branch is still open (PR not yet merged), Graphite automatically stacks the new branch on top of it. If starting fresh from `main`, check out `main` first.
 
 - Read the full issue body for acceptance criteria and technical notes:
 
@@ -49,21 +56,22 @@ If the previous story's branch is still open (PR not yet merged), Graphite autom
 gh issue view <number> --repo galamdring/apeiron-cipher
 ```
 
-- **Load architecture context:** Consult `docs/bmad/planning-artifacts/architecture/agent-context-routing.md` to determine which architecture shards are relevant to this story's domain (e.g., materials, persistence, error handling). Load those shards before writing code.
-- Implement the story. All acceptance criteria must be satisfied. The GitHub Issue is the canonical source for acceptance criteria — query it with `gh issue view <N> --repo galamdring/apeiron-cipher`.
-- Run `make check` (or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`) before committing.
+- **Load architecture context:** Consult `docs/bmad/planning-artifacts/architecture/agent-context-routing.md` to determine which architecture shards are relevant to this story's domain. Load those shards before writing code.
+- Implement the story. All acceptance criteria must be satisfied. The GitHub Issue is the canonical source for acceptance criteria.
+- Run `make check` before committing.
+- Commit directly to `develop`. Commit messages should follow Conventional Commits: `feat: N.N - short description`.
 
 ### Step 3a — Block (when the agent cannot proceed)
 
-If the agent cannot proceed without human input, it blocks the story and cascades to dependents.
+If the agent cannot proceed without human input, it blocks the story.
 
 **When to block:** Architectural ambiguity, a question where multiple reasonable approaches exist (per "collaborate, don't decide"), or an unresolvable build failure.
 
-**What NOT to block on:** Trivial implementation choices, clippy lint approaches, cosmetic tuning, sensitivity values — handle these and note them in the PR for review.
+**What NOT to block on:** Trivial implementation choices, clippy lint approaches, cosmetic tuning, sensitivity values — handle these and note them in the issue comment for review.
 
 **Procedure:**
 
-1. Post a comment on the story issue prefixed with `[Indy] Blocked:` explaining the specific question or blocker.
+1. Post a comment on the story issue prefixed with `[Agent] Blocked:` explaining the specific question or blocker.
 2. Move the story to _Blocked_:
 
 ```bash
@@ -72,65 +80,77 @@ gh issue edit <N> --remove-label "status:in-progress" --add-label "status:blocke
 
 3. Return to Step 1 — pick the next Ready story that is not blocked.
 
-**Resumption:** The human answers the question and moves the story back to Ready. On the next pipeline pass, the agent reads all issue comments on a previously-blocked story to incorporate the human's answer before resuming implementation.
+**Resumption:** The human answers the question and moves the story back to Ready. On the next pipeline pass, the agent reads all issue comments on a previously-blocked story to incorporate the human's answer before resuming.
 
-### Step 4 — Create PR and move to In review
+### Step 4 — Tag and move to In review
 
-- Submit the branch (and any unstacked branches below it) as PRs using Graphite:
+Once all acceptance criteria are met and `make check` passes:
+
+1. Tag the current commit on `develop`:
 
 ```bash
-gt submit
+git tag story-N.N-complete
+git push origin develop --tags
 ```
 
-Graphite creates or updates the GitHub PR for each branch in the stack.
-
-- Every story PR must target `main` when created. Graphite branch ancestry is still used to model dependencies locally, but GitHub PR base must remain `main`.
-- If this story depends on an unmerged ancestor branch, add `Depends on #<dependency_pr_number>` in the PR body and do not merge out of dependency order.
-- The PR body _must_ include `Closes #<issue_number>` so merge to `main` auto-closes the story issue.
-- After a dependency PR merges, run `gt stack sync` and `gt submit`, then verify the dependent PR diff only contains that story's changes.
-- Move the story to _In review_:
+2. Move the story to _In review_:
 
 ```bash
 gh issue edit <N> --remove-label "status:in-progress" --add-label "status:in-review" --repo galamdring/apeiron-cipher
 ```
 
-### Handling change requests on stacked PRs
+3. Post a comment on the issue:
 
-When a reviewer requests changes on a lower branch in the stack:
+```
+[Agent] Implementation complete. Tagged `story-N.N-complete` on develop. Ready for playtest.
+```
 
-1. Check out the branch that needs changes: `gt checkout epic-N/story-N.N-...`
-2. Make fixes, commit, then sync the stack: `gt stack restack`
-3. Re-submit the entire stack: `gt submit`
+The human will playtest from `develop` at the tag. If changes are needed, they post feedback on the issue and move it back to `status:in-progress`. When satisfied, the human posts:
 
-Graphite automatically rebases all branches above the changed one.
+```
+@automation approve
+```
+
+This triggers the automation workflow (see below) which squashes all commits since the previous story tag into a single commit, opens a staging branch, and creates a PR to `main`.
 
 ### Step 5 — Done (automated, never agent-triggered)
 
-_An agent must NEVER move an issue to Done or close it._ The Done transition happens automatically:
+_An agent must NEVER close an issue or merge a PR._ The Done transition happens automatically:
 
-- When a PR with `Closes #N` merges, GitHub auto-closes the story issue.
-- The `story-close-check` n8n workflow detects story closure, checks if all sibling stories in the epic are closed, and auto-closes the parent epic when complete.
+- The human merges the staging PR to `main`.
+- GitHub auto-closes the story issue via `Closes #N` in the PR body.
+- The release workflow runs on merge to `main`.
+
+---
+
+## @automation approve — What it does
+
+When the human comments `@automation approve` on a story issue, a GitHub Actions workflow:
+
+1. Identifies the story's tag (`story-N.N-complete`) from the issue number.
+2. Finds the previous story tag to determine the commit range.
+3. Creates a staging branch: `staging/story-N.N`.
+4. Runs `git merge --squash` to collapse the full diff into a single staged change.
+5. Assembles a commit message from all commit messages in the range plus story issue metadata.
+6. Builds a PR description from the issue body (acceptance criteria) and commit log.
+7. Opens a PR: `staging/story-N.N` → `main` with `Closes #N` in the body.
+
+The automation has permission to push branches and open PRs. It does **not** have permission to merge.
 
 ---
 
 ## PR Review Communication
 
-The agent replies to inline PR review comments directly on GitHub using the `gh` API. Because the CLI authenticates as the repo owner, all agent replies are prefixed with **[Indy]** to distinguish them from human comments.
+The agent replies to inline PR review comments directly on GitHub using the `gh` API. All agent replies are prefixed with **[Agent]** to distinguish them from human comments.
 
-When asked to "check your open PRs for comments," the agent will:
+When asked to address PR review comments:
 
-1. `gh pr list --state open` to find all open PRs
+1. `gh pr list --state open` to find open PRs
 2. `gh api repos/.../pulls/{n}/comments` for each PR to fetch inline comments
-3. Address each comment on its respective branch, reply with `[Indy]` prefix, push fixes
-
-If inline reply posting fails due to permissions or readonly execution (for example, HTTP 403/resource not accessible):
-
-1. Continue implementing fixes on the branch.
-2. Prepare proposed responses prefixed with `[Indy]` in the handoff/output message.
-3. Flag the PR as needing a human to post the prepared replies.
+3. Address each comment, commit to `develop`, retag if needed, reply with `[Agent]` prefix
 
 ---
 
 _For label taxonomy, issue map, health checks, and command reference, see `agent-workflow-reference.md`._
 
-Last Updated: 2026-04-18
+Last Updated: 2026-05-13

--- a/docs/bmad/gdd.md
+++ b/docs/bmad/gdd.md
@@ -1287,7 +1287,7 @@ These are assessed through playtesting observation and player feedback — not t
 | Bevy engine + ecosystem crates | Game engine, ECS, rendering, audio | Bevy is pre-1.0; breaking changes between versions |
 | Rust compiler toolchain | Build system | Low risk — stable release channel |
 | GitHub | Source control, issue tracking, releases | Low risk |
-| Graphite | Stacked PR / branch management | Low risk — workflow tooling only |
+| GitHub Actions | CI, release automation, `@automation approve` squash-merge workflow | Low risk |
 
 No backend services required for single-player. Multiplayer networking stack (Ring 5, Epic 22) is a future technical decision with no current dependency.
 

--- a/docs/bmad/planning-artifacts/architecture/agent-context-routing.md
+++ b/docs/bmad/planning-artifacts/architecture/agent-context-routing.md
@@ -36,6 +36,7 @@ Load:
 - [System Scheduling & Ordering](./decisions/system-scheduling-ordering.md) — determinism enforcement, phase pipeline
 - [Material Seed Model](./cross-cutting/material-seed-model.md)
 - [Determinism Enforcement](./cross-cutting/determinism-enforcement.md)
+- [Material Identity & Knowledge Model ADR](./decisions/material-identity-and-knowledge-model.md) — type identity is query-time classification, not generation-time assignment; KnowledgeGraph as sole store
 
 ---
 
@@ -43,10 +44,11 @@ Load:
 
 Load:
 - [Authority Boundary Pattern](./decisions/authority-boundary-pattern.md) — diegetic outcome expression, journal event log, accretion test
-- [Data Architecture](./decisions/data-architecture.md) — knowledge graph, journal visualization layers
+- [Data Architecture](./decisions/data-architecture.md) — knowledge graph as sole store, journal as stateless query layer
 - [Asset Pipeline Conventions](./decisions/asset-pipeline-conventions.md) — if loading data files for UI
 - [Knowledge-Driven Presentation](./cross-cutting/knowledge-driven-presentation.md)
 - [Diegetic Feedback Contract](./cross-cutting/diegetic-feedback.md)
+- [Material Identity & Knowledge Model ADR](./decisions/material-identity-and-knowledge-model.md) — Journal does not store entries; queries KnowledgeGraph; inspect panel reads from KG node
 
 ---
 

--- a/docs/bmad/planning-artifacts/architecture/core-principles.md
+++ b/docs/bmad/planning-artifacts/architecture/core-principles.md
@@ -4,7 +4,7 @@ Rules that apply to every line of code, every system, every story. No exceptions
 
 1. **Knowledge is the only progression system.** There are no levels, no XP, no skill trees, no unlocks. The player progresses by understanding the world better. Every system serves this.
 2. **Accretion over reward.** Every player action must teach something new through consequence, never through confirmation.
-3. **Diegetic only.** The game never tells — it reveals through world behavior. No UI text explaining state. No popups. No progress bars.
+3. **Diegetic only.** The game never tells — it reveals through world behavior. No UI text explaining state. No popups. No progress bars. This applies to **reactive/feedback UI** — the game must never use text to explain why an action failed or what the player should do next. Physical in-world objects that display text as part of their nature (journal datapad, inscriptions, fabricator readouts) are *the diegetic mechanism*, not a violation of it.
 4. **Deterministic.** Same seed + same inputs = same outputs. Always. Seeded RNG only. Explicit system ordering. No float ambiguity.
 5. **Server-authoritative.** Intent is untrusted. Simulation decides. Even in single-player.
 6. **Data-driven.** All tuning lives in asset files. If a tuning value is hardcoded in Rust source, it's wrong. Only truly fixed values (mathematical constants, protocol versions) are `const`.

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/index.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/index.md
@@ -1,11 +1,11 @@
 # Cross-Cutting Concerns
 
 - [Mirror System](./mirror-system.md) — behavioral observation hooks across all gameplay systems
-- [Knowledge-Driven World Presentation](./knowledge-driven-presentation.md) — continuous knowledge spectrum affects rendering, interaction, NPC response
+- [Knowledge-Driven World Presentation](./knowledge-driven-presentation.md) — continuous knowledge spectrum affects rendering, interaction, NPC response; KnowledgeGraph as sole store, Journal as stateless query layer
 - [Server-Authoritative Boundary](./server-authoritative-boundary.md) — Intent/Simulation separation, per-system generation authority
 - [Determinism Enforcement](./determinism-enforcement.md) — seeded RNG, system ordering, float consistency
-- [Material Seed Model](./material-seed-model.md) — canonical seed-derived properties, cascading data model
+- [Material Seed Model](./material-seed-model.md) — seeds are generation inputs; type identity is query-time classification against asset ranges, never stored; see also [Material Identity ADR](../decisions/material-identity-and-knowledge-model.md)
 - [Telemetry](./telemetry.md) — centralized compile-time-toggled event channel
-- [Diegetic Feedback Contract](./diegetic-feedback.md) — no UI explanations, consequences only
+- [Diegetic Feedback Contract](./diegetic-feedback.md) — no UI explanations of failure or game state; physical in-world objects that display text (journal, datapads) are the diegetic mechanism, not a violation
 - [Asset Pipeline Architecture](./asset-pipeline.md) — hot-reload, versioned schemas, async loading
 - [Persistence / Save Architecture](./persistence.md) — deterministic serialization, version migration, knowledge preservation

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
@@ -1,3 +1,69 @@
 # Cross-Cutting Concern: Knowledge-Driven World Presentation
 
-Knowledge state is a continuous spectrum (not boolean gates) that affects three distinct system categories: *rendering* (entities appear differently based on what the player knows), *interaction availability* (options the player perceives depend on knowledge state), and *NPC dialogue/response* (conversations and reactions reflect what the player has demonstrated understanding of). Every system must handle the full gradient from "player knows nothing" to "player knows everything." Because many systems query knowledge state every frame, knowledge access is a **hot path** — requires fast-access data structures (dedicated `KnowledgeState` component with indexed lookups), not HashMap queries per entity per system per frame.
+## Core Principle
+
+Knowledge state is a continuous spectrum (not boolean gates) that affects three distinct system categories:
+- **Rendering** — entities appear differently based on what the player knows
+- **Interaction availability** — options the player perceives depend on knowledge state
+- **NPC dialogue/response** — conversations and reactions reflect what the player has demonstrated understanding of
+
+Every system must handle the full gradient from "player knows nothing" to "player knows everything."
+
+## Architecture: KnowledgeGraph as Source of Truth
+
+**The KnowledgeGraph is the sole store for player knowledge.** The Journal is a stateless query layer over it — it holds no knowledge state of its own.
+
+```
+KnowledgeGraph (store)
+    ↑ observation events from game systems
+    ↓ queried by
+Journal (query layer) → present to player
+Inspect panel (query layer) → present to player
+Fabrication system (query layer) → gate on knowledge
+```
+
+Any system that needs to know "what does the player know about X" must query the KnowledgeGraph, not read from entity components or Journal entries.
+
+## What the KnowledgeGraph Stores
+
+- **Nodes** — observed entities (specific material instances, locations, fabrication events)
+- **Edges** — observed relationships (found-at, similar-to, used-in, reacts-with)
+- **Revealed property flags** — which properties the player has observed on each node (density revealed on pickup, thermal resistance revealed by heat exposure, etc.)
+- **Sighting records** — where and when an entity was encountered (planet, tick)
+- **Confidence** — continuous f32 per observation, grows with repeated encounters
+
+## What Does NOT Belong on Entity Components
+
+`PropertyVisibility` and any other "what does the player know" state must not live on `GameMaterial` or any other entity component. Entity components hold **world facts** — the physical properties of objects in the world. Knowledge about those facts lives in the KnowledgeGraph.
+
+**Wrong:**
+```rust
+// Don't do this — knowledge state on a world entity
+mat.density.visibility = PropertyVisibility::Observable;
+```
+
+**Right:**
+```rust
+// Record an observation — KnowledgeGraph node gets the revealed flag
+observation_writer.write(RecordObservation {
+    key: material_node_key,
+    category: ObservationCategory::Density,
+    ...
+});
+```
+
+## Inspect Panel Pattern
+
+The inspect panel composes two layers from KnowledgeGraph queries:
+
+1. **Type-level knowledge** — all observations accumulated across every instance with matching property profile. "Iron is dense and non-reactive."
+2. **Instance-level sighting** — where this specific piece was found. "Found on planet Kessler."
+
+It does not read `PropertyVisibility` from the entity. It queries the KnowledgeGraph node for this entity's seed, finds which property observation edges exist, and renders accordingly.
+
+## Performance
+
+Knowledge access is a **hot path** — many systems query knowledge state every frame. Requirements:
+- O(1) node lookup via `HashMap<ConceptId, NodeIndex>` internal index
+- No per-entity HashMap query in systems that run every frame
+- Dedicated `KnowledgeState` component with indexed lookups for frequently-queried entities (future optimization when profiling warrants it)

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/material-seed-model.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/material-seed-model.md
@@ -1,3 +1,51 @@
 # Cross-Cutting Concern: Material Seed Model
 
-Canonical material properties are derived from world seed and propagate into crafting, construction, visual rendering, NPC economies, and alien cultures. This is the most load-bearing data model — changes here cascade everywhere.
+## Overview
+
+Material seeds are **inputs to procedural generation**, not type identifiers. A planet seed combined with a world position produces raw property values (density, reactivity, conductivity, thermal resistance, toxicity). Those property values are what get stored and reasoned about — not the seed itself.
+
+## Identity is Emergent, Not Assigned
+
+Material type names ("iron", "ferrite", "obsidian") are never assigned at generation time. They are the result of **query-time classification**: comparing a material's observed property values against asset-defined ranges.
+
+```
+planet_seed + position → raw property values (generation)
+raw property values → fall within range definition → "iron" (query-time, Journal only)
+```
+
+The KnowledgeGraph stores observed property values on instance nodes. The Journal queries those nodes against `assets/materials/classifications.toml` (or equivalent) to group them into named types at presentation time.
+
+**Consequence:** Two pieces of material from different planets with the same property profile are the same type. The player discovers this by accumulating observations until the Journal's range-match produces the same name — not because the game assigned them the same ID.
+
+## Instance Variation
+
+Property values generated from different planet seeds will naturally vary within ranges. A piece of iron from a high-gravity world may have density 0.91; iron from a low-gravity world may have density 0.74. Both fall within the iron classification range. The Journal can surface this variation ("heavier than the iron you found on Kessler") by comparing node values within the matched cluster — no separate instance modifier system is needed.
+
+## What Lives Where
+
+| Data | Lives In | Notes |
+|------|----------|-------|
+| Raw property values | `GameMaterial` entity component | Immutable after generation — these are world facts |
+| Which properties the player has observed | `KnowledgeGraph` node (revealed flags / observation edges) | Never on the entity component |
+| Planet of origin | `KnowledgeGraph` node (sighting record) | Not encoded in any key |
+| Type name ("iron") | Nowhere — computed at query time | Result of range-match against asset classification |
+| Classification ranges | `assets/` data files | Data-driven, never hardcoded in Rust |
+
+## Transient vs Knowledge State on Entities
+
+`GameMaterial` entity components hold **world facts** — the physical properties of this piece of matter. They do not hold player knowledge. `PropertyVisibility` on a `GameMaterial` component is a transient rendering hint at most — it must never be used as the source of truth for what the player knows. All knowledge state lives in the KnowledgeGraph.
+
+## Future: Classification Ranges in Assets
+
+Classification ranges are a Ring 2 deliverable. Until they exist, the Journal presents individual observed instances by their raw property values. The architecture is already correct — the Journal queries the KnowledgeGraph; it just won't have range definitions to group by yet. Adding range definitions slots in without changing the Journal or KnowledgeGraph.
+
+## Cascade Impact
+
+Changes to the material seed model cascade into:
+- Crafting and fabrication (material compatibility checks)
+- Construction (structural property lookups)  
+- Visual rendering (appearance driven by property values, not type assignment)
+- NPC economies (future — value derived from observed properties)
+- Save/load (KnowledgeGraph serialization, not entity component state)
+
+Any system that currently keys off `PropertyVisibility` on a `GameMaterial` entity component must be migrated to read from the KnowledgeGraph instead.

--- a/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
@@ -15,16 +15,18 @@
 - Registries are effectively write-rarely, read-constantly — `Res<T>` access only after initial insertion
 
 **Player Knowledge (Journal, Encyclopedia, Associative Web):**
-- `KnowledgeGraph` resource backed by `petgraph::Graph` (not `StableGraph`), behind a trait interface for swappability
-- Nodes = concepts (category, confidence as continuous f32 spectrum, set of revealed properties, discovery timestamp)
-- Edges = typed relationships (relationship type, confidence, discovery timestamp) — edges are first-class discoverable knowledge, not UI convenience
+- `KnowledgeGraph` resource backed by `petgraph::Graph` (not `StableGraph`), behind a trait interface for swappability — this is the **sole store** for all player knowledge; the Journal is a stateless query layer over it, not a parallel storage layer
+- Nodes = observed entities (specific material instances, locations, fabrication events) — the graph does not categorize; it stores observed facts about specific things
+- Edges = typed relationships (found-at, similar-to, used-in, reacts-with, co-located-with) — edges are first-class discoverable knowledge, not UI convenience
+- Revealed properties (e.g. density observed on pickup, thermal resistance revealed by heat exposure) are stored as flags/edges on the KnowledgeGraph node — never on the entity component; `PropertyVisibility` on a `GameMaterial` entity is transient world state only and must not be used as the source of truth for what the player knows
 - Append-only growth via event-driven `DiscoveryEvent` processing — updates are IMMEDIATE, no staging buffer or delayed flush
 - Internal indexes: `HashMap<ConceptId, NodeIndex>` for O(1) lookup, `HashMap<Category, Vec<NodeIndex>>` for encyclopedia view, timeline `Vec<(Timestamp, NodeIndex)>` for event log
 
-**Journal Visualization (Three Layers):**
-- **Structured encyclopedia** (primary view): category-scoped entry points (planets, species, flora, fauna, materials, techniques), entries fill in as knowledge accumulates
+**Journal Visualization (Query Layer — no storage):**
+- The Journal is a **stateless query layer** over the KnowledgeGraph — it holds no `JournalEntry` storage between frames beyond UI navigation position
+- **Structured encyclopedia** (primary view): Journal queries the KnowledgeGraph for nodes matching asset-defined classification ranges; a "material type" entry (e.g. "iron") is computed on the fly by finding all material nodes whose observed properties fall within iron's ranges — not retrieved from stored records
 - **Associative web** (differentiator): graph neighborhood visualization around selected node, bounded BFS traversal filtered by category scope, cross-category nodes visible at edges where connections exist, zoom controls density
-- **Event log** (secondary): chronological record of discoveries
+- **Event log** (secondary): chronological record of discoveries, derived from node/edge timestamps in the graph
 
 **New Dependency:**
 - `petgraph` with `serde-1` feature — added for Ring 1 (Epic 10 — Journal Architecture). Pure Rust, minimal transitive dependencies (`fixedbitset`, `indexmap`). Behind trait interface so `Graph` can be swapped to `StableGraph` if needed.
@@ -34,7 +36,10 @@
 - Tests assert semantic equality exactly — if semantic equality fails, the interface is broken.
 
 **Material Seed Canonicality:**
-- Material seed data is canonical; entities are instances. A material seed defines the durable truth of that material: its generated properties, learned observations, and any other canonical knowledge the player can carry across multiple samples. World entities are only physical instances of that seed. Entity components may store transient world state (transform, held/placed status, current heat exposure, temporary visual reaction state) but must not become the long-term source of truth for what a material *is* or what the player *knows* about it.
-- UI and journal systems read seed-level knowledge, not entity-local copies. Inspect panels, journals, fabrication history, and future save data must resolve material identity through the seed and shared knowledge model. If two entities share a seed, learning a property from one sample must make that knowledge available everywhere the same seed is referenced.
+- Material seeds are inputs to property generation — a planet seed + position produces raw property values. The seed is not a type identifier.
+- Material type identity is **emergent and query-time**: when the Journal (or any system) needs to classify a material as "iron", it compares observed property values against asset-defined classification ranges. The name "iron" is never stored on an entity or graph node — it is the result of a range match.
+- Entity components may store transient world state (transform, held/placed status, current heat exposure, temporary visual reaction state) but must not store player knowledge state (`PropertyVisibility` on a `GameMaterial` is transient world state; what the player *knows* about that material lives exclusively in the KnowledgeGraph).
+- If two entities share the same property profile, learning a property from one sample makes that knowledge available everywhere the same profile is encountered — because knowledge is keyed by the KnowledgeGraph node for that observed instance, and the Journal query groups nodes by range-match at query time.
+- Planet of origin is recorded as a sighting on the KnowledgeGraph node, not encoded into any key or identifier.
 
 **Rationale:** The hybrid model separates immutable ground-truth (seed-derived, write-once registries) from mutable player progression (append-only knowledge graph). Registry lookups are O(1) via entity ID components. The knowledge graph uses a real graph library rather than hand-rolling adjacency lists, getting BFS traversal, connected components, and serde serialization for free. Journal visualization queries map directly to bounded graph operations.

--- a/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
@@ -1,0 +1,146 @@
+# ADR: Material Identity, Knowledge Graph as Store, Journal as Query Layer
+
+- **Status:** Proposed — decision required before further Journal/inspection implementation
+- **Category:** Knowledge Model / Material System
+- **Affects:** `KnowledgeGraph`, `Journal`, `JournalKey`, `JournalEntry`, `GameMaterial`, inspect panel, save/load, material generation
+
+---
+
+## Context
+
+Story 10.6 surfaced a fundamental mismatch between the intended architecture and the current implementation. The data-architecture decision already establishes the correct principle:
+
+> "Material seed data is canonical; entities are instances. If two entities share a seed, learning a property from one sample must make that knowledge available everywhere the same seed is referenced."
+
+However, the implementation has drifted into a model where:
+
+- `Journal` holds `BTreeMap<JournalKey, JournalEntry>` — making it a storage layer
+- `KnowledgeGraph` is downstream of the Journal, reading from it rather than being the source of truth
+- `JournalKey::Material { seed, planet_seed }` encodes provenance into the key, splitting what should be unified knowledge into per-planet fragments
+- `PropertyVisibility` lives on `GameMaterial` entity components — "what the player knows" stored on a physical world object
+
+All of these contradict the intended design.
+
+---
+
+## Intended Architecture
+
+### KnowledgeGraph — the store
+
+The `KnowledgeGraph` is the source of truth for everything the player has observed. It stores **specific observed entities and the relationships between them** — not categories, not types, not classifications.
+
+```
+nodes = observed things (this piece of material, this location, this fabrication event)
+edges = observed relationships (found-at, similar-to, used-in, reacts-with, co-located-with)
+```
+
+The graph does not categorize. It does not know what "iron" is. It knows:
+- Entity A was observed at tick 1200 on planet Kessler
+- Entity A has observed density 0.82, observed reactivity unknown
+- Entity A is similar-to Entity B (edge, added when similarity threshold crossed)
+- Entity B was observed at tick 3400 on planet Vorn
+
+Graph traversal finds clusters, connections, and patterns. The graph never infers — every node and edge requires an observation event to exist.
+
+### Journal — the query layer
+
+The Journal is a **read-only presentation layer** that queries the KnowledgeGraph. It has no storage of its own. A `JournalEntry` is a computed view, not a stored record.
+
+When the player opens the journal and sees "Iron (4 sightings)", that entry was produced by:
+
+1. Querying the graph for all material nodes whose **observed properties fall within the classification ranges for iron** (loaded from assets)
+2. Aggregating those nodes — their sighting locations, observation counts, confidence levels
+3. Presenting the result as a single entry
+
+Classification ranges live in `assets/` (data-driven, Core Principle 6). The Journal holds no state between frames beyond UI navigation position.
+
+### Material Generation — properties first, identity emergent
+
+World generation uses planet seed + position to produce raw property values. Property values are what gets stored in the graph. Classification into named types ("iron", "ferrite") is a **query-time operation**, not a generation-time assignment.
+
+```
+planet_seed + position → raw property values → KnowledgeGraph node (on observation)
+                                                      ↓
+                               Journal query: which asset-defined ranges do these match?
+                                                      ↓
+                                         JournalEntry { "iron", 4 sightings }
+```
+
+The player discovers that two things are the same substance by accumulating enough observations that both fall within the same classification window. The name "iron" is not assigned at spawn — it resolves through play.
+
+### Instance vs Type
+
+There is no stored "type." There are only observed instances in the graph and asset-defined classification ranges that the Journal uses to group them at query time.
+
+Instance-level variation (this piece from a high-gravity world is denser than other iron) is naturally represented: the node's observed density value simply sits at a different point within the iron range. The Journal can present this as "heavier than the iron you found on Kessler" by comparing node values within the cluster — no separate instance modifier system needed.
+
+---
+
+## Current Implementation Bugs
+
+These directly contradict the decided architecture:
+
+1. **Journal is a storage layer** — `BTreeMap<JournalKey, JournalEntry>` accumulates records. Should be a stateless query over the KnowledgeGraph.
+
+2. **KnowledgeGraph is downstream of Journal** — it reads from Journal entries. Should be the other way: Journal queries the graph.
+
+3. **`planet_seed` in `JournalKey`** — provenance encoded into the key fragments cross-planet knowledge. Provenance belongs on graph nodes, not on journal keys.
+
+4. **`PropertyVisibility` on entity components** — player knowledge stored on a physical world object. Should be derived from what observation edges exist in the graph for that entity's node.
+
+5. **Observations fire on raycast target change only** — picking up a material, examining it in hand, carrying it — none of these record observations. Observation should fire on meaningful player interaction (pickup, examine, fabrication use).
+
+---
+
+## Scope
+
+### This is a significant refactor
+
+The correct architecture requires inverting the Journal/KnowledgeGraph relationship. This is not a small fix — it touches the core data flow of the knowledge system.
+
+### What belongs in Story 10.6 (current scope)
+
+10.6 was scoped around making the inspect panel update correctly from player interaction. The bugs above make that impossible to fix correctly without addressing the underlying model. However, a full Journal/KnowledgeGraph inversion is more than one story.
+
+**Recommended 10.6 scope:**
+- Remove `planet_seed` from `JournalKey::Material` — planet recorded as a field on `JournalEntry`, not part of the key. Unblocks cross-planet knowledge accumulation immediately.
+- Move `PropertyVisibility` out of entity components — revealed properties tracked in the Journal entry (acceptable interim step; full graph-query model is a follow-on story).
+- Fix observation trigger — fire on pickup, not on raycast target change.
+- Inspect panel reads from Journal entry by seed, not from entity component.
+
+**Follow-on story (new issue):**
+- Invert Journal/KnowledgeGraph relationship — Journal becomes a stateless query layer over the graph.
+- Asset-defined classification ranges — Journal groups material nodes by range match rather than by stored key.
+- Remove `BTreeMap<JournalKey, JournalEntry>` storage from Journal entirely.
+
+---
+
+## Decision
+
+1. **Adopt the graph-as-store, journal-as-query model** as the target architecture. This ADR supersedes any prior framing of the Journal as a storage layer.
+
+2. **`JournalKey` gains two material variants** to cleanly separate instance-level and type-level knowledge:
+   - `JournalKey::MaterialInstance { seed: u64 }` — identifies a specific observed material entity by its generation seed. Used by the inspect panel and instance-level journal entries.
+   - `JournalKey::Material { classification: String }` — identifies a material type by its classification name (e.g. "iron"). Used by the journal encyclopedia view. This key is a follow-on epic deliverable — classification ranges must exist before it can be populated.
+   - The existing `JournalKey::Material { seed, planet_seed }` is removed. `planet_seed` moves off the key onto `RecordObservation` as context for the `FoundOn` KnowledgeGraph edge.
+
+3. **Story 10.6** implements the pragmatic fixes that unblock correct inspect panel behavior:
+   - Rename `JournalKey::Material` → `JournalKey::MaterialInstance { seed: u64 }`, removing `planet_seed` from the key
+   - `planet_seed` moves to `RecordObservation` as a context field for the `FoundOn` KG edge
+   - `PropertyVisibility` removed from entity components; revealed properties tracked on KG node
+   - Observation fires on pickup, not raycast target change
+   - Inspect panel reads from KG node by seed
+   - Journal displays what is known about this specific material instance
+   - `JournalKey::Material { classification }` is **not** introduced in 10.6 — it is a follow-on epic deliverable
+
+4. **New epic (Knowledge Model Inversion)** delivers the full architecture:
+   - Story N.1: KnowledgeGraph as sole observation store
+   - Story N.2: Journal as stateless query layer (introduces `JournalKey::Material { classification }`)
+   - Story N.3: Asset-defined classification ranges in `assets/`
+   - Story N.4: Material generation produces raw property values only — no type assignment at spawn
+
+5. **Classification** is always query-time, never generation-time. Material type names are never stored on entities or in the graph — they are the result of matching observed property values against asset-defined ranges.
+
+---
+
+*Drafted: 2026-05-13. Decision confirmed 2026-05-13. Requires no further sign-off — proceed to implementation.*

--- a/docs/bmad/planning-artifacts/architecture/project-context-analysis.md
+++ b/docs/bmad/planning-artifacts/architecture/project-context-analysis.md
@@ -52,7 +52,7 @@ The GDD defines a procedurally generated open universe sandbox where knowledge i
 - 3 epics complete (A Room to Stand In, Things to Touch, Try and Learn) establishing baseline patterns
 - 46 coding rules already codified in `project-context.md` for AI agent consistency
 - n8n automation for GitHub issue lifecycle (labels as state machine)
-- Graphite for stacked PR/branch management
+- `develop` branch with story tags for playtest checkpoints; `@automation approve` triggers squash PR to `main`
 
 **Hard Constraints from project-context.md:**
 - No `unsafe` code

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -24,11 +24,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::input::InputAction;
 use crate::interaction::HeldItem;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{GameMaterial, MaterialObject};
 use crate::observation::Confidence;
+use crate::observation::RecordObservation;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
-use crate::world_generation::WorldProfile;
 use leafwing_input_manager::prelude::*;
 
 const CONFIG_PATH: &str = "assets/config/carry.toml";
@@ -1372,16 +1372,14 @@ pub fn stash_entity_into_carry(
 /// `planet_seed` is the player's current planet seed (taken from
 /// `WorldProfile::planet_seed.0` at the call site), or `None` when no
 /// `WorldProfile` is in scope.  It is stamped onto the resulting
-/// [`JournalKey::Material`] so the journal's "current planet" filter
-/// (Story 10.3) can match this entry against the player's current
-/// planet without re-deriving provenance from observation history.
+/// Planet of origin is read directly from [`GameMaterial::origin_planet_seed`] —
+/// callers no longer need to extract it from `WorldProfile`.
 pub fn record_weight_observation(
     material: &GameMaterial,
     carry_strength: f32,
     config: &CarryConfig,
     journal_writer: &mut MessageWriter<RecordObservation>,
     descriptor_vocab: &crate::observation::DescriptorVocabulary,
-    planet_seed: Option<u64>,
 ) {
     // Use initial confidence for new observations - the journal system
     // will handle accumulation automatically for repeated observations
@@ -1406,11 +1404,12 @@ pub fn record_weight_observation(
         });
 
     journal_writer.write(RecordObservation {
-        key: JournalKey::Material {
+        key: JournalKey::MaterialInstance {
             seed: material.seed,
-            planet_seed,
         },
         name: material.name.clone(),
+        material_seed: Some(material.seed),
+        planet_seed: material.origin_planet_seed,
         observation: Observation {
             category: ObservationCategory::Weight,
             confidence: initial_confidence,
@@ -1469,9 +1468,7 @@ fn process_stash_intent(
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for _intent in reader.read() {
         let Some((held_entity, held_material)) = held_query.iter().next() else {
             reject_writer.write(CarryActionRejected {
@@ -1500,7 +1497,6 @@ fn process_stash_intent(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1519,9 +1515,7 @@ fn process_stash_held_for_pickup(
     config: Res<CarryConfig>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     mut player_query: Query<(&mut CarryState, &CarryStrength), With<Player>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for request in reader.read() {
         let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
             continue;
@@ -1539,7 +1533,6 @@ fn process_stash_held_for_pickup(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         // Also record weight for the newly picked material.
         record_weight_observation(
@@ -1548,7 +1541,6 @@ fn process_stash_held_for_pickup(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1561,9 +1553,7 @@ fn process_observe_weight(
     config: Res<CarryConfig>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     player_query: Query<&CarryStrength, With<Player>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for request in reader.read() {
         let Ok(carry_strength) = player_query.single() else {
             continue;
@@ -1574,7 +1564,6 @@ fn process_observe_weight(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
     }
 }
@@ -1595,9 +1584,7 @@ fn process_cycle_carry_intent(
     camera_query: Query<Entity, With<PlayerCamera>>,
     held_query: Query<(Entity, &GameMaterial), With<HeldItem>>,
     carried_material_query: Query<&GameMaterial, With<InCarry>>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
     for _intent in reader.read() {
         let Ok((mut carry_state, carry_strength)) = player_query.single_mut() else {
             continue;
@@ -1645,7 +1632,6 @@ fn process_cycle_carry_intent(
                 &config,
                 &mut journal_writer,
                 &descriptor_vocab,
-                planet_seed,
             );
         }
 
@@ -1665,7 +1651,6 @@ fn process_cycle_carry_intent(
             &config,
             &mut journal_writer,
             &descriptor_vocab,
-            planet_seed,
         );
         emit_carry_weight_changed(&mut weight_writer, &carry_state);
     }
@@ -1703,6 +1688,7 @@ mod tests {
             name: "Testite".into(),
             seed: 7,
             color: [0.1, 0.2, 0.3],
+            origin_planet_seed: None,
             density: property(value),
             thermal_resistance: property(0.5),
             reactivity: property(0.5),
@@ -2256,30 +2242,31 @@ exponent = 1.0
         // `record_weight_observation` takes a real `MessageWriter`, which
         // can only be obtained from a `World`.
         fn drive(
-            inputs: bevy::ecs::system::In<(GameMaterial, Option<u64>)>,
+            inputs: bevy::ecs::system::In<GameMaterial>,
             mut writer: MessageWriter<RecordObservation>,
             descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
         ) {
-            let (mat, seed) = inputs.0;
+            let mat = inputs.0;
             let cfg = CarryConfig::default();
-            record_weight_observation(&mat, 1.0, &cfg, &mut writer, &descriptor_vocab, seed);
+            record_weight_observation(&mat, 1.0, &cfg, &mut writer, &descriptor_vocab);
         }
 
-        let material = material_with_density(0.8);
-
-        for (label, supplied, expected) in [
+        for (label, origin_planet_seed, expected) in [
             (
-                "with current planet",
+                "with planet origin",
                 Some(0xDEAD_BEEFu64),
                 Some(0xDEAD_BEEFu64),
             ),
-            ("without WorldProfile", None, None),
+            ("without planet origin", None, None),
         ] {
+            let mut material = material_with_density(0.8);
+            material.origin_planet_seed = origin_planet_seed;
+
             let mut app = App::new();
             app.add_message::<RecordObservation>();
             app.insert_resource(crate::observation::DescriptorVocabulary::default());
             app.world_mut()
-                .run_system_cached_with(drive, (material.clone(), supplied))
+                .run_system_cached_with(drive, material.clone())
                 .expect("one-shot system should run");
 
             let mut messages = app
@@ -2288,14 +2275,14 @@ exponent = 1.0
             let recorded: Vec<RecordObservation> = messages.drain().collect();
             assert_eq!(recorded.len(), 1, "{label}: expected one observation");
             match &recorded[0].key {
-                JournalKey::Material { seed, planet_seed } => {
+                JournalKey::MaterialInstance { seed } => {
                     assert_eq!(*seed, material.seed, "{label}: material seed must match");
                     assert_eq!(
-                        *planet_seed, expected,
-                        "{label}: recorded planet_seed must equal the supplied value (no sentinel substitution)"
+                        recorded[0].planet_seed, expected,
+                        "{label}: planet_seed must come from material.origin_planet_seed"
                     );
                 }
-                other => panic!("{label}: expected JournalKey::Material, got {other:?}"),
+                other => panic!("{label}: expected JournalKey::MaterialInstance, got {other:?}"),
             }
         }
     }

--- a/src/classification.rs
+++ b/src/classification.rs
@@ -1,0 +1,441 @@
+//! Material classification — query-time grouping of observed instances.
+//!
+//! Loads `assets/materials/classifications.toml` at startup into the
+//! [`MaterialClassifications`] resource. The Journal and any other query
+//! layer uses [`MaterialClassifications::classify`] to map a material's
+//! observed property values to a named type (e.g. "Ferrite", "Volatite").
+//!
+//! **Classification is never stored.** No entity, component, or graph node
+//! ever carries a `classification` field — the name is always the result of
+//! a range-match at query time (Core Principle 6, Data Architecture ADR).
+//!
+//! A material that matches no range is "Unknown" — the Journal shows it as
+//! "Unknown [procedural-name]" derived from its seed so the player can still
+//! refer to it consistently before enough observations exist to name it.
+
+use std::{fs, path::Path};
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// ── Asset schema ─────────────────────────────────────────────────────────
+
+/// A min/max range for a single material property.
+///
+/// Both bounds are inclusive. A value equal to `min` or `max` is inside
+/// the range.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyRange {
+    /// Minimum value (inclusive). Must be in \[0.0, 1.0\].
+    pub min: f32,
+    /// Maximum value (inclusive). Must be in \[0.0, 1.0\].
+    pub max: f32,
+}
+
+impl PropertyRange {
+    /// Returns `true` if `value` is within `[min, max]` (inclusive).
+    pub fn contains(&self, value: f32) -> bool {
+        value >= self.min && value <= self.max
+    }
+}
+
+/// One classification entry loaded from `classifications.toml`.
+///
+/// Each entry describes the property ranges that an observed material must
+/// fall within to be considered a member of this type. Omitted properties
+/// are unconstrained — only the properties present in the TOML entry are
+/// checked.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClassificationEntry {
+    /// Internal name used as the `classification` field in
+    /// [`crate::journal::JournalKey::Material`] (e.g. "ferrite").
+    pub name: String,
+    /// Human-readable display name shown in the Journal (e.g. "Ferrite").
+    pub display_name: String,
+    /// Density range constraint, if any.
+    pub density: Option<PropertyRange>,
+    /// Thermal resistance range constraint, if any.
+    pub thermal_resistance: Option<PropertyRange>,
+    /// Reactivity range constraint, if any.
+    pub reactivity: Option<PropertyRange>,
+    /// Conductivity range constraint, if any.
+    pub conductivity: Option<PropertyRange>,
+    /// Toxicity range constraint, if any.
+    pub toxicity: Option<PropertyRange>,
+}
+
+impl ClassificationEntry {
+    /// Returns `true` if all property constraints whose corresponding
+    /// property has been *observed* (present in `revealed`) match the
+    /// recorded value, AND at least one constrained property is present.
+    ///
+    /// A material that has no revealed properties that overlap with this
+    /// entry's constraints returns `false` — the player hasn't observed
+    /// enough to classify it yet.
+    ///
+    /// Unconstrained properties (the `Option` is `None` on the entry) are
+    /// always satisfied regardless of observation state.
+    pub fn matches_observed(
+        &self,
+        revealed: &std::collections::HashMap<crate::journal::ObservationCategory, f32>,
+    ) -> bool {
+        use crate::journal::ObservationCategory;
+
+        // Helper: if the entry has a constraint for this property AND the
+        // player has observed it, the observed value must be in range.
+        // If the entry has a constraint but the property is NOT yet observed,
+        // we cannot classify — return false immediately.
+        let check = |range: &Option<PropertyRange>, cat: ObservationCategory| -> Option<bool> {
+            let r = range.as_ref()?; // None constraint → always ok (skip)
+            let &value = revealed.get(&cat)?; // not yet observed → can't classify
+            Some(r.contains(value))
+        };
+
+        // All constrained-and-observed properties must be in range.
+        // At least one constrained property must have been observed.
+        let mut any_constrained_observed = false;
+
+        for (range, cat) in [
+            (&self.density, ObservationCategory::Weight),
+            (
+                &self.thermal_resistance,
+                ObservationCategory::ThermalBehavior,
+            ),
+            // Reactivity / conductivity / toxicity observation systems not wired yet;
+            // their ranges are loaded but won't match until those systems exist.
+        ] {
+            if range.is_none() {
+                continue; // unconstrained — skip
+            }
+            match check(range, cat) {
+                None => return false,        // constrained but not observed
+                Some(false) => return false, // out of range
+                Some(true) => any_constrained_observed = true,
+            }
+        }
+
+        any_constrained_observed
+    }
+}
+
+/// Top-level shape of `classifications.toml` — an array of entries under
+/// the `[[classification]]` header.
+#[derive(Debug, Deserialize)]
+struct ClassificationsFile {
+    classification: Vec<ClassificationEntry>,
+}
+
+// ── Resource ─────────────────────────────────────────────────────────────
+
+/// All loaded material classification ranges, available to the Journal and
+/// any other query layer at runtime.
+///
+/// Populated once at `Startup` from `assets/materials/classifications.toml`.
+/// Never written to after startup — classifications are authoritative data,
+/// not runtime state.
+#[derive(Resource, Debug, Default)]
+pub struct MaterialClassifications {
+    entries: Vec<ClassificationEntry>,
+}
+
+impl MaterialClassifications {
+    /// Classify a material by its *observed* properties.
+    ///
+    /// Returns the first [`ClassificationEntry`] whose constrained properties
+    /// all match the values the player has revealed, or `None` if no
+    /// classification is confident enough yet.
+    pub fn classify_observed<'a>(
+        &'a self,
+        revealed: &std::collections::HashMap<crate::journal::ObservationCategory, f32>,
+    ) -> Option<&'a ClassificationEntry> {
+        self.entries.iter().find(|e| e.matches_observed(revealed))
+    }
+
+    /// All loaded classification entries in file order.
+    pub fn entries(&self) -> &[ClassificationEntry] {
+        &self.entries
+    }
+}
+
+// ── Plugin ────────────────────────────────────────────────────────────────
+
+/// Registers [`MaterialClassifications`] and loads it from disk at startup.
+pub struct MaterialClassificationsPlugin;
+
+impl Plugin for MaterialClassificationsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<MaterialClassifications>()
+            .add_systems(Startup, load_material_classifications);
+    }
+}
+
+const CLASSIFICATIONS_PATH: &str = "assets/materials/classifications.toml";
+
+/// Loads `classifications.toml` into the [`MaterialClassifications`] resource.
+///
+/// Runs at `Startup`. If the file is missing or malformed the resource stays
+/// empty — materials will all appear as "Unknown" in the Journal rather than
+/// crashing.
+fn load_material_classifications(mut classifications: ResMut<MaterialClassifications>) {
+    let path = Path::new(CLASSIFICATIONS_PATH);
+    if !path.exists() {
+        warn!(
+            "classifications.toml not found at {CLASSIFICATIONS_PATH} — all materials will be unclassified"
+        );
+        return;
+    }
+    let contents = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to read {CLASSIFICATIONS_PATH}: {e}");
+            return;
+        }
+    };
+    let file: ClassificationsFile = match toml::from_str(&contents) {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to parse {CLASSIFICATIONS_PATH}: {e}");
+            return;
+        }
+    };
+    classifications.entries = file.classification;
+    info!(
+        "Loaded {} material classifications",
+        classifications.entries.len()
+    );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::journal::ObservationCategory;
+
+    /// Build a fully-revealed HashMap for ferrite-like properties.
+    fn ferrite_revealed() -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, 0.78_f32); // density
+        m.insert(ObservationCategory::ThermalBehavior, 0.65_f32); // thermal_resistance
+        m
+    }
+
+    fn ferrite_entry() -> ClassificationEntry {
+        ClassificationEntry {
+            name: "ferrite".into(),
+            display_name: "Ferrite".into(),
+            // Seed 1001: density=0.5086, thermal=0.4468
+            density: Some(PropertyRange {
+                min: 0.49,
+                max: 0.56,
+            }),
+            thermal_resistance: Some(PropertyRange {
+                min: 0.38,
+                max: 0.51,
+            }),
+            reactivity: None,
+            conductivity: None,
+            toxicity: None,
+        }
+    }
+
+    /// Build a HashMap containing only Weight (density) for a single-property test.
+    fn weight_only(value: f32) -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, value);
+        m
+    }
+
+    /// Build a HashMap with both Weight and Thermal revealed.
+    fn weight_and_thermal(weight: f32, thermal: f32) -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, weight);
+        m.insert(ObservationCategory::ThermalBehavior, thermal);
+        m
+    }
+
+    #[test]
+    fn classify_matches_when_all_constrained_props_observed_and_in_range() {
+        // Ferrite seed-derived reference: d=0.5086, tr=0.4468 — inside ranges (0.49-0.56, 0.38-0.51)
+        let entry = ferrite_entry();
+        let revealed = weight_and_thermal(0.51, 0.45);
+        assert!(entry.matches_observed(&revealed));
+    }
+
+    #[test]
+    fn classify_boundary_values_inclusive() {
+        let entry = ferrite_entry();
+        // Min bounds
+        assert!(entry.matches_observed(&weight_and_thermal(0.49, 0.38)));
+        // Max bounds
+        assert!(entry.matches_observed(&weight_and_thermal(0.56, 0.51)));
+    }
+
+    #[test]
+    fn classify_outside_range_fails() {
+        let entry = ferrite_entry();
+        // density too low
+        assert!(!entry.matches_observed(&weight_and_thermal(0.10, 0.44)));
+        // thermal too high
+        assert!(!entry.matches_observed(&weight_and_thermal(0.51, 0.90)));
+    }
+
+    #[test]
+    fn classify_returns_false_when_constrained_prop_not_observed() {
+        // density constraint present but not in revealed map
+        let entry = ferrite_entry();
+        let revealed = HashMap::new(); // nothing observed
+        assert!(!entry.matches_observed(&revealed));
+    }
+
+    #[test]
+    fn classify_with_only_weight_observed_matches_when_in_range() {
+        let entry = ferrite_entry();
+        // thermal_resistance is constrained — not observed → cannot classify
+        assert!(!entry.matches_observed(&weight_only(0.51))); // 0.51 in d-range but thermal not observed
+    }
+
+    #[test]
+    fn no_entries_returns_none() {
+        let classifications = MaterialClassifications::default();
+        assert!(
+            classifications
+                .classify_observed(&weight_and_thermal(0.51, 0.45))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn first_matching_entry_wins() {
+        let mut classifications = MaterialClassifications::default();
+        classifications.entries.push(ferrite_entry());
+        // A second entry with overlapping density range but no thermal constraint.
+        classifications.entries.push(ClassificationEntry {
+            name: "also_ferrite".into(),
+            display_name: "Also Ferrite".into(),
+            density: Some(PropertyRange {
+                min: 0.49,
+                max: 0.56,
+            }),
+            thermal_resistance: None,
+            reactivity: None,
+            conductivity: None,
+            toxicity: None,
+        });
+        let result = classifications.classify_observed(&weight_and_thermal(0.51, 0.44));
+        assert_eq!(result.map(|e| e.name.as_str()), Some("ferrite"));
+    }
+
+    #[test]
+    fn classifications_toml_loads_all_entries() {
+        let contents = std::fs::read_to_string(CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        assert_eq!(
+            file.classification.len(),
+            10,
+            "expected 10 classification entries"
+        );
+    }
+
+    #[test]
+    fn well_known_seeds_classify_correctly_when_fully_revealed() {
+        // Each well-known seed should classify to the expected type when the
+        // player has observed both Weight and ThermalBehavior.
+        use crate::materials::{WELL_KNOWN_MATERIAL_SEEDS, derive_material_from_seed};
+
+        let contents = std::fs::read_to_string(CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        let classifications = MaterialClassifications {
+            entries: file.classification,
+        };
+
+        let expected: &[(&str, &str)] = &[
+            ("Ferrite", "ferrite"),
+            ("Calcium", "calcium"),
+            ("Sulfurite", "sulfurite"),
+            ("Prismate", "prismate"),
+            ("Verdant", "verdant"),
+            ("Osmium", "osmium"),
+            ("Volatite", "volatite"),
+            ("Cobaltine", "cobaltine"),
+            ("Silite", "silite"),
+            ("Phosphite", "phosphite"),
+        ];
+
+        for (seed, (mat_name, expected_class)) in
+            WELL_KNOWN_MATERIAL_SEEDS.iter().zip(expected.iter())
+        {
+            let (_label, seed_val) = seed;
+            let mat = derive_material_from_seed(*seed_val);
+            let props = mat.property_vector();
+            // Simulate player having observed both Weight and ThermalBehavior.
+            let revealed = weight_and_thermal(props[0], props[1]);
+            let result = classifications.classify_observed(&revealed);
+            assert_eq!(
+                result.map(|e| e.name.as_str()),
+                Some(*expected_class),
+                "{mat_name} (seed {seed_val}): density={:.4} thermal={:.4} — expected {} got {:?}",
+                props[0],
+                props[1],
+                expected_class,
+                result.map(|e| e.name.as_str())
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::journal::{JournalKey, ObservationCategory};
+    use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+    use std::collections::HashMap;
+
+    #[test]
+    fn revealed_properties_flow_end_to_end() {
+        use crate::materials::derive_material_from_seed;
+
+        // Simulate what update_knowledge_graph does when a Weight observation fires
+        let seed = 1001u64; // Ferrite
+        let mat = derive_material_from_seed(seed);
+        let density = mat.density.value();
+        let thermal = mat.thermal_resistance.value();
+
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node_idx = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+
+        // Simulate reveal_property being called for Weight
+        graph.reveal_property(node_idx, ObservationCategory::Weight, density);
+        graph.reveal_property(node_idx, ObservationCategory::ThermalBehavior, thermal);
+
+        let node = graph.node(node_idx).unwrap();
+        let revealed = &node.revealed_properties;
+
+        println!("Revealed: {:?}", revealed);
+        println!("density={:.4} thermal={:.4}", density, thermal);
+
+        // Now classify
+        let contents = std::fs::read_to_string(crate::classification::CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: crate::classification::ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        let classifications = MaterialClassifications {
+            entries: file.classification,
+        };
+
+        let result = classifications.classify_observed(revealed);
+        println!("Classification: {:?}", result.map(|e| &e.name));
+        assert_eq!(
+            result.map(|e| e.name.as_str()),
+            Some("ferrite"),
+            "Ferrite seed should classify as ferrite after Weight+Thermal revealed"
+        );
+    }
+}

--- a/src/combination.rs
+++ b/src/combination.rs
@@ -132,10 +132,16 @@ struct CombinationFile {
     rules: Vec<PairRuleEntry>,
 }
 
+/// TOML schema for a single pair rule entry.
+///
+/// Uses `material_seed_a` / `material_seed_b` — the generation seeds that
+/// deterministically identify each material — rather than names. Names are
+/// query-time artefacts (classification or procedural); seeds are the stable
+/// ground-truth identity (Core Principle 6, Data Architecture ADR).
 #[derive(Debug, Deserialize)]
 struct PairRuleEntry {
-    material_a: String,
-    material_b: String,
+    material_seed_a: u64,
+    material_seed_b: u64,
     #[serde(default)]
     density: Option<PropertyRule>,
     #[serde(default)]
@@ -150,28 +156,32 @@ struct PairRuleEntry {
 
 // ── Resource ────────────────────────────────────────────────────────────
 
-/// Canonical key for a material pair — alphabetically sorted so (A,B) == (B,A).
-fn pair_key(a: &str, b: &str) -> (String, String) {
-    if a <= b {
-        (a.to_string(), b.to_string())
+/// Canonical key for a material pair — lower seed first so (A,B) == (B,A).
+fn pair_key(seed_a: u64, seed_b: u64) -> (u64, u64) {
+    if seed_a <= seed_b {
+        (seed_a, seed_b)
     } else {
-        (b.to_string(), a.to_string())
+        (seed_b, seed_a)
     }
 }
 
-/// Loaded combination rules, keyed by sorted material name pairs.
+/// Loaded combination rules, keyed by sorted material seed pairs.
+///
+/// Seeds are the stable ground-truth identity of a material — names are
+/// query-time artefacts that must never be used as storage keys (ADR).
 #[derive(Resource, Debug, Default)]
 pub struct CombinationRules {
     /// Fallback rule used when no pair-specific entry exists.
     pub default_rule: PropertyRule,
-    /// Per-pair overrides keyed by alphabetically sorted material name tuples.
-    pub pair_rules: HashMap<(String, String), PairRuleSet>,
+    /// Per-pair overrides keyed by `(min_seed, max_seed)` tuples.
+    pub pair_rules: HashMap<(u64, u64), PairRuleSet>,
 }
 
 impl CombinationRules {
-    /// Look up the rule set for a pair, falling back to the default for each property.
-    pub fn rules_for(&self, name_a: &str, name_b: &str) -> PairRuleSet {
-        let key = pair_key(name_a, name_b);
+    /// Look up the rule set for a pair by their generation seeds,
+    /// falling back to the default for each property.
+    pub fn rules_for(&self, seed_a: u64, seed_b: u64) -> PairRuleSet {
+        let key = pair_key(seed_a, seed_b);
         if let Some(rules) = self.pair_rules.get(&key) {
             rules.clone()
         } else {
@@ -200,7 +210,7 @@ fn load_combination_rules(mut commands: Commands) {
                     let mut pair_rules = HashMap::new();
 
                     for entry in file.rules {
-                        let key = pair_key(&entry.material_a, &entry.material_b);
+                        let key = pair_key(entry.material_seed_a, entry.material_seed_b);
                         let rule_set = PairRuleSet {
                             density: entry.density.unwrap_or_else(|| default.clone()),
                             thermal_resistance: entry
@@ -296,13 +306,13 @@ mod tests {
 
     #[test]
     fn pair_key_is_order_independent() {
-        assert_eq!(pair_key("Ferrite", "Silite"), pair_key("Silite", "Ferrite"));
+        assert_eq!(pair_key(1001, 1009), pair_key(1009, 1001));
     }
 
     #[test]
     fn rules_for_returns_default_for_unknown_pair() {
         let rules = CombinationRules::default();
-        let pair = rules.rules_for("Unknown", "Other");
+        let pair = rules.rules_for(9999, 8888);
         assert_eq!(pair.density, PropertyRule::default());
     }
 
@@ -321,8 +331,8 @@ weight_a = 0.5
 weight_b = 0.5
 
 [[rules]]
-material_a = "A"
-material_b = "B"
+material_seed_a = 1001
+material_seed_b = 1010
 density = { type = "Max" }
 thermal_resistance = { type = "Catalyze", multiplier = 1.3 }
 reactivity = { type = "Min" }

--- a/src/debug_overlay.rs
+++ b/src/debug_overlay.rs
@@ -5,9 +5,14 @@
 //! between the player's actual Y and the terrain surface. This helps
 //! diagnose any mismatch between the visual heightmap mesh and the logical
 //! surface used for placement / camera height.
+//!
+//! Press **F3** (default) to toggle the panel on or off. The panel starts
+//! hidden — open it when you need it, close it when you don't.
 
 use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
 
+use crate::input::InputAction;
 use crate::player::{Player, PlayerCamera};
 use crate::scene::PositionXZ;
 use crate::world_generation::{
@@ -21,21 +26,32 @@ pub struct DebugOverlayPlugin;
 impl Plugin for DebugOverlayPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, spawn_debug_panel)
-            .add_systems(Update, update_debug_panel);
+            .add_systems(Update, (toggle_debug_panel, update_debug_panel).chain());
     }
 }
 
+/// Marker for the root node of the debug overlay panel.
+#[derive(Component)]
+struct DebugPanel;
+
+/// Marker for the text entity inside the debug overlay panel.
 #[derive(Component)]
 struct DebugText;
 
+/// Spawns the debug overlay panel in a hidden state.
+///
+/// Runs once at `Startup`. The panel is invisible by default — press F3
+/// (or the configured `ToggleDebugOverlay` binding) to show it.
 fn spawn_debug_panel(mut commands: Commands) {
     commands
         .spawn((
+            DebugPanel,
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(10.0),
                 left: Val::Px(10.0),
                 padding: UiRect::all(Val::Px(8.0)),
+                display: Display::None,
                 ..default()
             },
             BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.7)),
@@ -53,13 +69,50 @@ fn spawn_debug_panel(mut commands: Commands) {
         });
 }
 
+/// Toggles the debug panel visibility when the `ToggleDebugOverlay` action fires.
+///
+/// Runs in `Update`, before `update_debug_panel` — so we skip the terrain
+/// sampling work when the panel is hidden.
+fn toggle_debug_panel(
+    action_state: Option<Res<ActionState<InputAction>>>,
+    mut panel_query: Query<&mut Node, With<DebugPanel>>,
+) {
+    let Some(action_state) = action_state else {
+        return;
+    };
+    if !action_state.just_pressed(&InputAction::ToggleDebugOverlay) {
+        return;
+    }
+    let Ok(mut node) = panel_query.single_mut() else {
+        return;
+    };
+    node.display = if node.display == Display::None {
+        Display::Flex
+    } else {
+        Display::None
+    };
+}
+
+/// Updates the terrain diagnostic text each frame — only does work when
+/// the panel is visible.
+///
+/// Runs in `Update`, chained after `toggle_debug_panel`.
 fn update_debug_panel(
+    panel_query: Query<&Node, With<DebugPanel>>,
     player_query: Query<&Transform, With<Player>>,
     camera_query: Query<&GlobalTransform, With<PlayerCamera>>,
     world_profile: Option<Res<WorldProfile>>,
     world_gen_config: Res<WorldGenerationConfig>,
     mut text_query: Query<&mut Text, With<DebugText>>,
 ) {
+    // Skip all work if the panel is hidden.
+    let Ok(panel_node) = panel_query.single() else {
+        return;
+    };
+    if panel_node.display == Display::None {
+        return;
+    }
+
     let Ok(player_tf) = player_query.single() else {
         return;
     };

--- a/src/diegetic_ui.rs
+++ b/src/diegetic_ui.rs
@@ -1,0 +1,584 @@
+//! Diegetic UI Framework — in-world information surfaces.
+//!
+//! # What "diegetic" means in Apeiron Cipher
+//!
+//! Every piece of information the player can read must exist as a physical
+//! object in the game world.  No HUD overlays, no floating labels, no
+//! tooltip popups.  A journal is a datapad you hold up and look at.  A
+//! fabricator status is a gauge on the workbench.  A glowing mineral is its
+//! own advertisement.  The player's knowledge comes from *observing the world*,
+//! not from reading system messages.
+//!
+//! # How to add a new diegetic surface
+//!
+//! 1. Spawn an entity with the [`DiegeticSurface`] marker component.
+//! 2. Add a [`DiegeticSurfaceKind`] component to declare how far away the
+//!    surface can be perceived and interacted with.
+//! 3. Add a [`DiegeticFocusState`] component (default is [`DiegeticFocusState::OutOfRange`]).
+//! 4. For text-displaying surfaces, also add a [`ReadableSurfaceContent`]
+//!    component.  Systems that own the information write their content there;
+//!    the rendering system reads it.
+//! 5. Register your rendering logic in whatever system drives your surface's
+//!    visuals.  Query for `(&DiegeticFocusState, &ReadableSurfaceContent)` —
+//!    only render when the state is [`DiegeticFocusState::Focused`] or
+//!    [`DiegeticFocusState::Active`].
+//!
+//! # Surface kind selection guide
+//!
+//! | What you're building | Use |
+//! |---|---|
+//! | Text you read (journal, datapad, inscriptions) | `DiegeticSurfaceKind::Readable` |
+//! | Live readouts via gauges/lights (fabricator, navigation console) | `DiegeticSurfaceKind::Instrument` |
+//! | A world object whose appearance *is* the message (glowing mineral, stress cracks) | `DiegeticSurfaceKind::PhysicalIndicator` |
+//!
+//! # System ordering
+//!
+//! [`DiegeticUiPlugin`] schedules [`update_diegetic_focus`] in
+//! [`DiegeticUiSet::FocusUpdate`], which runs in `Update` before any
+//! rendering.  Downstream rendering systems should run after this set to see
+//! up-to-date focus states.
+
+use bevy::prelude::*;
+
+use crate::player::Player;
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+/// Registers the diegetic UI framework systems onto the [`App`].
+///
+/// Adds [`DiegeticUiSet::FocusUpdate`] to `Update`.  All diegetic surface
+/// rendering systems should run *after* this set.
+pub struct DiegeticUiPlugin;
+
+impl Plugin for DiegeticUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.configure_sets(
+            Update,
+            (DiegeticUiSet::FocusUpdate, DiegeticUiSet::VisibilitySync).chain(),
+        )
+        .add_systems(
+            Update,
+            update_diegetic_focus.in_set(DiegeticUiSet::FocusUpdate),
+        )
+        .add_systems(
+            Update,
+            sync_readable_surface_visibility.in_set(DiegeticUiSet::VisibilitySync),
+        );
+    }
+}
+
+// ── System sets ─────────────────────────────────────────────────────────────
+
+/// System sets for the diegetic UI framework.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DiegeticUiSet {
+    /// Proximity-based [`DiegeticFocusState`] updates.
+    ///
+    /// Runs every `Update` frame.  All downstream rendering systems that
+    /// care about focus state must run *after* this set.
+    FocusUpdate,
+    /// Visibility gating: sets [`Visibility`] on diegetic surface entities
+    /// based on [`DiegeticFocusState`].
+    ///
+    /// Runs after [`FocusUpdate`](DiegeticUiSet::FocusUpdate) so that focus
+    /// transitions and visibility are always in sync within the same frame.
+    VisibilitySync,
+}
+
+// ── Components ───────────────────────────────────────────────────────────────
+
+/// Marker component — every in-world information surface must carry this.
+///
+/// CI compliance tests query for `Text` nodes that are *not* descended from
+/// a [`DiegeticSurface`] entity.  Any screen-space text without this marker
+/// is an architectural violation.
+///
+/// See the module-level documentation for a step-by-step guide on adding
+/// new diegetic surfaces.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct DiegeticSurface;
+
+/// Determines how a diegetic surface is perceived and interacted with.
+///
+/// This drives the [`update_diegetic_focus`] system's proximity thresholds
+/// and is the primary selector for how your rendering code should behave.
+///
+/// Choose based on the interaction model, not the visual style:
+/// - **Readable** — the player approaches and reads static or paged text.
+/// - **Instrument** — real-time readouts through visual indicators (no text).
+/// - **PhysicalIndicator** — the object *is* the message; no proximity logic.
+#[derive(Component, Clone, Debug)]
+pub enum DiegeticSurfaceKind {
+    /// A surface the player reads (journal datapad, inscriptions, signage).
+    ///
+    /// Text rendering happens on a world-space quad; the player physically
+    /// moves close enough for the text to resolve.
+    Readable {
+        /// Distance at which the surface starts to be perceivable (fade-in
+        /// begins, text is blurry/dim).
+        perceivable_range: f32,
+        /// Distance at which text becomes fully legible (focus completes).
+        ///
+        /// Must be ≤ `perceivable_range`.
+        legible_range: f32,
+    },
+    /// An instrument with dynamic readouts (fabricator display, navigation console).
+    ///
+    /// State is communicated through visual indicators (lights, gauges), not
+    /// text.  The single `interaction_range` determines both when the surface
+    /// becomes perceivable (2×) and fully interactable (1×).
+    Instrument {
+        /// Distance at which the player can fully interact with the instrument.
+        ///
+        /// The perceivable threshold is `interaction_range * 2.0`.
+        interaction_range: f32,
+    },
+    /// A physical indicator — glow, heat shimmer, stress cracks, etc.
+    ///
+    /// No proximity logic is applied; the object communicates state purely
+    /// through its appearance.  [`update_diegetic_focus`] skips these
+    /// entities entirely.
+    PhysicalIndicator,
+}
+
+/// Current focus relationship between a diegetic surface and the player.
+///
+/// Transitions are driven by [`update_diegetic_focus`] based on player
+/// proximity.  The [`Active`](DiegeticFocusState::Active) state is managed
+/// exclusively by interaction systems — proximity updates never clear it.
+///
+/// Rendering systems should gate their work on this component:
+/// - [`OutOfRange`](DiegeticFocusState::OutOfRange) → nothing visible.
+/// - [`Perceivable`](DiegeticFocusState::Perceivable) → dim/blurry preview.
+/// - [`Focused`](DiegeticFocusState::Focused) → fully legible, awaiting activation.
+/// - [`Active`](DiegeticFocusState::Active) → player is actively using the surface.
+#[derive(Component, Clone, Debug, Default, PartialEq)]
+pub enum DiegeticFocusState {
+    /// Player is beyond perceivable range — surface produces no output.
+    #[default]
+    OutOfRange,
+    /// Player is within perceivable range but not yet within legible/interaction
+    /// range.  `proximity` is `1.0` at the legible boundary and `0.0` at the
+    /// perceivable boundary — use it to scale alpha, blur, or LOD.
+    Perceivable {
+        /// `0.0` = just entered perceivable range.  `1.0` = at legible boundary.
+        proximity: f32,
+    },
+    /// Player is within legible/interaction range.  The surface is fully
+    /// readable but the player has not yet activated it.
+    Focused,
+    /// Player is actively interacting (reading, operating an instrument).
+    ///
+    /// Set and cleared by interaction systems, *not* by proximity logic.
+    /// A surface stays `Active` even if the player steps away, until the
+    /// interaction system explicitly transitions it back.
+    Active,
+}
+
+/// Text content for a [`DiegeticSurfaceKind::Readable`] surface.
+///
+/// Owning systems (e.g. the journal plugin) write to this component every
+/// frame when the surface is [`Active`](DiegeticFocusState::Active).  The
+/// rendering system reads it — the two systems are decoupled through this
+/// component, which keeps each within the four-parameter limit.
+///
+/// Content lines should use qualitative language only — no raw numbers, no
+/// system identifiers.  The game never shows internal state.
+#[derive(Component, Clone, Debug, Default)]
+pub struct ReadableSurfaceContent {
+    /// Lines of text to display, already formatted for the player.
+    ///
+    /// Each element is one visible line.  The rendering system displays
+    /// `visible_lines` of them starting at `scroll_offset`.
+    pub lines: Vec<String>,
+    /// Index of the first visible line (for multi-page content).
+    pub scroll_offset: usize,
+    /// How many lines the surface's physical display area can show at once.
+    ///
+    /// Set once at spawn based on the surface's physical dimensions.
+    /// The rendering system clamps `scroll_offset` to keep the view valid.
+    pub visible_lines: usize,
+}
+
+// ── Systems ───────────────────────────────────────────────────────────────────
+
+/// Updates [`DiegeticFocusState`] on every diegetic surface based on how far
+/// the player is from it.
+///
+/// # Rules
+///
+/// - [`DiegeticSurfaceKind::PhysicalIndicator`] surfaces are skipped — they
+///   are always visible through their world appearance alone.
+/// - [`DiegeticFocusState::Active`] surfaces are never overridden here — that
+///   state is managed exclusively by interaction systems.
+/// - For all other surfaces the transition ladder is:
+///   `OutOfRange → Perceivable { proximity } → Focused`
+///
+/// Runs in [`DiegeticUiSet::FocusUpdate`].
+pub(crate) fn update_diegetic_focus(
+    player_query: Query<&Transform, With<Player>>,
+    mut surfaces: Query<
+        (&Transform, &DiegeticSurfaceKind, &mut DiegeticFocusState),
+        With<DiegeticSurface>,
+    >,
+) {
+    let Ok(player_transform) = player_query.single() else {
+        return;
+    };
+    let player_pos = player_transform.translation;
+
+    for (surface_transform, kind, mut focus_state) in surfaces.iter_mut() {
+        // Active state is owned by interaction systems — never clobber it.
+        if matches!(*focus_state, DiegeticFocusState::Active) {
+            continue;
+        }
+
+        // Physical indicators have no proximity logic — their appearance is
+        // always present in the world.
+        let (perceivable_range, legible_range) = match kind {
+            DiegeticSurfaceKind::Readable {
+                perceivable_range,
+                legible_range,
+            } => (*perceivable_range, *legible_range),
+            DiegeticSurfaceKind::Instrument { interaction_range } => {
+                (interaction_range * 2.0, *interaction_range)
+            }
+            DiegeticSurfaceKind::PhysicalIndicator => continue,
+        };
+
+        let distance = player_pos.distance(surface_transform.translation);
+
+        *focus_state = if distance <= legible_range {
+            DiegeticFocusState::Focused
+        } else if distance <= perceivable_range {
+            // Interpolate: 0.0 at outer perceivable edge, 1.0 at legible edge.
+            let span = perceivable_range - legible_range;
+            let proximity = if span > f32::EPSILON {
+                1.0 - (distance - legible_range) / span
+            } else {
+                // Degenerate: perceivable == legible, jump straight to focused.
+                1.0
+            };
+            DiegeticFocusState::Perceivable { proximity }
+        } else {
+            DiegeticFocusState::OutOfRange
+        };
+    }
+}
+
+/// Gates [`Visibility`] on every [`DiegeticSurface`] entity based on its
+/// current [`DiegeticFocusState`].
+///
+/// | State | Visibility |
+/// |---|---|
+/// | [`OutOfRange`](DiegeticFocusState::OutOfRange) | `Hidden` |
+/// | [`Perceivable`](DiegeticFocusState::Perceivable) | `Visible` (renderer dims via alpha) |
+/// | [`Focused`](DiegeticFocusState::Focused) | `Visible` |
+/// | [`Active`](DiegeticFocusState::Active) | `Visible` |
+///
+/// Downstream renderers are responsible for reading `proximity` from
+/// [`Perceivable`](DiegeticFocusState::Perceivable) and adjusting alpha /
+/// LOD accordingly — this system only manages show/hide.
+///
+/// Runs in [`DiegeticUiSet::VisibilitySync`], after [`DiegeticUiSet::FocusUpdate`].
+pub(crate) fn sync_readable_surface_visibility(
+    mut surfaces: Query<(&DiegeticFocusState, &mut Visibility), With<DiegeticSurface>>,
+) {
+    for (focus_state, mut visibility) in surfaces.iter_mut() {
+        *visibility = match focus_state {
+            DiegeticFocusState::OutOfRange => Visibility::Hidden,
+            _ => Visibility::Visible,
+        };
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::app::App;
+
+    // ── Phase 1 tests ────────────────────────────────────────────────────────
+
+    /// Default focus state is OutOfRange.
+    #[test]
+    fn default_focus_state_is_out_of_range() {
+        let state = DiegeticFocusState::default();
+        assert_eq!(state, DiegeticFocusState::OutOfRange);
+    }
+
+    /// Readable variant is constructible with expected parameters.
+    #[test]
+    fn readable_kind_constructible() {
+        let kind = DiegeticSurfaceKind::Readable {
+            perceivable_range: 5.0,
+            legible_range: 2.0,
+        };
+        match kind {
+            DiegeticSurfaceKind::Readable {
+                perceivable_range,
+                legible_range,
+            } => {
+                assert_eq!(perceivable_range, 5.0);
+                assert_eq!(legible_range, 2.0);
+            }
+            _ => panic!("expected Readable variant"),
+        }
+    }
+
+    /// Instrument variant is constructible with expected parameters.
+    #[test]
+    fn instrument_kind_constructible() {
+        let kind = DiegeticSurfaceKind::Instrument {
+            interaction_range: 3.0,
+        };
+        match kind {
+            DiegeticSurfaceKind::Instrument { interaction_range } => {
+                assert_eq!(interaction_range, 3.0);
+            }
+            _ => panic!("expected Instrument variant"),
+        }
+    }
+
+    /// PhysicalIndicator variant is constructible.
+    #[test]
+    fn physical_indicator_kind_constructible() {
+        let kind = DiegeticSurfaceKind::PhysicalIndicator;
+        assert!(matches!(kind, DiegeticSurfaceKind::PhysicalIndicator));
+    }
+
+    // ── Phase 2 tests ────────────────────────────────────────────────────────
+
+    /// Builds a minimal App with just enough to run `update_diegetic_focus`.
+    fn focus_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(bevy::app::Update, update_diegetic_focus);
+        app
+    }
+
+    fn spawn_player_at(app: &mut App, pos: Vec3) -> Entity {
+        app.world_mut()
+            .spawn((Player, Transform::from_translation(pos)))
+            .id()
+    }
+
+    fn spawn_surface_at(
+        app: &mut App,
+        pos: Vec3,
+        kind: DiegeticSurfaceKind,
+        initial_state: DiegeticFocusState,
+    ) -> Entity {
+        app.world_mut()
+            .spawn((
+                DiegeticSurface,
+                kind,
+                initial_state,
+                Transform::from_translation(pos),
+            ))
+            .id()
+    }
+
+    fn focus_state(app: &App, entity: Entity) -> DiegeticFocusState {
+        app.world()
+            .entity(entity)
+            .get::<DiegeticFocusState>()
+            .unwrap()
+            .clone()
+    }
+
+    /// Player beyond perceivable_range → OutOfRange.
+    #[test]
+    fn player_beyond_perceivable_range_is_out_of_range() {
+        let mut app = focus_test_app();
+        // Player at origin, surface 10 units away; perceivable_range = 5.
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(10.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::OutOfRange);
+    }
+
+    /// Player between perceivable and legible range → Perceivable with proximity in [0,1).
+    #[test]
+    fn player_in_perceivable_band_gives_proximity() {
+        let mut app = focus_test_app();
+        // perceivable = 6.0, legible = 2.0 → band is [2, 6]
+        // Player at distance 4.0 → midpoint → proximity = 1 - (4-2)/(6-2) = 0.5
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(4.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        match focus_state(&app, surface) {
+            DiegeticFocusState::Perceivable { proximity } => {
+                assert!(
+                    (proximity - 0.5).abs() < 1e-5,
+                    "expected proximity ~0.5, got {proximity}"
+                );
+            }
+            other => panic!("expected Perceivable, got {other:?}"),
+        }
+    }
+
+    /// Player within legible_range → Focused.
+    #[test]
+    fn player_within_legible_range_is_focused() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(1.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::Focused);
+    }
+
+    /// Active state is preserved even when player moves away.
+    #[test]
+    fn active_state_preserved_when_player_moves_away() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_at(
+            &mut app,
+            Vec3::new(100.0, 0.0, 0.0), // far away
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::Active, // already active
+        );
+        app.update();
+        // Must remain Active despite distance.
+        assert_eq!(focus_state(&app, surface), DiegeticFocusState::Active);
+    }
+
+    /// Proximity interpolates correctly: 0.0 at outer edge, 1.0 at legible edge.
+    #[test]
+    fn proximity_interpolates_between_zero_and_one() {
+        let mut app = focus_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+
+        // At the perceivable boundary (distance == perceivable_range) → proximity ≈ 0.0
+        let outer = spawn_surface_at(
+            &mut app,
+            Vec3::new(6.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        // At the legible boundary (distance == legible_range) → Focused (not Perceivable)
+        let inner = spawn_surface_at(
+            &mut app,
+            Vec3::new(2.0, 0.0, 0.0),
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 6.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+
+        match focus_state(&app, outer) {
+            DiegeticFocusState::Perceivable { proximity } => {
+                assert!(
+                    proximity < 0.01,
+                    "expected proximity ≈ 0.0 at outer edge, got {proximity}"
+                );
+            }
+            other => panic!("expected Perceivable at outer edge, got {other:?}"),
+        }
+        // At exactly legible_range, the system transitions to Focused.
+        assert_eq!(focus_state(&app, inner), DiegeticFocusState::Focused);
+    }
+
+    // ── Phase 3 tests ────────────────────────────────────────────────────────
+
+    fn visibility_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(
+            bevy::app::Update,
+            (update_diegetic_focus, sync_readable_surface_visibility).chain(),
+        );
+        app
+    }
+
+    fn spawn_surface_with_visibility(
+        app: &mut App,
+        pos: Vec3,
+        kind: DiegeticSurfaceKind,
+        initial_state: DiegeticFocusState,
+    ) -> Entity {
+        app.world_mut()
+            .spawn((
+                DiegeticSurface,
+                kind,
+                initial_state,
+                Transform::from_translation(pos),
+                Visibility::Hidden,
+            ))
+            .id()
+    }
+
+    fn vis(app: &App, entity: Entity) -> Visibility {
+        *app.world().entity(entity).get::<Visibility>().unwrap()
+    }
+
+    /// OutOfRange surface stays Hidden after sync.
+    #[test]
+    fn out_of_range_surface_is_hidden() {
+        let mut app = visibility_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_with_visibility(
+            &mut app,
+            Vec3::new(100.0, 0.0, 0.0), // far beyond range
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(vis(&app, surface), Visibility::Hidden);
+    }
+
+    /// Focused surface becomes Visible after sync.
+    #[test]
+    fn focused_surface_is_visible() {
+        let mut app = visibility_test_app();
+        spawn_player_at(&mut app, Vec3::ZERO);
+        let surface = spawn_surface_with_visibility(
+            &mut app,
+            Vec3::new(1.0, 0.0, 0.0), // within legible_range
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 5.0,
+                legible_range: 2.0,
+            },
+            DiegeticFocusState::OutOfRange,
+        );
+        app.update();
+        assert_eq!(vis(&app, surface), Visibility::Visible);
+    }
+}

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -14,11 +14,12 @@
 use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{
     GameMaterial, MATERIAL_SURFACE_GAP, MaterialCatalog, MaterialObject, MaterialProperty,
     PropertyVisibility,
 };
+use crate::observation::RecordObservation;
 use crate::scene::{FabricatorSceneConfig, FurnitureConfig, Workbench};
 
 /// Registers the fabricator workbench systems for combining materials.
@@ -287,14 +288,16 @@ fn tick_processing(
             output_seed: output_mat.seed,
         },
         name: output_mat.name.clone(),
+        material_seed: None,
         observation: Observation {
             category: ObservationCategory::FabricationResult,
             confidence: crate::observation::Confidence(0.8), // High confidence for fabrication results
             description,
             recorded_at: 0,
         },
-        // Populate input seeds so the knowledge graph can create DerivedFrom
-        // edges from the output material back to each input material.
+        // Pass input material seeds so the knowledge graph can wire DerivedFrom
+        // edges from the output concept to each input material (Story 10.5).
+        planet_seed: None,
         input_seeds: input_mats.iter().map(|m| m.seed).collect(),
         context_location: None,
     });
@@ -409,7 +412,7 @@ fn blend_color(a: &[f32; 3], b: &[f32; 3], catalytic: bool) -> [f32; 3] {
 // ── Main combine function ────────────────────────────────────────────────
 
 fn rule_combine(rules: &CombinationRules, a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
-    let pair_rules = rules.rules_for(&a.name, &b.name);
+    let pair_rules = rules.rules_for(a.seed, b.seed);
 
     let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);
     let name = procedural_name(combined_seed);
@@ -438,6 +441,9 @@ fn rule_combine(rules: &CombinationRules, a: &GameMaterial, b: &GameMaterial) ->
         name,
         seed: combined_seed,
         color,
+        // Fabricated materials have no planet origin — they are produced at
+        // the fabricator, not found in the world.
+        origin_planet_seed: None,
         density: {
             let base_density = apply_rule_with_perturbation(
                 &pair_rules.density,
@@ -489,6 +495,7 @@ mod tests {
             name: name.into(),
             seed,
             color: [0.5, 0.5, 0.5],
+            origin_planet_seed: None,
             density: MaterialProperty::new(density, PropertyVisibility::Observable),
             thermal_resistance: prop(0.4),
             reactivity: prop(0.6),
@@ -577,7 +584,7 @@ mod tests {
     fn catalytic_pair_shifts_color_hue() {
         let mut rules = default_rules();
         rules.pair_rules.insert(
-            ("Aaa".into(), "Bbb".into()),
+            (1, 2),
             PairRuleSet {
                 density: PropertyRule::Catalyze { multiplier: 1.5 },
                 thermal_resistance: PropertyRule::default(),
@@ -678,9 +685,7 @@ mod tests {
     #[test]
     fn inert_pair_produces_waste() {
         let mut rules = default_rules();
-        rules
-            .pair_rules
-            .insert(("Alpha".into(), "Beta".into()), PairRuleSet::all_inert());
+        rules.pair_rules.insert((1, 2), PairRuleSet::all_inert());
 
         let a = test_material("Alpha", 1, 0.8);
         let b = test_material("Beta", 2, 0.9);
@@ -720,7 +725,7 @@ mod tests {
     fn pair_order_independent() {
         let mut rules = default_rules();
         rules.pair_rules.insert(
-            ("Alpha".into(), "Beta".into()),
+            (1, 2),
             PairRuleSet {
                 density: PropertyRule::Max,
                 thermal_resistance: PropertyRule::Min,

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -17,11 +17,11 @@
 use bevy::prelude::*;
 
 use crate::descriptions::describe_thermal_observation;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::Confidence;
+use crate::observation::RecordObservation;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
-use crate::world_generation::WorldProfile;
 
 /// Plugin that manages heat sources and temperature-based material interactions.
 pub struct HeatPlugin;
@@ -278,11 +278,9 @@ fn reveal_thermal_property(
         ),
         With<MaterialObject>,
     >,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
     let reveal_secs = hs_cfg.reveal_seconds;
     let mut revealed_seeds = Vec::new();
-    let planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
 
     for (entity, exp, mut mat, recorded) in &mut material_query {
         if exp.elapsed < reveal_secs {
@@ -313,20 +311,10 @@ fn reveal_thermal_property(
             let initial_confidence = Confidence(0.2);
 
             journal_writer.write(RecordObservation {
-                key: JournalKey::Material {
-                    seed: mat.seed,
-                    // Capture the planet on which this thermal observation
-                    // is being recorded so the journal's "current planet"
-                    // filter (Story 10.3) can match this entry against the
-                    // player's current `WorldProfile::planet_seed`.  When
-                    // no `WorldProfile` is in scope (early bring-up or
-                    // ad-hoc integration tests) the field stays `None` —
-                    // see `JournalKey::Material::planet_seed`'s docs for
-                    // why "unknown provenance" is kept explicit instead
-                    // of defaulting to a sentinel.
-                    planet_seed,
-                },
+                key: JournalKey::MaterialInstance { seed: mat.seed },
                 name: mat.name.clone(),
+                material_seed: Some(mat.seed),
+                planet_seed: mat.origin_planet_seed,
                 observation: Observation {
                     category: ObservationCategory::ThermalBehavior,
                     confidence: initial_confidence,
@@ -382,6 +370,7 @@ mod tests {
             name: format!("TestMat-{seed}"),
             seed,
             color: [0.5, 0.5, 0.5],
+            origin_planet_seed: None,
             density: MaterialProperty::new(0.5, PropertyVisibility::Observable),
             thermal_resistance: MaterialProperty::new(0.65, PropertyVisibility::Hidden),
             reactivity: MaterialProperty::new(0.35, PropertyVisibility::Hidden),
@@ -624,7 +613,11 @@ mod tests {
 
         app.world_mut().spawn((
             MaterialObject,
-            test_material(7),
+            {
+                let mut mat = test_material(7);
+                mat.origin_planet_seed = Some(expected_seed);
+                mat
+            },
             HeatExposure {
                 elapsed: 5.0,
                 in_zone: true,
@@ -643,15 +636,15 @@ mod tests {
             "exactly one thermal observation should be recorded for one revealed entity"
         );
         match &recorded[0].key {
-            JournalKey::Material { seed, planet_seed } => {
+            JournalKey::MaterialInstance { seed } => {
                 assert_eq!(*seed, 7, "material seed should match the test material");
                 assert_eq!(
-                    *planet_seed,
+                    recorded[0].planet_seed,
                     Some(expected_seed),
                     "observation must capture the WorldProfile's planet seed so the journal's current-planet filter can match it"
                 );
             }
-            other => panic!("expected JournalKey::Material, got {other:?}"),
+            other => panic!("expected JournalKey::MaterialInstance, got {other:?}"),
         }
     }
 
@@ -690,14 +683,14 @@ mod tests {
         let recorded: Vec<RecordObservation> = messages.drain().collect();
         assert_eq!(recorded.len(), 1);
         match &recorded[0].key {
-            JournalKey::Material { seed, planet_seed } => {
+            JournalKey::MaterialInstance { seed } => {
                 assert_eq!(*seed, 11);
                 assert_eq!(
-                    *planet_seed, None,
+                    recorded[0].planet_seed, None,
                     "without a WorldProfile, planet_seed must be None — never a sentinel"
                 );
             }
-            other => panic!("expected JournalKey::Material, got {other:?}"),
+            other => panic!("expected JournalKey::MaterialInstance, got {other:?}"),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -74,6 +74,8 @@ pub enum InputAction {
     Place,
     /// Toggle the journal overlay on or off.
     ToggleJournal,
+    /// Toggle the debug overlay panel on or off.
+    ToggleDebugOverlay,
     /// Activate the fabricator to begin processing.
     Activate,
     /// Pause the game.
@@ -136,6 +138,11 @@ struct BindingsConfig {
     pub activate: Vec<String>,
     #[serde(default = "default_pause", rename = "Pause")]
     pub pause: Vec<String>,
+    #[serde(
+        default = "default_toggle_debug_overlay",
+        rename = "ToggleDebugOverlay"
+    )]
+    pub toggle_debug_overlay: Vec<String>,
 }
 
 impl Default for BindingsConfig {
@@ -152,6 +159,7 @@ impl Default for BindingsConfig {
             toggle_journal: default_toggle_journal(),
             activate: default_activate(),
             pause: default_pause(),
+            toggle_debug_overlay: default_toggle_debug_overlay(),
         }
     }
 }
@@ -221,6 +229,9 @@ fn default_activate() -> Vec<String> {
 fn default_pause() -> Vec<String> {
     vec!["Escape".into()]
 }
+fn default_toggle_debug_overlay() -> Vec<String> {
+    vec!["F3".into()]
+}
 
 // ── Input name parsing ──────────────────────────────────────────────────
 
@@ -256,6 +267,12 @@ fn parse_key(name: &str) -> Option<KeyCode> {
         "Space" => Some(KeyCode::Space),
         "Escape" => Some(KeyCode::Escape),
         "Tab" => Some(KeyCode::Tab),
+        "F1" => Some(KeyCode::F1),
+        "F2" => Some(KeyCode::F2),
+        "F3" => Some(KeyCode::F3),
+        "F4" => Some(KeyCode::F4),
+        "F5" => Some(KeyCode::F5),
+        "F6" => Some(KeyCode::F6),
         "ShiftLeft" => Some(KeyCode::ShiftLeft),
         "ShiftRight" => Some(KeyCode::ShiftRight),
         "ControlLeft" => Some(KeyCode::ControlLeft),
@@ -375,6 +392,11 @@ fn build_input_map(config: &InputConfig) -> InputMap<InputAction> {
     );
     insert_bindings(&mut input_map, InputAction::Activate, &bindings.activate);
     insert_bindings(&mut input_map, InputAction::Pause, &bindings.pause);
+    insert_bindings(
+        &mut input_map,
+        InputAction::ToggleDebugOverlay,
+        &bindings.toggle_debug_overlay,
+    );
 
     input_map
 }

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -21,13 +21,10 @@ use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, Ra
 use bevy::prelude::*;
 
 use crate::carry::{CarryConfig, CarryState, ObserveWeight, StashHeldForPickup};
-use crate::descriptions::{
-    describe_color, describe_density, describe_thermal_observation, describe_value,
-};
+use crate::descriptions::describe_density;
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
-use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, PropertyVisibility};
+use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject};
 use crate::observation::Confidence;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
@@ -152,11 +149,8 @@ fn update_interaction_target(
     mut ray_cast: MeshRayCast,
     material_query: Query<&GameMaterial, With<MaterialObject>>,
     held_query: Query<(), With<HeldItem>>,
-    mut encounter_writer: MessageWriter<RecordObservation>,
-    descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
-    world_profile: Option<Res<WorldProfile>>,
 ) {
-    let previous_target = target.entity;
+    let _previous_target = target.entity;
     target.entity = None;
 
     let Ok((camera, cam_gtf)) = camera_query.single() else {
@@ -183,56 +177,6 @@ fn update_interaction_target(
         && hit.distance <= INTERACTION_RANGE
     {
         target.entity = Some(entity);
-    }
-
-    if target.entity != previous_target
-        && let Some(entity) = target.entity
-        && let Ok(material) = material_query.get(entity)
-    {
-        encounter_writer.write(RecordObservation {
-            key: JournalKey::Material {
-                seed: material.seed,
-                // Capture the planet on which this material is being
-                // observed so the journal's "current planet" filter
-                // (Story 10.3) can match the entry against the player's
-                // current `WorldProfile::planet_seed` without re-deriving
-                // provenance from observation history.  When no
-                // `WorldProfile` is in scope (early bring-up, ad-hoc
-                // integration tests, future non-planetary discovery
-                // sites) the field stays `None` rather than defaulting to
-                // a sentinel — see `JournalKey::Material::planet_seed`'s
-                // docs for why "unknown provenance" is kept explicit.
-                planet_seed: world_profile.as_deref().map(|p| p.planet_seed.0),
-            },
-            name: material.name.clone(),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.1), // Low initial confidence for first observation
-                description: {
-                    // Use the DescriptorVocabulary for surface appearance
-                    // For surface appearance, we'll use the density value as the primary property
-                    // since it's more quantifiable than color
-                    descriptor_vocab
-                        .describe(
-                            &ObservationCategory::SurfaceAppearance,
-                            material.density.value(),
-                            Confidence(0.1),
-                        )
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| {
-                            // Fallback to old system if vocabulary lookup fails
-                            format!(
-                                "Color: {}\nWeight: {}",
-                                describe_color(&material.color),
-                                describe_density(material.density.value())
-                            )
-                        })
-                },
-                recorded_at: 0,
-            },
-            input_seeds: Vec::new(),
-            context_location: None,
-        });
     }
 }
 
@@ -412,6 +356,10 @@ fn process_pickup(
             .insert(HeldItem)
             .set_parent_in_place(camera_entity)
             .insert(Transform::from_translation(carry_config.hold_offset_vec3()));
+        // Density is revealed on pickup via the ObserveWeight message above,
+        // which fires a RecordObservation → KnowledgeGraph.reveal_property("Weight").
+        // The inspect panel reads revealed properties from the KG node — no
+        // entity component mutation needed here.
     }
 }
 
@@ -833,15 +781,13 @@ fn update_examine_panel(
     state: Res<ExamineState>,
     target: Res<InteractionTarget>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
-    held_query: Query<&GameMaterial, With<HeldItem>>,
-    material_query: Query<&GameMaterial, With<MaterialObject>>,
-    mut panel_query: Query<&mut Visibility, With<ExaminePanel>>,
-    mut text_query: Query<&mut Text, With<ExamineText>>,
+    graph: Res<crate::knowledge_graph::KnowledgeGraph>,
+    mut queries: ExaminePanelQueries,
 ) {
-    let Ok(mut vis) = panel_query.single_mut() else {
+    let Ok(mut vis) = queries.panel_query.single_mut() else {
         return;
     };
-    let Ok(mut text) = text_query.single_mut() else {
+    let Ok(mut text) = queries.text_query.single_mut() else {
         return;
     };
 
@@ -850,11 +796,11 @@ fn update_examine_panel(
         return;
     }
 
-    // Prefer held item; fall back to whatever the player is looking at.
-    let mat = held_query
-        .iter()
-        .next()
-        .or_else(|| target.entity.and_then(|e| material_query.get(e).ok()));
+    let mat = queries.held_query.iter().next().or_else(|| {
+        target
+            .entity
+            .and_then(|e| queries.material_query.get(e).ok())
+    });
 
     let Some(mat) = mat else {
         *vis = Visibility::Hidden;
@@ -862,70 +808,76 @@ fn update_examine_panel(
     };
 
     *vis = Visibility::Visible;
-    text.0 = build_examine_text(mat, &descriptor_vocab);
+    text.0 = build_examine_text(mat, &descriptor_vocab, &graph);
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct ExaminePanelQueries<'w, 's> {
+    held_query: Query<'w, 's, &'static GameMaterial, With<HeldItem>>,
+    material_query: Query<'w, 's, &'static GameMaterial, With<MaterialObject>>,
+    panel_query: Query<'w, 's, &'static mut Visibility, With<ExaminePanel>>,
+    text_query: Query<'w, 's, &'static mut Text, With<ExamineText>>,
+}
+
+/// Build the examine panel text for a material, reading revealed properties
+/// from the KnowledgeGraph node rather than from entity `PropertyVisibility`.
+///
+/// The KnowledgeGraph `revealed_properties` set uses
+/// `ObservationCategory::display_label()` strings as keys — the same strings
+/// written by `update_knowledge_graph` when it calls `reveal_property`.
 fn build_examine_text(
     mat: &GameMaterial,
     descriptor_vocab: &crate::observation::DescriptorVocabulary,
+    graph: &crate::knowledge_graph::KnowledgeGraph,
 ) -> String {
+    // Look up what the player has revealed about this material instance.
+    let revealed = graph
+        .lookup_material_by_seed(mat.seed)
+        .and_then(|idx| graph.node_weight(idx))
+        .map(|node| &node.revealed_properties);
+
+    let is_revealed = |cat: &crate::journal::ObservationCategory| -> bool {
+        revealed.is_some_and(|r| r.contains_key(cat))
+    };
+
     let mut lines = vec![mat.name.clone()];
     lines.push(String::new());
 
-    append_prop(&mut lines, "Weight", &mat.density, describe_density);
-    append_thermal_prop(&mut lines, mat, descriptor_vocab);
-    append_prop(&mut lines, "Reactivity", &mat.reactivity, describe_value);
-    append_prop(
-        &mut lines,
-        "Conductivity",
-        &mat.conductivity,
-        describe_value,
-    );
-    append_prop(&mut lines, "Toxicity", &mat.toxicity, describe_value);
-
-    lines.join("\n")
-}
-
-fn append_prop(
-    lines: &mut Vec<String>,
-    label: &str,
-    prop: &crate::materials::MaterialProperty,
-    describer: fn(f32) -> &'static str,
-) {
-    if prop.visibility == PropertyVisibility::Observable
-        || prop.visibility == PropertyVisibility::Revealed
-    {
-        lines.push(format!("{label}: {}", describer(prop.value())));
+    // Weight — revealed on pickup via Weight observation
+    if is_revealed(&crate::journal::ObservationCategory::Weight) {
+        lines.push(format!("Weight: {}", describe_density(mat.density.value())));
     } else {
-        lines.push(format!("{label}: ???"));
+        lines.push("Weight: ???".to_string());
     }
-}
 
-fn append_thermal_prop(
-    lines: &mut Vec<String>,
-    mat: &GameMaterial,
-    descriptor_vocab: &crate::observation::DescriptorVocabulary,
-) {
-    match mat.thermal_resistance.visibility {
-        PropertyVisibility::Hidden => lines.push("Heat response: ???".to_string()),
-        PropertyVisibility::Observable | PropertyVisibility::Revealed => {
-            // Use a default confidence for examine panel display
-            // The actual confidence tracking happens in the journal system
-            let display_confidence = Confidence(0.5);
-            let description = descriptor_vocab
-                .describe(
-                    &ObservationCategory::ThermalBehavior,
+    // Heat response — revealed by heat exposure system
+    if is_revealed(&crate::journal::ObservationCategory::ThermalBehavior) {
+        let display_confidence = Confidence(0.5);
+        let description = descriptor_vocab
+            .describe(
+                &crate::journal::ObservationCategory::ThermalBehavior,
+                mat.thermal_resistance.value(),
+                display_confidence,
+            )
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                crate::descriptions::describe_thermal_observation(
                     mat.thermal_resistance.value(),
                     display_confidence,
                 )
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| {
-                    // Fallback to old system if vocabulary lookup fails
-                    describe_thermal_observation(mat.thermal_resistance.value(), display_confidence)
-                });
-            lines.push(format!("Heat response: {description}"));
-        }
+            });
+        lines.push(format!("Heat response: {description}"));
+    } else {
+        lines.push("Heat response: ???".to_string());
     }
+
+    // Remaining properties — no reveal mechanism exists yet; always ???
+    // These will be wired when their observation systems are implemented.
+    lines.push("Reactivity: ???".to_string());
+    lines.push("Conductivity: ???".to_string());
+    lines.push("Toxicity: ???".to_string());
+
+    lines.join("\n")
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -954,67 +906,94 @@ mod tests {
     }
 
     fn test_material() -> GameMaterial {
+        use crate::materials::PropertyVisibility;
         GameMaterial {
             name: "TestMat".into(),
             seed: 1,
             color: [0.5, 0.5, 0.5],
-            density: MaterialProperty::new(0.78, PropertyVisibility::Observable),
+            origin_planet_seed: None,
+            density: MaterialProperty::new(0.78, PropertyVisibility::Hidden),
             thermal_resistance: MaterialProperty::new(0.65, PropertyVisibility::Hidden),
             reactivity: MaterialProperty::new(0.35, PropertyVisibility::Hidden),
-            conductivity: MaterialProperty::new(0.72, PropertyVisibility::Revealed),
+            conductivity: MaterialProperty::new(0.72, PropertyVisibility::Hidden),
             toxicity: MaterialProperty::new(0.05, PropertyVisibility::Hidden),
         }
     }
 
-    #[test]
-    fn examine_text_shows_observable_and_revealed_hides_hidden() {
-        let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
+    fn graph_with_weight_revealed(seed: u64) -> crate::knowledge_graph::KnowledgeGraph {
+        use crate::journal::{JournalKey, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+        graph.reveal_property(node, ObservationCategory::Weight, 0.78);
+        graph
+    }
 
+    fn graph_with_thermal_revealed(seed: u64) -> crate::knowledge_graph::KnowledgeGraph {
+        use crate::journal::{JournalKey, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+        graph.reveal_property(node, ObservationCategory::ThermalBehavior, 0.65);
+        graph
+    }
+
+    #[test]
+    fn examine_text_shows_name_always() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
         assert!(text.contains("TestMat"));
-        assert!(text.contains("Weight: Very heavy"));
-        assert!(text.contains("Conductivity: Very high"));
-        assert!(text.contains("Heat response: ???"));
-        assert!(text.contains("Reactivity: ???"));
-        assert!(text.contains("Toxicity: ???"));
     }
 
     #[test]
     fn examine_text_name_is_first_line() {
         let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
-        let first_line = text.lines().next().unwrap();
-        assert_eq!(first_line, "TestMat");
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert_eq!(text.lines().next().unwrap(), "TestMat");
     }
 
     #[test]
-    fn examine_text_shows_heat_response_for_revealed_thermal_property() {
-        let mut mat = test_material();
-        mat.thermal_resistance.visibility = PropertyVisibility::Revealed;
-
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
-        let text = build_examine_text(&mat, &descriptor_vocab);
-        // Check for the presence of Heat response rather than specific confidence language
-        assert!(text.contains("Heat response:"));
-        // Check that the heat response line specifically doesn't contain "???"
-        let heat_line = text
-            .lines()
-            .find(|line| line.contains("Heat response:"))
-            .unwrap();
-        assert!(!heat_line.contains("???"));
-    }
-
-    #[test]
-    fn examine_text_shows_thermal_knowledge_for_hidden_property_when_previously_observed() {
+    fn examine_text_weight_hidden_without_observation() {
         let mat = test_material();
-        let descriptor_vocab = crate::observation::DescriptorVocabulary::default();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert!(text.contains("Weight: ???"));
+    }
 
-        // With the new system, hidden properties always show "???" regardless of previous observations
-        // The confidence tracking is now handled in the journal system, not the examine panel
-        let text = build_examine_text(&mat, &descriptor_vocab);
+    #[test]
+    fn examine_text_weight_shown_after_weight_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = graph_with_weight_revealed(mat.seed);
+        let text = build_examine_text(&mat, &vocab, &graph);
+        assert!(!text.contains("Weight: ???"));
+        assert!(text.contains("Weight:"));
+    }
+
+    #[test]
+    fn examine_text_heat_hidden_without_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = crate::knowledge_graph::KnowledgeGraph::default();
+        let text = build_examine_text(&mat, &vocab, &graph);
         assert!(text.contains("Heat response: ???"));
+    }
+
+    #[test]
+    fn examine_text_heat_shown_after_thermal_observation() {
+        let mat = test_material();
+        let vocab = crate::observation::DescriptorVocabulary::default();
+        let graph = graph_with_thermal_revealed(mat.seed);
+        let text = build_examine_text(&mat, &vocab, &graph);
+        let heat_line = text.lines().find(|l| l.contains("Heat response:")).unwrap();
+        assert!(!heat_line.contains("???"));
     }
 
     #[test]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -6,18 +6,21 @@
 //! fabricator. Unknown properties are omitted entirely rather than shown as
 //! placeholders.
 
-use std::collections::BTreeMap;
+use std::collections::VecDeque;
 
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+use petgraph::graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
+use crate::classification::MaterialClassifications;
+use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
 use crate::input::InputAction;
-use crate::knowledge_graph::{ConceptId, KnowledgeGraph, RelationshipType};
+use crate::knowledge_graph::{ConceptId, ConceptNode, KnowledgeGraph};
 use crate::observation::Confidence;
 use crate::player::{Player, cursor_is_captured, spawn_player};
-use crate::world_generation::{BiomeType, WorldProfile};
+use crate::world_generation::BiomeType;
 
 // ── Biome key type safety ──────────────────────────────────────────────
 
@@ -118,7 +121,7 @@ impl ObservationCategory {
     }
 
     /// Player-facing label used as a group header in the detail panel.
-    fn display_label(&self) -> &'static str {
+    pub fn display_label(&self) -> &'static str {
         match self {
             ObservationCategory::SurfaceAppearance => "Surface",
             ObservationCategory::ThermalBehavior => "Thermal",
@@ -180,46 +183,47 @@ pub struct Observation {
 
 /// Unique key identifying a journal subject.
 ///
-/// Each variant encodes both the *type* of subject (material, fabrication
-/// output, etc.) and the identity that distinguishes one instance from
+/// Each variant encodes both the *type* of subject (material instance,
+/// fabrication output, etc.) and the identity that distinguishes one from
 /// another. The enum is intentionally non-exhaustive so future systems
-/// (navigation, trade, language) can add variants without breaking
-/// existing match arms.
+/// (navigation, trade, language, material classification) can add variants
+/// without breaking existing match arms.
+///
+/// # Material identity
+///
+/// `MaterialInstance` identifies a specific observed material entity by its
+/// generation seed. Planet of origin is carried on [`RecordObservation`] as
+/// context for the `FoundOn` KnowledgeGraph edge — not baked into the key.
 ///
 /// `Ord` is derived so that `JournalKey` can serve as a `BTreeMap` key,
 /// giving the journal a stable, deterministic iteration order.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum JournalKey {
-    /// A raw or discovered material, keyed by its procedural seed.
+    /// A specific observed material instance, keyed by its generation seed.
     ///
-    /// The optional `planet_seed` records the planet on which this
-    /// material was first observed, so context-aware filters
-    /// (Story 10.3 — "entries relevant to current planet") can match
-    /// entries against the player's [`WorldProfile::planet_seed`]
-    /// without re-deriving provenance from observation history.
-    ///
-    /// `planet_seed` is `None` for entries created in contexts where
-    /// no planetary world profile is in scope (early bring-up, ad-hoc
-    /// integration tests, future non-planetary discovery sites).
-    /// Treating it as `Option<u64>` rather than baking in a sentinel
-    /// keeps the "unknown provenance" case explicit at every match
-    /// site.
-    ///
-    /// Field ordering is `seed` then `planet_seed` so the derived
-    /// `Ord` continues to sort primarily by material identity — the
-    /// existing journal iteration order is preserved when
-    /// `planet_seed` is `None` everywhere, which matches the
-    /// pre-extension behaviour bit-for-bit.
-    Material {
-        /// The deterministic seed that uniquely identifies this material
-        /// within the world generation system.
+    /// All knowledge accumulated about this material — density, reactivity,
+    /// thermal response, sightings — is stored on the KnowledgeGraph node
+    /// identified by this key.  Planet of origin is recorded as a `FoundOn`
+    /// edge on that node, not as part of this key.
+    MaterialInstance {
+        /// The generation seed that uniquely identifies this material instance.
         seed: u64,
-        /// The planet on which this material was first observed, taken
-        /// from `WorldProfile::planet_seed.0` at observation time.
-        /// `None` indicates the recording site had no planetary context
-        /// available; such entries are excluded from
-        /// [`JournalContext::CurrentPlanet`] filtering.
-        planet_seed: Option<u64>,
+    },
+    /// A material *type* (classification), grouping instances that share a
+    /// property profile into a named family — e.g. "cesium", "ferrite".
+    ///
+    /// Classification names are defined by asset-side ranges (Story N.3).
+    /// Until N.3 lands this variant is introduced here so the KnowledgeGraph
+    /// and journal query layer can represent type-level nodes; no instances
+    /// will carry this key until the classification system assigns them.
+    ///
+    /// A `MaterialInstance` node with seed `cesium-386` would be linked to
+    /// its `Material { classification: "cesium" }` node via a `ClassifiedAs`
+    /// edge once N.3 wires the classification pass.
+    Material {
+        /// The human-readable classification name assigned by the asset
+        /// pipeline (e.g. "cesium", "ferrite", "volatite").
+        classification: String,
     },
     /// The output of a fabrication process, keyed by the resulting
     /// material's seed.
@@ -227,34 +231,47 @@ pub enum JournalKey {
         /// The deterministic seed of the fabricated output material.
         output_seed: u64,
     },
+    /// A planetary or regional location, keyed by its planet seed.
+    ///
+    /// Created automatically by the knowledge graph system whenever a
+    /// material observation carries planet provenance — giving the graph
+    /// a concrete node to attach `FoundOn` and `ObservedAt` edges to.
+    /// Location entries are not displayed in the main journal entry list
+    /// because the player encounters planets through the world, not
+    /// through a catalog — but they are reachable as cross-reference
+    /// targets from material entries.
+    Location {
+        /// The planet seed that uniquely identifies this location within
+        /// the world generation system.  Matches `WorldProfile::planet_seed.0`.
+        planet_seed: u64,
+    },
 }
 
 impl JournalKey {
-    /// Planet on which the subject identified by this key was first
-    /// observed, when that information is available.
+    /// Planet on which the subject identified by this key was observed,
+    /// when that information is available.
     ///
-    /// Returns `Some(seed)` for [`JournalKey::Material`] entries that
-    /// were recorded with a planetary world profile in scope, and `None`
-    /// for materials recorded without one (early bring-up, ad-hoc
-    /// integration tests, future non-planetary discovery sites).
-    ///
-    /// [`JournalKey::Fabrication`] entries return `None` because
-    /// fabrications are produced at the player's fabricator and are
-    /// intentionally not tied to a discovery planet — the same recipe
-    /// produces the same output regardless of where it was crafted.  The
-    /// "current planet" filter therefore intentionally hides
-    /// fabrications, which matches the player-mental-model of the
-    /// filter ("show me things tied to where I am") better than
-    /// pretending fabrications belong to whichever planet the player
-    /// happened to be standing on at craft time.
-    ///
-    /// Used by [`matches_filter`] to evaluate
-    /// [`JournalContext::CurrentPlanet`] without re-deriving provenance
-    /// from observation history.
+    /// `Location` keys return their planet seed directly. All other variants
+    /// return `None` — planet provenance for material instances is stored on
+    /// the KnowledgeGraph node as a `FoundOn` edge, not on the key.
     pub fn planet_seed(&self) -> Option<u64> {
         match self {
-            JournalKey::Material { planet_seed, .. } => *planet_seed,
+            JournalKey::MaterialInstance { .. } => None,
+            JournalKey::Material { .. } => None,
             JournalKey::Fabrication { .. } => None,
+            JournalKey::Location { planet_seed } => Some(*planet_seed),
+        }
+    }
+
+    /// Map this key to the coarse [`crate::knowledge_graph::ConceptCategory`]
+    /// used for graph storage.
+    pub fn concept_category(&self) -> crate::knowledge_graph::ConceptCategory {
+        use crate::knowledge_graph::ConceptCategory;
+        match self {
+            JournalKey::MaterialInstance { .. } => ConceptCategory::Material,
+            JournalKey::Material { .. } => ConceptCategory::Material,
+            JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
+            JournalKey::Location { .. } => ConceptCategory::Location,
         }
     }
 }
@@ -341,69 +358,22 @@ pub struct JournalFilter {
     pub context: Option<JournalContext>,
 }
 
-/// Predicate evaluating whether a journal entry should be shown under the
-/// active filter.
+/// Predicate evaluating whether a knowledge-graph concept node should be shown
+/// under the active journal filter.
 ///
-/// The two filter dimensions combine with **AND** logic: an entry is
-/// kept when *every* `Some(_)` dimension matches it.  `None` on a
-/// dimension means "no restriction on this dimension" — the
-/// [`JournalFilter::default`] value (both dimensions `None`) therefore
-/// returns `true` for every entry, satisfying the Story 10.3
-/// acceptance criterion that the "All" filter shows everything.
-///
-/// Dimension semantics:
-///
-/// * **Category match** — the entry contains at least one observation
-///   whose [`Observation::category`] equals the requested category.  An
-///   entry with no observations cannot match any category restriction
-///   (the `any` fold returns `false` over an empty iterator), which is
-///   the correct behaviour: an entry with zero observations carries no
-///   evidence of belonging to any category.
-/// * **Context match** — the entry's captured location metadata
-///   matches the requested context.  For
-///   [`JournalContext::CurrentPlanet`] this consults
-///   [`JournalKey::planet_seed`]: an entry matches iff its key recorded
-///   the same planet seed.  Entries whose key has no planet seed
-///   (`None`) are excluded from current-planet filtering — this is by
-///   design (see [`JournalKey::Material::planet_seed`]'s docs):
-///   "unknown provenance" should not silently be assumed to mean
-///   "current planet".
-///
-///   [`JournalContext::CurrentBiome`] is not yet evaluated and
-///   currently returns `true` (no restriction).  Biome provenance is
-///   not captured on [`JournalKey`] today; wiring it up is tracked as a
-///   follow-up so that filter UI cycling can already expose the option
-///   without false-negative behaviour.  When biome capture is added,
-///   this arm changes to compare against the entry's recorded biome
-///   key — no other call site needs to change.
-///
-/// The function is intentionally pure (no `WorldContext` parameter):
-/// the filter already carries the planet seed / biome key it is
-/// matching against, and the entry already carries the metadata being
-/// matched.  Keeping the predicate parameter-light means it can be
-/// dropped into an iterator chain (`entries.filter(|e|
-/// matches_filter(e, &filter))`) without threading additional
-/// resources through the render pipeline.
-pub fn matches_filter(entry: &JournalEntry, filter: &JournalFilter) -> bool {
+/// Both filter dimensions combine with AND logic — a node is kept when every
+/// `Some(_)` dimension matches. `None` on any dimension means "no restriction",
+/// so the default filter (both `None`) keeps every node.
+pub fn matches_filter_node(node: &ConceptNode, filter: &JournalFilter) -> bool {
     let category_match = filter
         .category
         .as_ref()
-        .is_none_or(|cat| entry.observations.keys().any(|entry_cat| entry_cat == cat));
+        .is_none_or(|cat| node.observations.keys().any(|node_cat| node_cat == cat));
 
     let context_match = filter.context.as_ref().is_none_or(|ctx| match ctx {
         JournalContext::CurrentPlanet { planet_seed } => {
-            entry.key.planet_seed() == Some(*planet_seed)
+            node.origin_planet_seed == Some(*planet_seed)
         }
-        // Biome provenance is not yet captured on JournalKey; until it
-        // is, the biome filter is a no-op (matches everything) rather
-        // than excluding every entry.  Returning `true` here keeps the
-        // UI affordance usable without producing a misleading "no
-        // matching entries" panel for a filter that hasn't been
-        // wired through to the data model yet.
-        //
-        // When biome capture is added, this arm will compare the entry's
-        // recorded biome key against `biome_key.biome_type()` — no other
-        // call site needs to change.
         JournalContext::CurrentBiome { .. } => true,
     });
 
@@ -448,11 +418,11 @@ pub enum JournalSet {
 
 impl Plugin for JournalPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<RecordObservation>()
-            .add_message::<ToggleJournalIntent>()
+        app.add_message::<ToggleJournalIntent>()
             .init_resource::<JournalUiState>()
             .init_resource::<JournalSelectionTracker>()
             .init_resource::<JournalRenderCache>()
+            .init_resource::<JournalNavigationStack>()
             .configure_sets(
                 Update,
                 (JournalSet::Navigate, JournalSet::Compute, JournalSet::Sync).chain(),
@@ -471,15 +441,20 @@ impl Plugin for JournalPlugin {
                     toggle_journal_visibility
                         .in_set(JournalSet::Navigate)
                         .after(emit_toggle_journal_intent),
-                    journal_navigation
+                    sync_journal_ui_state_from_focus
                         .in_set(JournalSet::Navigate)
                         .after(toggle_journal_visibility),
+                    journal_navigation
+                        .in_set(JournalSet::Navigate)
+                        .after(sync_journal_ui_state_from_focus),
                     update_journal_context_on_planet_change
                         .in_set(JournalSet::Navigate)
                         .after(journal_navigation),
-                    apply_observations.in_set(JournalSet::Navigate),
+                    journal_cross_ref_navigation
+                        .in_set(JournalSet::Navigate)
+                        .after(journal_navigation),
                     compute_journal_panels.in_set(JournalSet::Compute),
-                    append_cross_reference_spans
+                    populate_cross_ref_links
                         .in_set(JournalSet::Compute)
                         .after(compute_journal_panels),
                     sync_journal_ui.in_set(JournalSet::Sync),
@@ -488,364 +463,24 @@ impl Plugin for JournalPlugin {
     }
 }
 
-// ── Messages ────────────────────────────────────────────────────────────
+// ── Re-export observation message ────────────────────────────────────────
 
-/// Unified message for recording any observation in the player's journal.
+/// Re-exported for backward compatibility — `RecordObservation` now lives in
+/// [`crate::observation`] where all game-event types belong.
+pub use crate::observation::RecordObservation;
+
+// ── Player-owned journal component ──────────────────────────────────────
+
+/// Marker component attached to the player entity.
 ///
-/// Any game system (materials, heat, carry, fabrication, navigation, trade)
-/// sends this single message type instead of a per-category variant. The
-/// journal ingestion system routes based on the [`Observation::category`]
-/// field — callers only need to fill in the key, name, and observation.
-///
-/// **Planet seed handling:** For [`JournalKey::Material`] observations,
-/// the `planet_seed` field is automatically resolved by the ingestion
-/// system from the current [`WorldProfile`] resource. Observation producers
-/// should pass `planet_seed: None` and let the system fill it in centrally.
-/// This eliminates the need for every observation site to manually extract
-/// `world_profile.as_deref().map(|p| p.planet_seed.0)` and prevents silent
-/// failures when new observation sites forget this pattern.
-#[derive(Message, Clone)]
-pub struct RecordObservation {
-    /// Which journal subject this observation belongs to.
-    pub key: JournalKey,
-    /// Player-facing display name for the subject (used to initialise the
-    /// entry on first encounter; ignored for subsequent observations of the
-    /// same key).
-    pub name: String,
-    /// The observation payload including category, confidence, description,
-    /// and game-time tick.
-    pub observation: Observation,
-    /// For fabrication observations: the seeds of the input materials that
-    /// were combined to produce this output. Used by the knowledge graph to
-    /// create `DerivedFrom` edges. Empty for non-fabrication observations.
-    pub input_seeds: Vec<u64>,
-    /// The location where this observation occurred, if applicable. Used by
-    /// the knowledge graph to create `FoundOn` / `ObservedAt` edges. `None`
-    /// when the observation has no spatial context (e.g., fabrication results,
-    /// abstract property comparisons).
-    pub context_location: Option<JournalKey>,
-}
-
-// ── Player-owned journal data ───────────────────────────────────────────
-
-/// A journal entry that accumulates observations about a single subject over time.
-///
-/// Each entry is keyed by a [`JournalKey`] and holds a chronologically ordered
-/// vector of [`Observation`]s. The `first_observed_at` and `last_updated_at`
-/// timestamps track the game-time ticks bounding the observation window, which
-/// later systems (e.g., confidence decay, staleness indicators) can use without
-/// re-scanning all observations.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JournalEntry {
-    /// The unique identifier for this journal subject.
-    pub key: JournalKey,
-    /// Player-facing display name for this subject.
-    pub name: String,
-    /// Observations grouped by category, each group in chronological order.
-    ///
-    /// Using a `BTreeMap` gives deterministic iteration order over categories
-    /// (important for rendering stability and save/load reproducibility).
-    /// Within each category the `Vec` preserves insertion (chronological) order.
-    pub observations: BTreeMap<ObservationCategory, Vec<Observation>>,
-    /// Game-time tick when the player first recorded *any* observation about
-    /// this subject.
-    pub first_observed_at: u64,
-    /// Game-time tick of the most recent observation recorded for this subject.
-    pub last_updated_at: u64,
-}
-
-impl JournalEntry {
-    /// Create a new journal entry with no observations yet recorded.
-    ///
-    /// The `tick` parameter sets both `first_observed_at` and `last_updated_at`
-    /// to the same initial value; they diverge once additional observations
-    /// arrive.
-    pub fn new(key: JournalKey, name: String, tick: u64) -> Self {
-        Self {
-            key,
-            name,
-            observations: BTreeMap::new(),
-            first_observed_at: tick,
-            last_updated_at: tick,
-        }
-    }
-
-    /// Record an observation, deduplicating against existing entries in the
-    /// same category group.
-    ///
-    /// If an observation with the same category **and** the same description
-    /// already exists, the duplicate is not appended. Instead, the existing
-    /// observation's confidence is upgraded to the higher of the two values
-    /// and the `last_updated_at` timestamp is advanced. This prevents the
-    /// journal from bloating when systems repeatedly report the same finding
-    /// (e.g., picking up the same material multiple times).
-    ///
-    /// When the observation is genuinely new (different category or different
-    /// description), it is appended to the appropriate category group.
-    pub fn add_observation(&mut self, observation: Observation) {
-        self.last_updated_at = observation.recorded_at;
-
-        let group = self
-            .observations
-            .entry(observation.category.clone())
-            .or_default();
-
-        // Look for an existing observation with the same description within this category.
-        if let Some(existing) = group
-            .iter_mut()
-            .find(|o| o.description == observation.description)
-        {
-            // Upgrade confidence if the new evidence is stronger.
-            if observation.confidence.0 > existing.confidence.0 {
-                existing.confidence = observation.confidence;
-            }
-            return;
-        }
-
-        group.push(observation);
-    }
-
-    /// Record an observation with confidence accumulation for existing observations.
-    ///
-    /// This method implements the confidence evolution system described in Story 10.4.
-    /// When an observation with the same category and description already exists,
-    /// it calls `accumulate()` on the existing observation's confidence using the
-    /// base observation weight from the configuration. This provides diminishing
-    /// returns as evidence accumulates, matching the technical design.
-    ///
-    /// When the observation is genuinely new (different category or different
-    /// description), it is appended to the appropriate category group.
-    pub fn add_observation_with_accumulation(
-        &mut self,
-        observation: Observation,
-        config: &crate::observation::ConfidenceConfig,
-    ) {
-        self.add_observation_with_domain_weighted_accumulation(observation, config, 1.0);
-    }
-
-    /// Add an observation with domain-weighted confidence accumulation.
-    ///
-    /// This method extends the basic accumulation system with domain-weighted
-    /// recovery. The recovery multiplier adjusts the accumulation rate based
-    /// on recent death context and whether the player is engaging with the
-    /// death-relevant domain.
-    ///
-    /// # Arguments
-    /// * `recovery_multiplier` - Multiplier applied to base observation weight
-    ///   - > 1.0 for death-relevant domain (faster recovery)
-    ///   - < 1.0 for unrelated domains (slower recovery)
-    ///   - = 1.0 for no death context (normal rate)
-    pub fn add_observation_with_domain_weighted_accumulation(
-        &mut self,
-        observation: Observation,
-        config: &crate::observation::ConfidenceConfig,
-        recovery_multiplier: f32,
-    ) {
-        self.last_updated_at = observation.recorded_at;
-
-        let group = self
-            .observations
-            .entry(observation.category.clone())
-            .or_default();
-
-        // Look for an existing observation with the same description within this category.
-        if let Some(existing) = group
-            .iter_mut()
-            .find(|o| o.description == observation.description)
-        {
-            // Apply domain-weighted recovery to the accumulation weight
-            let adjusted_weight = config.base_observation_weight * recovery_multiplier;
-
-            // Accumulate evidence using the confidence system with diminishing returns.
-            existing.confidence.accumulate(adjusted_weight);
-            return;
-        }
-
-        group.push(observation);
-    }
-
-    /// Return all observations matching a given category, in recorded order.
-    ///
-    /// Returns an empty slice if no observations exist for the category.
-    pub fn observations_by_category(&self, category: &ObservationCategory) -> &[Observation] {
-        self.observations
-            .get(category)
-            .map_or(&[], |v| v.as_slice())
-    }
-
-    /// Total number of observations across all categories.
-    pub fn observation_count(&self) -> usize {
-        self.observations.values().map(|v| v.len()).sum()
-    }
-
-    /// Iterator over all observations across all categories, ordered by
-    /// category (deterministic via `BTreeMap`) then by insertion order
-    /// within each category.
-    pub fn all_observations(&self) -> impl Iterator<Item = &Observation> {
-        self.observations.values().flat_map(|v| v.iter())
-    }
-}
-
-/// The player's journal — accumulates all observations about every subject
-/// the player has investigated.
-///
-/// Keyed by [`JournalKey`] so lookups are O(log n) and iteration order is
-/// deterministic (important for save/load reproducibility and test stability).
+/// As of Story 387 the `Journal` no longer stores observations — that data
+/// lives in [`KnowledgeGraph`] `ConceptNode`s. The component is kept so
+/// existing system queries (`With<Player>`, `With<Journal>`) continue to
+/// compile without change while the query layer is being migrated in Phase 5.
 #[derive(Component, Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Journal {
-    /// All journal entries, keyed by subject identity.
-    ///
-    /// Serialized as a list of entries (not a JSON object) because
-    /// [`JournalKey`] is an enum and cannot serve as a JSON map key.
-    #[serde(with = "journal_entries_serde")]
-    pub entries: BTreeMap<JournalKey, JournalEntry>,
-}
-
-/// Serialize/deserialize a `BTreeMap<JournalKey, JournalEntry>` as a
-/// `Vec<JournalEntry>`. Each entry already carries its key, so the vec
-/// representation is lossless and avoids the JSON "keys must be strings"
-/// limitation.
-mod journal_entries_serde {
-    use super::*;
-    use serde::de::Deserializer;
-    use serde::ser::Serializer;
-
-    pub fn serialize<S: Serializer>(
-        map: &BTreeMap<JournalKey, JournalEntry>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        let entries: Vec<&JournalEntry> = map.values().collect();
-        entries.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<BTreeMap<JournalKey, JournalEntry>, D::Error> {
-        let entries: Vec<JournalEntry> = Vec::deserialize(deserializer)?;
-        Ok(entries.into_iter().map(|e| (e.key.clone(), e)).collect())
-    }
-}
-
-impl Journal {
-    /// Look up or create a journal entry for the given key.
-    ///
-    /// If no entry exists yet, one is created with the provided `name` and
-    /// `tick` as the initial observation timestamp. If an entry already exists,
-    /// the existing entry is returned unchanged (name is *not* overwritten —
-    /// the first observer wins).
-    pub fn ensure_entry(&mut self, key: JournalKey, name: &str, tick: u64) -> &mut JournalEntry {
-        self.entries
-            .entry(key.clone())
-            .or_insert_with(|| JournalEntry::new(key, name.to_string(), tick))
-    }
-
-    /// Record an observation against a subject, creating the entry if needed.
-    ///
-    /// This is the primary write path that future systems (materials, heat,
-    /// fabrication, navigation, trade, language) use to push knowledge into
-    /// the journal.
-    pub fn record(&mut self, key: JournalKey, name: &str, observation: Observation) {
-        let entry = self.ensure_entry(key, name, observation.recorded_at);
-        entry.add_observation(observation);
-    }
-
-    /// Record an observation with confidence accumulation for existing observations.
-    ///
-    /// This method uses the confidence accumulation system to properly handle
-    /// repeated observations of the same property. When an observation with the
-    /// same category and description already exists, it calls `accumulate()` on
-    /// the existing observation's confidence using the base observation weight
-    /// from the configuration.
-    pub fn record_with_accumulation(
-        &mut self,
-        key: JournalKey,
-        name: &str,
-        observation: Observation,
-        config: &crate::observation::ConfidenceConfig,
-    ) {
-        let entry = self.ensure_entry(key, name, observation.recorded_at);
-        entry.add_observation_with_accumulation(observation, config);
-    }
-
-    /// Record an observation with domain-weighted confidence accumulation.
-    ///
-    /// This method extends the basic accumulation system with domain-weighted
-    /// recovery based on recent death context. The recovery multiplier adjusts
-    /// the accumulation rate based on whether the player is engaging with the
-    /// death-relevant domain or avoiding it.
-    ///
-    /// # Arguments
-    /// * `recovery_multiplier` - Multiplier applied to base observation weight
-    ///   - > 1.0 for death-relevant domain (faster recovery)
-    ///   - < 1.0 for unrelated domains (slower recovery)
-    ///   - = 1.0 for no death context (normal rate)
-    pub fn record_with_domain_weighted_accumulation(
-        &mut self,
-        key: JournalKey,
-        name: &str,
-        observation: Observation,
-        config: &crate::observation::ConfidenceConfig,
-        recovery_multiplier: f32,
-    ) {
-        let entry = self.ensure_entry(key, name, observation.recorded_at);
-        entry.add_observation_with_domain_weighted_accumulation(
-            observation,
-            config,
-            recovery_multiplier,
-        );
-    }
-}
+pub struct Journal;
 
 // ── UI state ────────────────────────────────────────────────────────────
-
-/// Tracks navigation history for back-navigation through cross-references.
-///
-/// When the player follows a cross-reference link, the source entry's key is
-/// pushed onto this stack.  Pressing Backspace while the journal is open pops
-/// the stack and returns to the previous entry.  The stack is bounded by
-/// `max_depth` to prevent unbounded growth during deep exploration sessions.
-#[derive(Clone, Debug)]
-pub struct JournalNavigationStack {
-    /// Previously visited entry keys, oldest first.
-    pub history: Vec<JournalKey>,
-    /// Maximum number of entries retained in the history.  When the stack
-    /// reaches this limit, the oldest entry is dropped before pushing a new
-    /// one.
-    pub max_depth: usize,
-}
-
-impl JournalNavigationStack {
-    /// Default maximum history depth — deep enough for any reasonable
-    /// exploration session without unbounded memory growth.
-    const DEFAULT_MAX_DEPTH: usize = 32;
-
-    fn new() -> Self {
-        Self {
-            history: Vec::new(),
-            max_depth: Self::DEFAULT_MAX_DEPTH,
-        }
-    }
-
-    /// Push a key onto the history stack, evicting the oldest entry when the
-    /// stack is at capacity.
-    fn push(&mut self, key: JournalKey) {
-        if self.history.len() >= self.max_depth {
-            self.history.remove(0);
-        }
-        self.history.push(key);
-    }
-
-    /// Pop the most recently visited key, returning it if the stack is
-    /// non-empty.
-    fn pop(&mut self) -> Option<JournalKey> {
-        self.history.pop()
-    }
-
-    /// Whether the stack has any history to go back to.
-    fn can_go_back(&self) -> bool {
-        !self.history.is_empty()
-    }
-}
 
 /// Tracks the journal panel's visibility and navigation state.
 ///
@@ -891,19 +526,6 @@ pub struct JournalUiState {
     /// accessor and setter on this type, keeping the [`JournalSet`]
     /// ordering contract enforceable.
     filter: JournalFilter,
-    /// Index of the currently highlighted cross-reference link in the detail
-    /// panel, or `None` when no link is focused.
-    ///
-    /// When `Some(i)`, the i-th cross-reference link in the "Related" section
-    /// is highlighted and can be followed with Enter.  Arrow keys within the
-    /// detail panel cycle through links; Escape or ArrowLeft returns to the
-    /// entry list without following a link.
-    selected_link_index: Option<usize>,
-    /// Navigation history for back-navigation through cross-reference links.
-    ///
-    /// When the player follows a link, the source entry's key is pushed here.
-    /// Backspace pops the stack and returns to the previous entry.
-    navigation_stack: JournalNavigationStack,
 }
 
 impl JournalUiState {
@@ -973,19 +595,6 @@ impl JournalUiState {
         self.filter = filter;
     }
 
-    /// Index of the currently highlighted cross-reference link, or `None`
-    /// when no link is focused.
-    #[allow(dead_code)]
-    pub fn selected_link_index(&self) -> Option<usize> {
-        self.selected_link_index
-    }
-
-    /// Whether the navigation stack has any history to go back to.
-    #[allow(dead_code)]
-    pub fn can_go_back(&self) -> bool {
-        self.navigation_stack.can_go_back()
-    }
-
     /// Clamp `selected_index` and `scroll_offset` so they stay within valid
     /// bounds for the given total entry count.  Called after any navigation
     /// input and before rendering so the UI never references out-of-range
@@ -1016,8 +625,6 @@ impl Default for JournalUiState {
             scroll_offset: 0,
             entries_per_page: Self::DEFAULT_ENTRIES_PER_PAGE,
             filter: JournalFilter::default(),
-            selected_link_index: None,
-            navigation_stack: JournalNavigationStack::new(),
         }
     }
 }
@@ -1084,6 +691,68 @@ struct JournalSelectionTracker {
     last_scroll_offset: usize,
 }
 
+// ── Cross-reference navigation stack ────────────────────────────────────
+
+/// Tracks the player's breadcrumb trail through journal cross-reference links.
+///
+/// When the player presses Enter on a cross-reference link, the current
+/// entry's [`JournalKey`] is pushed here before the view jumps to the
+/// linked entry. Pressing Backspace pops the stack and returns to the
+/// previous entry. This gives the player a browser-history-like
+/// back-navigation experience.
+///
+/// The stack is bounded at [`Self::MAX_DEPTH`] entries to prevent
+/// unbounded growth from very long browsing sessions. When the limit is
+/// reached, the oldest entry is silently dropped (the stack slides).
+///
+/// Persists across journal close/reopen so the player can close the
+/// journal mid-browse and return to their trail.
+#[derive(Resource, Default)]
+pub struct JournalNavigationStack {
+    /// Breadcrumb entries from oldest to newest.
+    ///
+    /// Back of the deque is the most recently visited entry — the one that
+    /// Backspace will return the player to. Front of the deque is the oldest
+    /// entry (evicted first when the depth limit is reached).
+    history: VecDeque<(JournalKey, JournalFilter)>,
+}
+
+impl JournalNavigationStack {
+    /// Maximum number of entries held in the navigation history.
+    ///
+    /// Capped to prevent unbounded memory growth and to keep the
+    /// back-navigation depth reasonable. 32 steps should cover any
+    /// real browsing session.
+    pub const MAX_DEPTH: usize = 32;
+
+    /// Push the current entry and active filter onto the back-navigation stack
+    /// before jumping to a cross-reference target. Backspace pops and restores
+    /// both.
+    pub fn push(&mut self, key: JournalKey, filter: JournalFilter) {
+        if self.history.len() >= Self::MAX_DEPTH {
+            // Evict the oldest entry in O(1) — VecDeque makes this free.
+            self.history.pop_front();
+        }
+        self.history.push_back((key, filter));
+    }
+
+    /// Pop and return the most recent entry on the back-navigation stack.
+    ///
+    /// Returns `None` when the history is empty (the player is already at
+    /// their starting point and there is nothing to go back to).
+    pub fn pop(&mut self) -> Option<(JournalKey, JournalFilter)> {
+        self.history.pop_back()
+    }
+
+    /// Returns `true` when there are entries on the back-navigation stack.
+    ///
+    /// Used by the navigation system to decide whether to show the Backspace
+    /// hint in the help bar.
+    pub fn can_go_back(&self) -> bool {
+        !self.history.is_empty()
+    }
+}
+
 /// Root container for the entire journal overlay (two-panel layout).
 #[derive(Component)]
 struct JournalPanel;
@@ -1108,7 +777,7 @@ fn attach_journal_to_player(mut commands: Commands, player_query: Query<Entity, 
     let Ok(player) = player_query.single() else {
         return;
     };
-    commands.entity(player).insert(Journal::default());
+    commands.entity(player).insert(Journal);
 }
 
 /// Spawns the two-panel journal overlay: a vertical flex container holding
@@ -1138,6 +807,27 @@ fn spawn_journal_ui(mut commands: Commands) {
     commands
         .spawn((
             JournalPanel,
+            // ── Diegetic surface registration (Story 10.6) ───────────────
+            //
+            // The journal is an in-world datapad the player holds up to read,
+            // not a HUD overlay.  Attaching these three components registers it
+            // with the DiegeticUiPlugin:
+            //   • DiegeticSurface  — marks it as a diegetic information surface
+            //     so the CI compliance test can verify no rogue screen-space text exists.
+            //   • DiegeticSurfaceKind::Readable — declares interaction model.
+            //     The player "holds up" the datapad (Active state); physical distance
+            //     does not drive focus here because the journal is always on the player.
+            //     The ranges are set to 0.0 so proximity logic collapses to Focused
+            //     the moment the entity exists — actual open/close is managed by
+            //     toggle_journal_datapad_focus below.
+            //   • DiegeticFocusState::OutOfRange — journal starts closed.
+            DiegeticSurface,
+            DiegeticSurfaceKind::Readable {
+                perceivable_range: 0.0,
+                legible_range: 0.0,
+            },
+            DiegeticFocusState::OutOfRange,
+            // ─────────────────────────────────────────────────────────────
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(24.0),
@@ -1258,9 +948,14 @@ fn spawn_journal_ui(mut commands: Commands) {
 
 fn emit_toggle_journal_intent(
     player_query: Query<&ActionState<InputAction>, With<Player>>,
-    cursor_options: Single<&bevy::window::CursorOptions>,
+    cursor_options: Option<Single<&bevy::window::CursorOptions>>,
     mut writer: MessageWriter<ToggleJournalIntent>,
 ) {
+    // If no window entity exists (e.g. headless integration tests), the journal
+    // cannot receive input — skip gracefully.
+    let Some(cursor_options) = cursor_options else {
+        return;
+    };
     if !cursor_is_captured(cursor_options.grab_mode) {
         return;
     }
@@ -1275,11 +970,38 @@ fn emit_toggle_journal_intent(
 
 fn toggle_journal_visibility(
     mut reader: MessageReader<ToggleJournalIntent>,
-    mut state: ResMut<JournalUiState>,
+    mut panel_query: Query<&mut DiegeticFocusState, With<JournalPanel>>,
 ) {
     for _ in reader.read() {
-        state.visible = !state.visible;
+        let Ok(mut focus) = panel_query.single_mut() else {
+            continue;
+        };
+        // Toggle the journal datapad between Active (open) and OutOfRange (closed).
+        // DiegeticUiPlugin's VisibilitySync will flip the Visibility component;
+        // sync_journal_ui_state_from_focus keeps JournalUiState.visible in lockstep.
+        *focus = match *focus {
+            DiegeticFocusState::Active => DiegeticFocusState::OutOfRange,
+            _ => DiegeticFocusState::Active,
+        };
     }
+}
+
+/// Keeps [`JournalUiState::visible`] in lockstep with the journal panel's
+/// [`DiegeticFocusState`].
+///
+/// All existing journal systems (navigation, compute, sync) gate on
+/// `JournalUiState::visible` — this bridge system means none of them need
+/// to know about the diegetic framework.  It runs in [`JournalSet::Navigate`]
+/// before navigation so that `compute_journal_panels` always sees a
+/// consistent `visible` flag.
+fn sync_journal_ui_state_from_focus(
+    panel_query: Query<&DiegeticFocusState, With<JournalPanel>>,
+    mut state: ResMut<JournalUiState>,
+) {
+    let Ok(focus) = panel_query.single() else {
+        return;
+    };
+    state.visible = matches!(focus, DiegeticFocusState::Active);
 }
 
 // ── Navigation ──────────────────────────────────────────────────────────
@@ -1298,30 +1020,13 @@ fn toggle_journal_visibility(
 /// - Home/End: jump to first/last entry.
 /// - Scroll offset auto-adjusts via `clamp_to_entry_count` so the
 ///   selected entry is always within the visible window.
-/// - When a cross-reference link is focused (selected_link_index is Some):
-///   - Up/Down moves the link cursor within the "Related" section.
-///   - Enter follows the focused link, pushing the current entry onto the
-///     navigation stack and jumping to the related entry.
-///   - Backspace or Escape clears the link cursor without navigating.
-/// - Backspace when no link is focused pops the navigation stack and
-///   returns to the previously visited entry.
 fn journal_navigation(
     mut state: ResMut<JournalUiState>,
     keys: Res<ButtonInput<KeyCode>>,
-    q: Query<&Journal, With<Player>>,
-    world_profile: Option<Res<crate::world_generation::WorldProfile>>,
     graph: Option<Res<KnowledgeGraph>>,
+    world_profile: Option<Res<crate::world_generation::WorldProfile>>,
 ) {
     if !state.visible {
-        return;
-    }
-
-    let Ok(journal) = q.single() else {
-        return;
-    };
-
-    let entry_count = journal.entries.len();
-    if entry_count == 0 {
         return;
     }
 
@@ -1411,180 +1116,136 @@ fn journal_navigation(
         state.scroll_offset = 0;
     }
 
-    // ── Cross-reference link navigation ───────────────────────────────
-    //
-    // When a link is focused (selected_link_index is Some), arrow keys move
-    // the cursor within the "Related" section.  Enter follows the focused
-    // link.  Escape or Backspace clears the cursor.
-    //
-    // When no link is focused, Backspace pops the navigation stack to return
-    // to the previously visited entry.  Tab/Shift+Tab and arrow keys operate
-    // on the entry list as usual.
-    //
-    // The link count is derived from the KnowledgeGraph for the currently
-    // selected entry.  When the graph is absent (test apps) link navigation
-    // is silently skipped.
-    let link_count = graph.as_ref().and_then(|g| {
-        let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-        sorted.sort_by(|a, b| a.name.cmp(&b.name));
-        let filtered: Vec<&JournalEntry> = sorted
-            .into_iter()
-            .filter(|e| matches_filter(e, state.filter()))
-            .collect();
-        let entry = filtered.get(state.selected_index)?;
-        let node_idx = g.lookup(&ConceptId::new(entry.key.clone()))?;
-        let rels = g.relationships(node_idx);
-        if rels.is_empty() {
-            None
-        } else {
-            Some(rels.len())
-        }
-    });
-
-    if let Some(link_idx) = state.selected_link_index {
-        // ── Link cursor is active ──────────────────────────────────────
-        let count = link_count.unwrap_or(0);
-
-        if keys.just_pressed(KeyCode::ArrowUp) {
-            state.selected_link_index = if link_idx == 0 {
-                // Wrap back to entry list navigation by clearing the cursor.
-                None
-            } else {
-                Some(link_idx - 1)
-            };
-            // Early return — do not also move the entry list selection.
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::ArrowDown) {
-            if count > 0 && link_idx + 1 < count {
-                state.selected_link_index = Some(link_idx + 1);
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Escape) || keys.just_pressed(KeyCode::ArrowLeft) {
-            // Cancel link focus without navigating.
-            state.selected_link_index = None;
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Backspace) {
-            // Backspace while a link is focused: cancel link focus first.
-            state.selected_link_index = None;
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        if keys.just_pressed(KeyCode::Enter) {
-            // Follow the focused link: look up the target entry and jump to it.
-            if let Some(g) = graph.as_ref() {
-                let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-                sorted.sort_by(|a, b| a.name.cmp(&b.name));
-                let filtered: Vec<&JournalEntry> = sorted
-                    .iter()
-                    .copied()
-                    .filter(|e| matches_filter(e, state.filter()))
-                    .collect();
-                if let Some(current_entry) = filtered.get(state.selected_index) {
-                    let concept_id = ConceptId::new(current_entry.key.clone());
-                    if let Some(node_idx) = g.lookup(&concept_id) {
-                        let rels = g.relationships(node_idx);
-                        // Build ref_lines in the same sort order as
-                        // append_cross_reference_spans: (rel_label, target_name).
-                        let mut ref_lines: Vec<(String, String, JournalKey)> = rels
-                            .iter()
-                            .filter_map(|(neighbor_idx, edge)| {
-                                let neighbor_node = g.node(*neighbor_idx)?;
-                                let target_key = neighbor_node.id.key().clone();
-                                let rel_label =
-                                    relationship_display_label(&edge.relationship).to_string();
-                                let target_name = journal
-                                    .entries
-                                    .get(&target_key)
-                                    .map(|e| e.name.clone())
-                                    .unwrap_or_else(|| format!("{target_key:?}"));
-                                Some((rel_label, target_name, target_key))
-                            })
-                            .collect();
-                        ref_lines.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-
-                        if let Some((_, _, target_key)) = ref_lines.get(link_idx) {
-                            // Push the current entry onto the navigation stack.
-                            state.navigation_stack.push(current_entry.key.clone());
-                            // Find the target entry's index in the filtered list.
-                            if let Some(target_pos) =
-                                filtered.iter().position(|e| &e.key == target_key)
-                            {
-                                state.selected_index = target_pos;
-                            }
-                            // Clear the link cursor after following the link.
-                            state.selected_link_index = None;
-                        }
-                    }
-                }
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-        // Any other key while link cursor is active: fall through to normal
-        // entry-list navigation (Tab, Shift+Tab, PageUp/Down, Home/End).
-    } else {
-        // ── No link cursor — handle Backspace for back-navigation ─────
-        if keys.just_pressed(KeyCode::Backspace) && state.navigation_stack.can_go_back() {
-            if let Some(prev_key) = state.navigation_stack.pop() {
-                // Find the previous entry in the filtered list.
-                let mut sorted: Vec<&JournalEntry> = journal.entries.values().collect();
-                sorted.sort_by(|a, b| a.name.cmp(&b.name));
-                let filtered: Vec<&JournalEntry> = sorted
-                    .into_iter()
-                    .filter(|e| matches_filter(e, state.filter()))
-                    .collect();
-                if let Some(pos) = filtered.iter().position(|e| e.key == prev_key) {
-                    state.selected_index = pos;
-                }
-            }
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
-
-        // ArrowRight enters link mode when the selected entry has cross-references.
-        if keys.just_pressed(KeyCode::ArrowRight) && link_count.is_some() {
-            state.selected_link_index = Some(0);
-            state.clamp_to_entry_count(entry_count);
-            return;
-        }
+    // ── Navigation keys — only when there are entries ─────────────────
+    let entry_count = graph
+        .as_ref()
+        .map(|g| g.named_node_count_filtered(state.filter()))
+        .unwrap_or(0);
+    if entry_count == 0 {
+        return;
     }
 
     if keys.just_pressed(KeyCode::ArrowUp) {
         state.selected_index = state.selected_index.saturating_sub(1);
-        // Moving the entry list selection clears any stale link cursor.
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::ArrowDown) {
         state.selected_index = (state.selected_index + 1).min(entry_count - 1);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::PageUp) {
         state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::PageDown) {
         state.selected_index = (state.selected_index + state.entries_per_page).min(entry_count - 1);
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::Home) {
         state.selected_index = 0;
-        state.selected_link_index = None;
     }
     if keys.just_pressed(KeyCode::End) {
         state.selected_index = entry_count - 1;
-        state.selected_link_index = None;
     }
 
     state.clamp_to_entry_count(entry_count);
 }
 
-/// System that automatically updates the journal context filter when the
+/// Handles cross-reference link navigation within the journal detail panel.
+///
+/// Runs in Update in [`JournalSet::Navigate`], after `journal_navigation`.
+/// Only active when the journal is visible and the current entry has cross-
+/// reference links (i.e. `cache.cross_ref_links` is non-empty).
+///
+/// Key bindings:
+/// - `Alt+Down` / `Alt+Up` — cycle the highlighted cross-reference link.
+/// - `Enter` — follow the highlighted link: push current key onto
+///   [`JournalNavigationStack`], then find the linked entry's position
+///   in the sorted filtered list and set `selected_index` to it.
+/// - `Backspace` — pop the navigation stack and return to the previous
+///   entry.
+fn journal_cross_ref_navigation(
+    mut state: ResMut<JournalUiState>,
+    mut cache: ResMut<JournalRenderCache>,
+    mut nav_stack: ResMut<JournalNavigationStack>,
+    keys: Res<ButtonInput<KeyCode>>,
+    graph: Option<Res<KnowledgeGraph>>,
+) {
+    if !state.visible {
+        return;
+    }
+
+    // ── Back-navigation (Backspace) ─────────────────────────────────
+    if keys.just_pressed(KeyCode::Backspace) {
+        if let Some((prev_key, prev_filter)) = nav_stack.pop() {
+            state.set_filter(prev_filter);
+            if let Some(graph) = graph.as_ref() {
+                let sorted = graph.nodes_sorted_by_name();
+                let filtered: Vec<NodeIndex> = sorted
+                    .into_iter()
+                    .filter(|&idx| {
+                        graph
+                            .node(idx)
+                            .is_some_and(|n| matches_filter_node(n, state.filter()))
+                    })
+                    .collect();
+                let target_id = ConceptId(prev_key);
+                if let Some(pos) = filtered
+                    .iter()
+                    .position(|&idx| graph.lookup(&target_id).is_some_and(|ti| ti == idx))
+                {
+                    state.selected_index = pos;
+                    state.scroll_offset = pos.saturating_sub(state.entries_per_page / 2);
+                    state.clamp_to_entry_count(filtered.len());
+                }
+            }
+        }
+        return;
+    }
+
+    let link_count = cache.cross_ref_links.len();
+    if link_count == 0 {
+        return;
+    }
+
+    // ── Cross-ref link cursor movement (Alt+Up / Alt+Down) ───────────
+    let alt = keys.pressed(KeyCode::AltLeft) || keys.pressed(KeyCode::AltRight);
+    if alt && keys.just_pressed(KeyCode::ArrowDown) {
+        cache.selected_cross_ref = (cache.selected_cross_ref + 1).min(link_count - 1);
+    }
+    if alt && keys.just_pressed(KeyCode::ArrowUp) {
+        cache.selected_cross_ref = cache.selected_cross_ref.saturating_sub(1);
+    }
+
+    // ── Follow cross-reference (Enter) ────────────────────────────────
+    if keys.just_pressed(KeyCode::Enter) {
+        let selected_idx = cache.selected_cross_ref.min(link_count - 1);
+        let (_, target_key, _) = cache.cross_ref_links[selected_idx].clone();
+
+        let Some(graph) = graph.as_ref() else {
+            return;
+        };
+
+        let sorted = graph.nodes_sorted_by_name();
+
+        // Push the current selection AND active filter onto the back-nav stack.
+        if let Some(&current_idx) = sorted.get(state.selected_index)
+            && let Some(node) = graph.node(current_idx)
+        {
+            nav_stack.push(node.id.0.clone(), state.filter().clone());
+        }
+
+        // Clear filter so the target is always in view, then jump.
+        state.set_filter(JournalFilter::default());
+        let sorted_all = graph.nodes_sorted_by_name();
+        let target_id = ConceptId(target_key);
+        if let Some(pos) = sorted_all
+            .iter()
+            .position(|&idx| graph.lookup(&target_id).is_some_and(|ti| ti == idx))
+        {
+            state.selected_index = pos;
+            state.scroll_offset = pos.saturating_sub(state.entries_per_page / 2);
+            state.clamp_to_entry_count(sorted_all.len());
+            cache.selected_cross_ref = 0;
+        }
+    }
+}
 /// planet changes (WorldProfile resource changes).
 ///
 /// When the player switches planets, this system detects the change in
@@ -1638,66 +1299,6 @@ fn update_journal_context_on_planet_change(
     }
 }
 
-// ── Record ingestion ────────────────────────────────────────────────────
-
-/// Unified ingestion system — reads [`RecordObservation`] messages and
-/// writes them into the player's [`Journal`] with domain-weighted recovery.
-///
-/// Callers pass `recorded_at: 0` — this system overwrites with real
-/// elapsed time so caller signatures stay lean.
-///
-/// The system applies domain-weighted confidence recovery based on recent
-/// death context. If the player died recently and is now observing the
-/// death-relevant domain, confidence accumulates faster. If they're
-/// avoiding the death domain, it accumulates slower.
-fn apply_observations(
-    mut reader: MessageReader<RecordObservation>,
-    mut player_query: Query<&mut Journal, With<Player>>,
-    time: Res<Time>,
-    config: Res<crate::observation::ConfidenceConfig>,
-    death_context: Option<Res<crate::observation::DeathContext>>,
-    world_profile: Option<Res<WorldProfile>>,
-) {
-    let Ok(mut journal) = player_query.single_mut() else {
-        return;
-    };
-
-    let tick = time.elapsed().as_millis() as u64;
-    let current_planet_seed = world_profile.as_deref().map(|p| p.planet_seed.0);
-
-    for event in reader.read() {
-        let mut obs = event.observation.clone();
-        obs.recorded_at = tick;
-
-        // Automatically resolve planet_seed for Material observations if not already set
-        let key = match &event.key {
-            JournalKey::Material {
-                seed,
-                planet_seed: None,
-            } => JournalKey::Material {
-                seed: *seed,
-                planet_seed: current_planet_seed,
-            },
-            key => key.clone(),
-        };
-
-        // Calculate recovery multiplier based on death context
-        let recovery_multiplier = if let Some(death_ctx) = &death_context {
-            death_ctx.recovery_multiplier(&obs.category, tick, &config)
-        } else {
-            1.0 // No death context, use base rate
-        };
-
-        journal.record_with_domain_weighted_accumulation(
-            key,
-            &event.name,
-            obs,
-            &config,
-            recovery_multiplier,
-        );
-    }
-}
-
 /// Cached text output computed by `compute_journal_panels` and consumed
 /// by `sync_journal_ui` to update the Bevy `Text` nodes.  Keeping the
 /// computation and UI sync in separate systems allows each system to stay
@@ -1714,6 +1315,23 @@ struct JournalRenderCache {
     detail_spans: Vec<DetailSpan>,
     /// Text for the bottom help bar.
     help: String,
+    /// Cross-reference links available on the currently selected entry.
+    ///
+    /// Each entry is `(relationship_label, target_key, target_name)`. The
+    /// navigation system uses this list to jump to a related entry when Enter
+    /// is pressed. Populated each frame by `compute_journal_panels`.
+    cross_ref_links: Vec<(String, JournalKey, String)>,
+    /// Index of the currently highlighted cross-reference link.
+    ///
+    /// `0` when no cross-references exist (no link is highlighted). Clamped
+    /// to `[0, cross_ref_links.len() - 1]` each frame.
+    selected_cross_ref: usize,
+    /// The journal key of the entry whose cross-references are currently cached.
+    ///
+    /// When `populate_cross_ref_links` finds a different selected entry than this
+    /// key, it resets `selected_cross_ref` to 0 so the link cursor doesn't carry
+    /// over from a different entry.
+    cross_ref_entry_key: Option<JournalKey>,
 }
 
 /// A single line in the entry list panel, carrying its display text and
@@ -1739,15 +1357,18 @@ enum DetailSpanKind {
     /// Qualitative confidence label (e.g. "Uncertain", "Noted", "Confirmed")
     /// rendered after each observation description in a subdued style.
     ConfidenceLabel,
-    /// Section header for the "Related" cross-reference block (e.g. "\n\nRelated").
-    CrossReferenceHeader,
-    /// A single cross-reference link line (e.g. "\n  → Found on: Volcanic Plains").
-    CrossReferenceLink,
-    /// A cross-reference link that is currently highlighted by the link cursor.
-    /// Rendered with a brighter color to signal that Enter will follow it.
-    CrossReferenceLinkSelected,
     /// Placeholder text when the journal is empty.
     Placeholder,
+    /// A cross-reference link in the "Related" section.
+    ///
+    /// The selected link is highlighted with a brighter cyan accent so the
+    /// player can see which one Enter will follow.  Unselected links use a
+    /// muted teal.
+    CrossRef {
+        /// Whether this link is the one currently highlighted by the
+        /// cross-reference cursor (i.e. Enter will follow this link).
+        selected: bool,
+    },
 }
 
 /// A styled segment in the detail panel.  The panel is rebuilt each frame
@@ -1787,7 +1408,8 @@ struct DetailSpan {
 ///   onto whatever entry is now selected.
 fn compute_journal_panels(
     mut state: ResMut<JournalUiState>,
-    player_query: Query<&Journal, With<Player>>,
+    graph: Option<Res<KnowledgeGraph>>,
+    classifications: Option<Res<MaterialClassifications>>,
     mut cache: ResMut<JournalRenderCache>,
     mut tracker: ResMut<JournalSelectionTracker>,
 ) {
@@ -1799,7 +1421,7 @@ fn compute_journal_panels(
         return;
     }
 
-    let Ok(journal) = player_query.single() else {
+    let Some(graph) = graph else {
         cache.filter_bar.clear();
         cache.list_lines.clear();
         cache.detail_spans.clear();
@@ -1807,76 +1429,59 @@ fn compute_journal_panels(
         return;
     };
 
-    // Sort entries alphabetically for stable display order.
-    let mut sorted_entries: Vec<&JournalEntry> = journal.entries.values().collect();
-    sorted_entries.sort_by(|a, b| a.name.cmp(&b.name));
-
-    // Apply active filter to the sorted entries
-    let filtered_entries: Vec<&JournalEntry> = sorted_entries
+    // Alphabetically sorted, filtered node list.
+    let filtered_nodes: Vec<NodeIndex> = graph
+        .nodes_sorted_by_name()
         .into_iter()
-        .filter(|entry| matches_filter(entry, state.filter()))
+        .filter(|&idx| {
+            graph
+                .node(idx)
+                .is_some_and(|n| matches_filter_node(n, state.filter()))
+        })
         .collect();
 
-    let entry_count = filtered_entries.len();
+    let entry_count = filtered_nodes.len();
+    let has_any = graph.named_node_count() > 0;
 
     // ── Selection reconciliation ────────────────────────────────────
-    //
-    // Only follow the tracked key when the user did NOT navigate this
-    // frame.  We detect navigation by comparing the live `selected_index`
-    // to the index the tracker recorded at the end of the previous frame:
-    // they match iff no navigation key fired in between.
-    // When the user has not navigated this frame and the tracked entry
-    // still exists, snap `selected_index` to its (possibly shifted) sort
-    // position.  When it no longer exists, `selected_index` is left as-is
-    // so that `clamp_to_entry_count` pulls it to the nearest valid entry
-    // — the entry now occupying the deleted slot, or the new last entry
-    // if the deletion was at the end of the list.
     if let Some(tracked_key) = tracker.key.clone()
         && state.selected_index == tracker.last_index
-        && let Some(new_pos) = filtered_entries.iter().position(|e| e.key == tracked_key)
     {
-        state.selected_index = new_pos;
+        let tracked_id = ConceptId(tracked_key);
+        if let Some(pos) = filtered_nodes
+            .iter()
+            .position(|&idx| graph.lookup(&tracked_id).is_some_and(|ti| ti == idx))
+        {
+            state.selected_index = pos;
+        }
     }
 
     // ── Scroll-offset reconciliation ────────────────────────────────
-    //
-    // Same idea as selection reconciliation, but for the top of the
-    // visible window.  When the user did not page/jump this frame
-    // (`scroll_offset` matches what the tracker recorded last frame) and
-    // the entry that was at the top of the window still exists, snap
-    // `scroll_offset` to that entry's new sort position.  This keeps the
-    // visible rows pinned to the same subjects when a new entry is
-    // recorded outside the visible window — without it, an insertion
-    // before `scroll_offset` would silently scroll every visible row
-    // down by one and disrupt the player's reading.
-    //
-    // When the previous top entry has been deleted we leave
-    // `scroll_offset` alone; `clamp_to_entry_count` below ensures the
-    // (possibly already re-anchored) selection stays visible.
     if let Some(top_key) = tracker.top_key.clone()
         && state.scroll_offset == tracker.last_scroll_offset
-        && let Some(new_top_pos) = filtered_entries.iter().position(|e| e.key == top_key)
     {
-        state.scroll_offset = new_top_pos;
+        let top_id = ConceptId(top_key);
+        if let Some(new_top_pos) = filtered_nodes
+            .iter()
+            .position(|&idx| graph.lookup(&top_id).is_some_and(|ti| ti == idx))
+        {
+            state.scroll_offset = new_top_pos;
+        }
     }
 
     state.clamp_to_entry_count(entry_count);
 
     // ── Update tracker for the next frame ───────────────────────────
-    //
-    // Anchor onto whatever entry is now selected (which, after clamping,
-    // is guaranteed to exist when entry_count > 0) and onto whatever
-    // entry now occupies the top of the visible window.
-    if let Some(entry) = filtered_entries.get(state.selected_index) {
-        tracker.key = Some(entry.key.clone());
+    if let Some(&sel_idx) = filtered_nodes.get(state.selected_index) {
+        if let Some(node) = graph.node(sel_idx) {
+            tracker.key = Some(node.id.0.clone());
+        }
         tracker.last_index = state.selected_index;
-        tracker.top_key = filtered_entries
+        tracker.top_key = filtered_nodes
             .get(state.scroll_offset)
-            .map(|e| e.key.clone());
+            .and_then(|&idx| graph.node(idx).map(|n| n.id.0.clone()));
         tracker.last_scroll_offset = state.scroll_offset;
     } else {
-        // Empty journal: clear the tracker so a future first observation
-        // does not cause us to re-anchor onto a stale key.
         tracker.key = None;
         tracker.last_index = 0;
         tracker.top_key = None;
@@ -1884,9 +1489,96 @@ fn compute_journal_panels(
     }
 
     cache.filter_bar = build_filter_bar_text(state.filter());
-    cache.list_lines = build_entry_list_lines(&filtered_entries, &state);
-    cache.detail_spans = build_detail_spans(&filtered_entries, &state, !journal.entries.is_empty());
-    cache.help = build_help_text(entry_count, &state);
+    cache.list_lines =
+        build_entry_list_lines(&filtered_nodes, &graph, &state, classifications.as_deref());
+    cache.cross_ref_links.clear();
+
+    // Build detail spans from the selected ConceptNode.
+    let selected_node = filtered_nodes
+        .get(state.selected_index)
+        .and_then(|&idx| graph.node(idx));
+    cache.detail_spans = build_detail_spans(selected_node, has_any, classifications.as_deref());
+    cache.help = build_help_text(entry_count, &state, 0);
+}
+
+/// Populates [`JournalRenderCache::cross_ref_links`] from the knowledge
+/// graph for the currently selected journal entry.
+///
+/// Runs in the [`JournalSet::Compute`] set, immediately after
+/// [`compute_journal_panels`], which clears `cross_ref_links` first.
+///
+/// If the KnowledgeGraph resource is absent (lightweight tests), cross-
+/// references are silently omitted.
+fn populate_cross_ref_links(
+    state: Res<JournalUiState>,
+    mut cache: ResMut<JournalRenderCache>,
+    graph: Option<Res<KnowledgeGraph>>,
+) {
+    if !state.visible {
+        return;
+    }
+    let Some(graph) = graph else {
+        return;
+    };
+
+    // Rebuild the filtered node list to find the selected node.
+    let filtered_nodes: Vec<NodeIndex> = graph
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter(|&idx| {
+            graph
+                .node(idx)
+                .is_some_and(|n| matches_filter_node(n, state.filter()))
+        })
+        .collect();
+
+    let Some(&sel_idx) = filtered_nodes.get(state.selected_index) else {
+        return;
+    };
+    let Some(selected_node) = graph.node(sel_idx) else {
+        return;
+    };
+
+    // Reset link cursor when selected entry changes.
+    if cache.cross_ref_entry_key.as_ref() != Some(&selected_node.id.0) {
+        cache.selected_cross_ref = 0;
+        cache.cross_ref_entry_key = Some(selected_node.id.0.clone());
+    }
+
+    // Collect relationships from the graph.
+    for (neighbor_idx, edge) in graph.relationships(sel_idx) {
+        let Some(neighbor_node) = graph.node(neighbor_idx) else {
+            continue;
+        };
+        // Use the node's own name; fall back to category label for unnamed concepts.
+        let target_name = if neighbor_node.name.is_empty() {
+            format!("{:?}", neighbor_node.category)
+        } else {
+            neighbor_node.name.clone()
+        };
+        let rel_label = edge.relationship.display_label().to_string();
+        cache
+            .cross_ref_links
+            .push((rel_label, neighbor_node.id.0.clone(), target_name));
+    }
+
+    let link_count = cache.cross_ref_links.len();
+    if link_count > 0 {
+        cache.selected_cross_ref = cache.selected_cross_ref.min(link_count - 1);
+    } else {
+        cache.selected_cross_ref = 0;
+    }
+
+    let links_snapshot = cache.cross_ref_links.clone();
+    let selected_cross_ref = cache.selected_cross_ref;
+
+    cache.detail_spans = build_detail_spans_with_cross_refs(
+        selected_node,
+        true,
+        &links_snapshot,
+        selected_cross_ref,
+    );
+    cache.help = build_help_text(filtered_nodes.len(), &state, links_snapshot.len());
 }
 
 /// Syncs the cached text into the Bevy UI `Text` nodes and toggles
@@ -1903,7 +1595,6 @@ fn sync_journal_ui(
     state: Res<JournalUiState>,
     cache: Res<JournalRenderCache>,
     mut commands: Commands,
-    mut panel_query: Query<&mut Visibility, With<JournalPanel>>,
     list_query: Query<(Entity, Option<&Children>), With<JournalEntryListText>>,
     detail_query: Query<(Entity, Option<&Children>), With<JournalDetailText>>,
     mut texts: ParamSet<(
@@ -1913,16 +1604,12 @@ fn sync_journal_ui(
         Query<&mut Text, With<JournalHelpText>>,
     )>,
 ) {
-    let Ok(mut panel_vis) = panel_query.single_mut() else {
-        return;
-    };
-
+    // Visibility is now managed by DiegeticUiPlugin::sync_readable_surface_visibility.
+    // This system only updates text content; it skips work when the journal is not
+    // visible to avoid rebuilding TextSpan trees every frame while closed.
     if !state.visible {
-        *panel_vis = Visibility::Hidden;
         return;
     }
-
-    *panel_vis = Visibility::Visible;
 
     // ── Entry list: rebuild TextSpan children for per-line coloring ──
     //
@@ -1979,13 +1666,6 @@ fn sync_journal_ui(
     let body_color = TextColor(Color::srgba(0.92, 0.92, 0.88, 1.0));
     let confidence_color = TextColor(Color::srgba(0.6, 0.65, 0.7, 1.0));
     let placeholder_color = TextColor(Color::srgba(0.55, 0.55, 0.50, 1.0));
-    // Cross-reference section header uses the same amber accent as category headers.
-    let cross_ref_header_color = TextColor(Color::srgba(0.75, 0.68, 0.45, 1.0));
-    // Cross-reference links use a cyan-tinted color to signal navigability.
-    let cross_ref_link_color = TextColor(Color::srgba(0.45, 0.80, 0.85, 1.0));
-    // Selected cross-reference link uses a bright white-cyan to signal it is
-    // focused and can be followed with Enter.
-    let cross_ref_link_selected_color = TextColor(Color::srgba(1.0, 1.0, 0.35, 1.0));
 
     if let Ok((detail_entity, detail_children)) = detail_query.single() {
         if let Some(children) = detail_children {
@@ -2005,10 +1685,16 @@ fn sync_journal_ui(
                     DetailSpanKind::CategoryGroupHeader => category_group_color,
                     DetailSpanKind::Body => body_color,
                     DetailSpanKind::ConfidenceLabel => confidence_color,
-                    DetailSpanKind::CrossReferenceHeader => cross_ref_header_color,
-                    DetailSpanKind::CrossReferenceLink => cross_ref_link_color,
-                    DetailSpanKind::CrossReferenceLinkSelected => cross_ref_link_selected_color,
                     DetailSpanKind::Placeholder => placeholder_color,
+                    // Selected cross-reference link: bright cyan to draw the eye.
+                    DetailSpanKind::CrossRef { selected: true } => {
+                        TextColor(Color::srgba(0.3, 0.9, 0.85, 1.0))
+                    }
+                    // Unselected cross-reference link: muted teal — visible but not
+                    // competing with the observation text.
+                    DetailSpanKind::CrossRef { selected: false } => {
+                        TextColor(Color::srgba(0.3, 0.65, 0.62, 1.0))
+                    }
                 };
                 parent.spawn((TextSpan::new(span.text.clone()), span_font.clone(), color));
             }
@@ -2053,24 +1739,52 @@ fn build_filter_bar_text(filter: &JournalFilter) -> String {
 /// Each line carries its display text and a flag indicating whether it is
 /// the currently selected entry.  The selected entry is prefixed with `>`
 /// and rendered with a distinct highlight color by the UI sync system.
-fn build_entry_list_lines(entries: &[&JournalEntry], state: &JournalUiState) -> Vec<EntryListLine> {
-    if entries.is_empty() {
+/// Builds structured line data for the left-panel entry list from KG nodes.
+fn build_entry_list_lines(
+    nodes: &[NodeIndex],
+    graph: &KnowledgeGraph,
+    state: &JournalUiState,
+    classifications: Option<&crate::classification::MaterialClassifications>,
+) -> Vec<EntryListLine> {
+    if nodes.is_empty() {
         return Vec::new();
     }
 
-    let page_end = (state.scroll_offset + state.entries_per_page).min(entries.len());
-    let visible = &entries[state.scroll_offset..page_end];
+    let page_end = (state.scroll_offset + state.entries_per_page).min(nodes.len());
+    let visible = &nodes[state.scroll_offset..page_end];
 
     visible
         .iter()
         .enumerate()
-        .map(|(i, entry)| {
+        .map(|(i, &idx)| {
             let abs_index = state.scroll_offset + i;
             let selected = abs_index == state.selected_index;
             let prefix = if selected { ">" } else { " " };
-            let obs_count = entry.observation_count();
+
+            let (name, obs_count) = graph
+                .node(idx)
+                .map(|n| (n.name.as_str(), n.observation_count()))
+                .unwrap_or(("<unknown>", 0));
+
+            // Show classification in brackets if the player has observed
+            // enough properties for a match, otherwise show "Unknown [name]"
+            // so unclassified materials are still consistently identifiable.
+            let display_name = if let Some(node) = graph.node(idx)
+                && let Some(cls) = classifications
+                && let Some(entry) = cls.classify_observed(&node.revealed_properties)
+            {
+                format!("{} [{}]", name, entry.display_name)
+            } else if graph
+                .node(idx)
+                .is_some_and(|n| !n.revealed_properties.is_empty())
+            {
+                format!("Unknown [{}]", name)
+            } else {
+                name.to_string()
+            };
+
             EntryListLine {
-                text: format!("{prefix} {} ({obs_count} obs)", entry.name),
+                text: format!("{prefix} {} ({obs_count} obs)", display_name),
                 selected,
             }
         })
@@ -2078,23 +1792,44 @@ fn build_entry_list_lines(entries: &[&JournalEntry], state: &JournalUiState) -> 
 }
 
 /// Builds styled spans for the right-panel detail view of the currently
-/// selected entry.
+/// selected `ConceptNode`.
 ///
-/// The header (entry name) renders in a bright highlight color.  Category
-/// labels ("Surface:", "Heat:", etc.) use an amber accent, while observation
-/// descriptions use the normal body color.  If no entries exist, a single
-/// placeholder span is returned.
-///
-/// The `has_any_entries` parameter distinguishes between an empty journal
-/// (shows "No observations yet.") and a filter that produces no results
-/// (shows "No matching entries").
+/// `has_any` — whether the KG has any named nodes at all (distinguishes
+/// "no observations yet" from "filter produced no results").
 fn build_detail_spans(
-    entries: &[&JournalEntry],
-    state: &JournalUiState,
-    has_any_entries: bool,
+    node: Option<&ConceptNode>,
+    has_any: bool,
+    classifications: Option<&crate::classification::MaterialClassifications>,
 ) -> Vec<DetailSpan> {
-    if entries.is_empty() {
-        let message = if has_any_entries {
+    build_detail_spans_with_cross_refs_opt(node, has_any, &[], 0, classifications)
+}
+
+/// Internal implementation of detail-span building that accepts cross-reference
+/// data computed externally.
+fn build_detail_spans_with_cross_refs(
+    node: &ConceptNode,
+    has_any: bool,
+    cross_ref_links: &[(String, JournalKey, String)],
+    selected_cross_ref: usize,
+) -> Vec<DetailSpan> {
+    build_detail_spans_with_cross_refs_opt(
+        Some(node),
+        has_any,
+        cross_ref_links,
+        selected_cross_ref,
+        None,
+    )
+}
+
+fn build_detail_spans_with_cross_refs_opt(
+    node: Option<&ConceptNode>,
+    has_any: bool,
+    cross_ref_links: &[(String, JournalKey, String)],
+    selected_cross_ref: usize,
+    classifications: Option<&crate::classification::MaterialClassifications>,
+) -> Vec<DetailSpan> {
+    let Some(node) = node else {
+        let message = if has_any {
             "No matching entries"
         } else {
             "No observations yet."
@@ -2103,46 +1838,44 @@ fn build_detail_spans(
             text: message.to_string(),
             kind: DetailSpanKind::Placeholder,
         }];
-    }
+    };
 
-    let entry = entries[state.selected_index.min(entries.len() - 1)];
     let mut spans: Vec<DetailSpan> = Vec::new();
 
-    // Entry name header.
+    // Entry name header — show classification in the header if known.
+    let header_text = if let Some(cls) = classifications
+        && let Some(entry) = cls.classify_observed(&node.revealed_properties)
+    {
+        format!("{} — {}", node.name, entry.display_name)
+    } else if !node.revealed_properties.is_empty() {
+        format!("{} — Unknown [{}]", node.name, node.name)
+    } else {
+        node.name.clone()
+    };
     spans.push(DetailSpan {
-        text: entry.name.clone(),
+        text: header_text,
         kind: DetailSpanKind::Header,
     });
 
-    // Iterate categories in canonical display order, emitting a group
-    // header followed by the observations for each non-empty category.
-    // The order is driven by `ObservationCategory::display_order` (backed
-    // by `strum::EnumIter`) so a new variant added to the enum is
-    // automatically rendered here in its declared position.
+    // Iterate categories in canonical display order.
     for category in ObservationCategory::display_order() {
-        let observations = entry.observations_by_category(&category);
+        let observations = node.observations_by_category(&category);
         if observations.is_empty() {
             continue;
         }
 
-        // Category group header (e.g. "\n\nSurface").
         spans.push(DetailSpan {
             text: format!("\n\n{}", category.display_label()),
             kind: DetailSpanKind::CategoryGroupHeader,
         });
 
-        // For categories that converge on a single reading, show only
-        // the most recent observation. Otherwise show all.
         let visible: &[Observation] = if category.shows_latest_only() {
-            // Safe: we checked `!is_empty()` above.
             &observations[observations.len() - 1..]
         } else {
             observations
         };
 
         for obs in visible {
-            // Multi-line descriptions (e.g. surface observations that combine
-            // color + weight) need each line indented consistently.
             let indented = obs
                 .description
                 .lines()
@@ -2152,8 +1885,6 @@ fn build_detail_spans(
                 text: indented,
                 kind: DetailSpanKind::Body,
             });
-            // Qualitative confidence indicator — communicates certainty
-            // without exposing internal counts.
             spans.push(DetailSpan {
                 text: format!("  [{}]", obs.confidence.tier().display_label()),
                 kind: DetailSpanKind::ConfidenceLabel,
@@ -2161,150 +1892,33 @@ fn build_detail_spans(
         }
     }
 
+    // ── Related section (cross-references) ──────────────────────────
+    if !cross_ref_links.is_empty() {
+        spans.push(DetailSpan {
+            text: "\n\nRelated".to_string(),
+            kind: DetailSpanKind::CategoryGroupHeader,
+        });
+        for (i, (rel_label, _, target_name)) in cross_ref_links.iter().enumerate() {
+            let selected = i == selected_cross_ref;
+            let prefix = if selected { "→ " } else { "  " };
+            spans.push(DetailSpan {
+                text: format!("\n{prefix}{}: {}", rel_label, target_name),
+                kind: DetailSpanKind::CrossRef { selected },
+            });
+        }
+    }
+
     spans
 }
 
-/// Appends cross-reference spans to the detail panel render cache.
-///
-/// Runs in [`JournalSet::Compute`] after [`compute_journal_panels`].  Reads
-/// the [`KnowledgeGraph`] to find all relationships for the currently selected
-/// journal entry and appends a "Related" section to the cached detail spans.
-///
-/// The section is omitted entirely when the selected entry has no cross-
-/// references in the graph, keeping the panel clean for newly discovered
-/// concepts.
-///
-/// Each cross-reference line shows the relationship type label and the display
-/// name of the related concept (looked up from the player's journal).  When
-/// the related concept has no journal entry yet (e.g., a location concept that
-/// predates the journal entry system), the raw key debug representation is
-/// used as a fallback.
-fn append_cross_reference_spans(
-    state: Res<JournalUiState>,
-    player_query: Query<&Journal, With<Player>>,
-    mut cache: ResMut<JournalRenderCache>,
-    graph: Option<Res<KnowledgeGraph>>,
-) {
-    // Only append when the journal is visible and has a selected entry.
-    if !state.visible {
-        return;
-    }
-
-    // KnowledgeGraph may not be present in test apps that don't add
-    // KnowledgeGraphPlugin — skip gracefully rather than panicking.
-    let Some(graph) = graph else {
-        return;
-    };
-
-    let Ok(journal) = player_query.single() else {
-        return;
-    };
-
-    // Sort entries alphabetically — same order as compute_journal_panels.
-    let mut sorted_entries: Vec<&JournalEntry> = journal.entries.values().collect();
-    sorted_entries.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let filtered_entries: Vec<&JournalEntry> = sorted_entries
-        .into_iter()
-        .filter(|entry| matches_filter(entry, state.filter()))
-        .collect();
-
-    let Some(entry) = filtered_entries.get(
-        state
-            .selected_index
-            .min(filtered_entries.len().saturating_sub(1)),
-    ) else {
-        return;
-    };
-
-    // Look up the concept node for the selected entry.
-    let concept_id = ConceptId::new(entry.key.clone());
-    let Some(node_idx) = graph.lookup(&concept_id) else {
-        // No concept node yet — no cross-references to show.
-        return;
-    };
-
-    let relationships = graph.relationships(node_idx);
-    if relationships.is_empty() {
-        return;
-    }
-
-    // Append the "Related" section header.
-    cache.detail_spans.push(DetailSpan {
-        text: "\n\nRelated".to_string(),
-        kind: DetailSpanKind::CrossReferenceHeader,
-    });
-
-    // Append one line per cross-reference, sorted by relationship type label
-    // then by target name for stable display order.
-    let mut ref_lines: Vec<(String, String)> = relationships
-        .iter()
-        .filter_map(|(neighbor_idx, edge)| {
-            let neighbor_node = graph.node(*neighbor_idx)?;
-            let target_key = neighbor_node.id.key();
-            // Prefer the journal entry name; fall back to a key-derived label.
-            let target_name = journal
-                .entries
-                .get(target_key)
-                .map(|e| e.name.clone())
-                .unwrap_or_else(|| format!("{target_key:?}"));
-            let rel_label = relationship_display_label(&edge.relationship).to_string();
-            Some((rel_label, target_name))
-        })
-        .collect();
-
-    ref_lines.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-
-    for (link_idx, (rel_label, target_name)) in ref_lines.iter().enumerate() {
-        // Highlight the link that the cursor is currently on so the player
-        // knows which entry Enter will jump to.
-        let kind = if state.selected_link_index == Some(link_idx) {
-            DetailSpanKind::CrossReferenceLinkSelected
-        } else {
-            DetailSpanKind::CrossReferenceLink
-        };
-        cache.detail_spans.push(DetailSpan {
-            text: format!("\n  \u{2192} {rel_label}: {target_name}"),
-            kind,
-        });
-    }
-}
-
-/// Returns the player-facing label for a [`RelationshipType`].
-///
-/// These labels appear in the "Related" section of the journal detail panel.
-/// They are intentionally terse — the arrow prefix (`→`) already signals
-/// directionality, so the label only needs to name the relationship.
-fn relationship_display_label(rel: &RelationshipType) -> &'static str {
-    match rel {
-        RelationshipType::FoundOn => "Found on",
-        RelationshipType::CombinedWith => "Combined with",
-        RelationshipType::DerivedFrom => "Derived from",
-        RelationshipType::SimilarTo => "Similar to",
-        RelationshipType::ObservedAt => "Observed at",
-    }
-}
-
 /// Builds the bottom help bar showing navigation hints and a page indicator.
-fn build_help_text(entry_count: usize, state: &JournalUiState) -> String {
+fn build_help_text(entry_count: usize, state: &JournalUiState, cross_ref_count: usize) -> String {
     if entry_count == 0 {
         return "J: Close".to_string();
     }
 
     let page_start = state.scroll_offset + 1;
     let page_end = (state.scroll_offset + state.entries_per_page).min(entry_count);
-
-    // When a cross-reference link is focused, show link-specific hints.
-    if state.selected_link_index.is_some() {
-        let back_hint = if state.navigation_stack.can_go_back() {
-            "  Backspace: Cancel"
-        } else {
-            "  Esc: Cancel"
-        };
-        return format!(
-            "\u{2191}\u{2193} Move link  Enter: Follow  {back_hint}  J: Close  [{page_start}-{page_end} of {entry_count}]"
-        );
-    }
 
     // Show active filter status if any filter is applied
     let filter_status = match (&state.filter().category, &state.filter().context) {
@@ -2324,14 +1938,15 @@ fn build_help_text(entry_count: usize, state: &JournalUiState) -> String {
         }
     };
 
-    let back_hint = if state.navigation_stack.can_go_back() {
-        "  Backspace: Back"
+    // Cross-reference hint when links exist.
+    let cross_ref_hint = if cross_ref_count > 0 {
+        "  Alt+↑↓: Link  Enter: Follow  Backspace: Back"
     } else {
         ""
     };
 
     format!(
-        "\u{2191}\u{2193} Navigate  \u{2192}: Links  PgUp/PgDn: Page  Home/End: Jump  Shift+Tab: Context Filter  J: Close{filter_status}{back_hint}  [{page_start}-{page_end} of {entry_count}]"
+        "\u{2191}\u{2193} Navigate  PgUp/PgDn: Page  Home/End: Jump  Shift+Tab: Context Filter  J: Close{filter_status}{cross_ref_hint}  [{page_start}-{page_end} of {entry_count}]"
     )
 }
 

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -1,9 +1,14 @@
 use super::*;
+use crate::knowledge_graph::{ConceptId, ConceptNode, KnowledgeGraph};
 use crate::observation::Confidence;
 use crate::world_generation::BiomeType;
 
-fn build_entry_list_text(entries: &[&JournalEntry], state: &JournalUiState) -> String {
-    let lines = build_entry_list_lines(entries, state);
+fn build_entry_list_text(
+    nodes: &[NodeIndex],
+    graph: &KnowledgeGraph,
+    state: &JournalUiState,
+) -> String {
+    let lines = build_entry_list_lines(nodes, graph, state, None);
     lines
         .iter()
         .map(|l| l.text.as_str())
@@ -25,24 +30,22 @@ fn detail_spans_to_string(spans: &[DetailSpan]) -> String {
 /// UI now uses `build_entry_list_text` / `build_detail_spans` instead, but
 /// this function exercises the same rendering logic in a flat format that
 /// is convenient for unit-test assertions.
-fn build_journal_text(journal: &Journal) -> String {
-    if journal.entries.is_empty() {
+fn build_journal_text(kg: &KnowledgeGraph) -> String {
+    let nodes = kg.nodes_sorted_by_name();
+    if nodes.is_empty() {
         return "Journal\n\nNo observations yet.".to_string();
     }
 
     let mut out = vec!["Journal".to_string()];
 
-    // Collect all fabrication result descriptions across all entries, in
-    // insertion order (BTreeMap iteration is deterministic). This mirrors
-    // the legacy "Recent Fabrication" section which was a flat log.
-    let fabrication_descriptions: Vec<&str> = journal
-        .entries
-        .values()
-        .flat_map(|entry| {
-            entry
-                .observations_by_category(&ObservationCategory::FabricationResult)
+    // Collect all fabrication result descriptions, alphabetical node order.
+    let fabrication_descriptions: Vec<String> = nodes
+        .iter()
+        .filter_map(|&idx| kg.node(idx))
+        .flat_map(|n| {
+            n.observations_by_category(&ObservationCategory::FabricationResult)
                 .iter()
-                .map(|o| o.description.as_str())
+                .map(|o| o.description.clone())
         })
         .collect();
 
@@ -54,37 +57,26 @@ fn build_journal_text(journal: &Journal) -> String {
         }
     }
 
-    // Sort entries by name for stable, alphabetical display order.
-    let mut entries: Vec<&JournalEntry> = journal.entries.values().collect();
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
-
-    for entry in entries {
-        // Visual separator between entries for legibility.
+    for &idx in &nodes {
+        let Some(entry) = kg.node(idx) else { continue };
         out.push(String::new());
         out.push(format!("--- {} ---", entry.name));
 
         for obs in entry.observations_by_category(&ObservationCategory::SurfaceAppearance) {
             out.push(format!("  Surface: {}", obs.description));
         }
-
-        // Show only the most recent thermal observation (matches legacy
-        // behavior where `thermal_observation` was a single `Option<String>`).
         if let Some(thermal) = entry
             .observations_by_category(&ObservationCategory::ThermalBehavior)
             .last()
         {
             out.push(format!("  Heat: {}", thermal.description));
         }
-
-        // Show only the most recent weight observation (matches legacy
-        // behavior where `weight_observation` was a single `Option<String>`).
         if let Some(weight) = entry
             .observations_by_category(&ObservationCategory::Weight)
             .last()
         {
             out.push(format!("  Carried: {}", weight.description));
         }
-
         for obs in entry.observations_by_category(&ObservationCategory::FabricationResult) {
             out.push(format!("  {}", obs.description));
         }
@@ -95,12 +87,9 @@ fn build_journal_text(journal: &Journal) -> String {
 
 #[test]
 fn journal_omits_unknown_properties() {
-    let mut journal = Journal::default();
-    journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+    let mut kg = KnowledgeGraph::default();
+    kg.record(
+        JournalKey::MaterialInstance { seed: 1 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -110,15 +99,15 @@ fn journal_omits_unknown_properties() {
         },
     );
 
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
     assert!(text.contains("Weight: Heavy"));
     assert!(!text.contains("Heat:"));
 }
 
 #[test]
 fn journal_includes_fabrication_history() {
-    let mut journal = Journal::default();
-    journal.record(
+    let mut kg = KnowledgeGraph::default();
+    kg.record(
         JournalKey::Fabrication { output_seed: 2 },
         "Neoite",
         Observation {
@@ -129,19 +118,16 @@ fn journal_includes_fabrication_history() {
         },
     );
 
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
     assert!(text.contains("Combined Ferrite + Silite -> Neoite"));
     assert!(text.contains("Recent Fabrication"));
 }
 
 #[test]
 fn journal_shows_thermal_observation_when_present() {
-    let mut journal = Journal::default();
-    journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+    let mut kg = KnowledgeGraph::default();
+    kg.record(
+        JournalKey::MaterialInstance { seed: 3 },
         "TestMat",
         Observation {
             category: ObservationCategory::ThermalBehavior,
@@ -151,56 +137,28 @@ fn journal_shows_thermal_observation_when_present() {
         },
     );
 
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
     assert!(text.contains("Heat: Reliably hold together under heat"));
 }
 
 #[test]
 fn journal_key_material_equality() {
-    let a = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let b = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let c = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
+    let a = JournalKey::MaterialInstance { seed: 42 };
+    let b = JournalKey::MaterialInstance { seed: 42 };
+    let c = JournalKey::MaterialInstance { seed: 99 };
     assert_eq!(a, b);
     assert_ne!(a, c);
 }
 
-/// `planet_seed` participates in `JournalKey::Material` identity: two
-/// otherwise-identical material keys captured on different planets
-/// must be distinct so the journal records them as separate entries.
-/// This is what lets the upcoming context filter (Story 10.3) treat
-/// "Ferrite seen on Planet A" and "Ferrite seen on Planet B" as
-/// independent observations.
+/// `MaterialInstance` keys are equal when seeds match — planet of origin
+/// is stored on the entry, not the key.
 #[test]
-fn journal_key_material_planet_seed_participates_in_equality() {
-    let unknown = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let on_planet_a = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(1),
-    };
-    let on_planet_b = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(2),
-    };
-    let on_planet_a_again = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(1),
-    };
-
-    assert_ne!(unknown, on_planet_a);
-    assert_ne!(on_planet_a, on_planet_b);
-    assert_eq!(on_planet_a, on_planet_a_again);
+fn journal_key_material_instance_equality_is_seed_only() {
+    let a = JournalKey::MaterialInstance { seed: 42 };
+    let b = JournalKey::MaterialInstance { seed: 42 };
+    let c = JournalKey::MaterialInstance { seed: 99 };
+    assert_eq!(a, b);
+    assert_ne!(a, c);
 }
 
 /// Derived `Ord` sorts material keys primarily by `seed`, with
@@ -212,43 +170,19 @@ fn journal_key_material_planet_seed_participates_in_equality() {
 #[test]
 fn journal_key_material_ord_seed_then_planet_seed() {
     let mut keys = vec![
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(0),
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(99),
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(1),
-        },
+        JournalKey::MaterialInstance { seed: 2 },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 1 },
     ];
     keys.sort();
     assert_eq!(
         keys,
         vec![
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: None
-            },
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: Some(1)
-            },
-            JournalKey::Material {
-                seed: 1,
-                planet_seed: Some(99)
-            },
-            JournalKey::Material {
-                seed: 2,
-                planet_seed: Some(0)
-            },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 1 },
+            JournalKey::MaterialInstance { seed: 2 },
         ],
     );
 }
@@ -358,8 +292,17 @@ fn journal_context_biome_equality_is_string_based() {
 // Helpers for the matches_filter tests below.  Build a small entry
 // with a single observation so the category dimension can be
 // exercised independently of the context dimension.
-fn entry_with_observation(key: JournalKey, category: ObservationCategory) -> JournalEntry {
-    let mut entry = JournalEntry::new(key, "Subject".to_string(), 0);
+fn node_with_observation(key: JournalKey, category: ObservationCategory) -> ConceptNode {
+    node_with_observation_on_planet(key, category, Some(7))
+}
+
+fn node_with_observation_on_planet(
+    key: JournalKey,
+    category: ObservationCategory,
+    planet_seed: Option<u64>,
+) -> ConceptNode {
+    let mut entry = ConceptNode::new(key, "Subject", 0);
+    entry.origin_planet_seed = planet_seed;
     entry.add_observation(Observation {
         category,
         confidence: Confidence(0.2),
@@ -375,24 +318,14 @@ fn matches_filter_default_accepts_every_entry() {
     // dimension; every entry — including one with no observations —
     // must pass.  This is the Story 10.3 default behaviour.
     let filter = JournalFilter::default();
-    let entry = JournalEntry::new(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        "Empty".to_string(),
-        0,
-    );
-    assert!(matches_filter(&entry, &filter));
+    let entry = ConceptNode::new(JournalKey::MaterialInstance { seed: 1 }, "Empty", 0);
+    assert!(matches_filter_node(&entry, &filter));
 
-    let populated = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(99),
-        },
+    let populated = node_with_observation(
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
     );
-    assert!(matches_filter(&populated, &filter));
+    assert!(matches_filter_node(&populated, &filter));
 }
 
 #[test]
@@ -404,23 +337,17 @@ fn matches_filter_category_only_keeps_matching_entries() {
         context: None,
     };
 
-    let thermal = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+    let thermal = node_with_observation(
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::ThermalBehavior,
     );
-    assert!(matches_filter(&thermal, &filter));
+    assert!(matches_filter_node(&thermal, &filter));
 
-    let surface = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+    let surface = node_with_observation(
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
     );
-    assert!(!matches_filter(&surface, &filter));
+    assert!(!matches_filter_node(&surface, &filter));
 }
 
 #[test]
@@ -431,54 +358,39 @@ fn matches_filter_category_rejects_entry_with_no_observations() {
         category: Some(ObservationCategory::SurfaceAppearance),
         context: None,
     };
-    let empty = JournalEntry::new(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        "Empty".to_string(),
-        0,
-    );
-    assert!(!matches_filter(&empty, &filter));
+    let empty = ConceptNode::new(JournalKey::MaterialInstance { seed: 1 }, "Empty", 0);
+    assert!(!matches_filter_node(&empty, &filter));
 }
 
 #[test]
-fn matches_filter_current_planet_uses_key_planet_seed() {
-    // CurrentPlanet matches an entry iff its key's planet_seed
-    // equals the filter's seed.  Entries without a recorded planet
-    // (planet_seed == None) are excluded — "unknown provenance"
-    // must not silently masquerade as "current planet".
+fn matches_filter_current_planet_uses_entry_origin_planet_seed() {
+    // CurrentPlanet matches an entry iff its origin_planet_seed equals
+    // the filter's seed. Entries without a recorded planet are excluded.
     let filter = JournalFilter {
         category: None,
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
 
-    let on_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+    let on_planet = node_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
+        Some(7),
     );
-    assert!(matches_filter(&on_planet, &filter));
+    assert!(matches_filter_node(&on_planet, &filter));
 
-    let other_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(8),
-        },
+    let other_planet = node_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 2 },
         ObservationCategory::SurfaceAppearance,
+        Some(99),
     );
-    assert!(!matches_filter(&other_planet, &filter));
+    assert!(!matches_filter_node(&other_planet, &filter));
 
-    let no_planet = entry_with_observation(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+    let no_planet = node_with_observation_on_planet(
+        JournalKey::MaterialInstance { seed: 3 },
         ObservationCategory::SurfaceAppearance,
+        None,
     );
-    assert!(!matches_filter(&no_planet, &filter));
+    assert!(!matches_filter_node(&no_planet, &filter));
 }
 
 #[test]
@@ -489,11 +401,12 @@ fn matches_filter_current_planet_excludes_fabrications() {
         category: None,
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
-    let fab = entry_with_observation(
+    let fab = node_with_observation_on_planet(
         JournalKey::Fabrication { output_seed: 42 },
         ObservationCategory::FabricationResult,
+        None, // fabrications have no planet origin
     );
-    assert!(!matches_filter(&fab, &filter));
+    assert!(!matches_filter_node(&fab, &filter));
 }
 
 #[test]
@@ -501,11 +414,8 @@ fn matches_filter_combined_uses_and_logic() {
     // Both dimensions must match.  Verify the four corners of the
     // 2x2 truth table for an entry on planet 7 with a Surface
     // observation against a Surface + planet 7 filter.
-    let entry = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+    let entry = node_with_observation(
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
     );
 
@@ -513,25 +423,25 @@ fn matches_filter_combined_uses_and_logic() {
         category: Some(ObservationCategory::SurfaceAppearance),
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
-    assert!(matches_filter(&entry, &both_match));
+    assert!(matches_filter_node(&entry, &both_match));
 
     let category_mismatch = JournalFilter {
         category: Some(ObservationCategory::ThermalBehavior),
         context: Some(JournalContext::CurrentPlanet { planet_seed: 7 }),
     };
-    assert!(!matches_filter(&entry, &category_mismatch));
+    assert!(!matches_filter_node(&entry, &category_mismatch));
 
     let context_mismatch = JournalFilter {
         category: Some(ObservationCategory::SurfaceAppearance),
         context: Some(JournalContext::CurrentPlanet { planet_seed: 8 }),
     };
-    assert!(!matches_filter(&entry, &context_mismatch));
+    assert!(!matches_filter_node(&entry, &context_mismatch));
 
     let both_mismatch = JournalFilter {
         category: Some(ObservationCategory::ThermalBehavior),
         context: Some(JournalContext::CurrentPlanet { planet_seed: 8 }),
     };
-    assert!(!matches_filter(&entry, &both_mismatch));
+    assert!(!matches_filter_node(&entry, &both_mismatch));
 }
 
 #[test]
@@ -547,38 +457,30 @@ fn matches_filter_current_biome_is_no_op_until_data_capture() {
             biome_key: BiomeKey::from(BiomeType::FrostShelf),
         }),
     };
-    let entry = entry_with_observation(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(7),
-        },
+    let entry = node_with_observation(
+        JournalKey::MaterialInstance { seed: 1 },
         ObservationCategory::SurfaceAppearance,
     );
-    assert!(matches_filter(&entry, &filter));
+    assert!(matches_filter_node(&entry, &filter));
 }
 
+/// `planet_seed()` on `JournalKey` only returns a value for Location keys.
+/// Material instances carry planet provenance on `JournalEntry::origin_planet_seed`,
+/// not on the key itself.
 #[test]
 fn journal_key_planet_seed_accessor() {
-    // Material carries an Option<u64>; Fabrication is always None.
     assert_eq!(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(42),
-        }
-        .planet_seed(),
-        Some(42)
-    );
-    assert_eq!(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        }
-        .planet_seed(),
-        None
+        JournalKey::MaterialInstance { seed: 1 }.planet_seed(),
+        None,
+        "material instance keys do not carry planet_seed — it lives on the entry"
     );
     assert_eq!(
         JournalKey::Fabrication { output_seed: 7 }.planet_seed(),
         None
+    );
+    assert_eq!(
+        JournalKey::Location { planet_seed: 42 }.planet_seed(),
+        Some(42)
     );
 }
 
@@ -589,18 +491,17 @@ fn matches_filter_handles_500_entries_quickly() {
     // < 1ms".  The threshold here is generous (10ms) to absorb
     // noise on loaded CI hardware while still catching pathological
     // regressions that would land us in the seconds.
-    let entries: Vec<JournalEntry> = (0..500u64)
+    let entries: Vec<ConceptNode> = (0..500u64)
         .map(|i| {
-            entry_with_observation(
-                JournalKey::Material {
-                    seed: i,
-                    planet_seed: Some(i % 4),
-                },
+            // Give entries a planet seed of i%4 so some match planet 2 and some don't
+            node_with_observation_on_planet(
+                JournalKey::MaterialInstance { seed: i },
                 if i % 2 == 0 {
                     ObservationCategory::SurfaceAppearance
                 } else {
                     ObservationCategory::ThermalBehavior
                 },
+                Some(i % 4), // seeds 0,1,2,3 → planet 0,1,2,3
             )
         })
         .collect();
@@ -613,7 +514,7 @@ fn matches_filter_handles_500_entries_quickly() {
     let start = std::time::Instant::now();
     let kept = entries
         .iter()
-        .filter(|e| matches_filter(e, &filter))
+        .filter(|e| matches_filter_node(e, &filter))
         .count();
     let elapsed = start.elapsed();
 
@@ -638,10 +539,7 @@ fn journal_key_fabrication_equality() {
 
 #[test]
 fn journal_key_variants_are_distinct() {
-    let mat = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mat = JournalKey::MaterialInstance { seed: 42 };
     let fab = JournalKey::Fabrication { output_seed: 42 };
     assert_ne!(mat, fab);
 }
@@ -649,9 +547,9 @@ fn journal_key_variants_are_distinct() {
 #[test]
 fn journal_key_serde_round_trip() {
     let keys = vec![
+        JournalKey::MaterialInstance { seed: 123 },
         JournalKey::Material {
-            seed: 123,
-            planet_seed: None,
+            classification: "cesium".into(),
         },
         JournalKey::Fabrication { output_seed: 456 },
     ];
@@ -668,49 +566,34 @@ fn journal_key_btreemap_ordering_is_stable() {
     use std::collections::BTreeMap;
     let mut map = BTreeMap::new();
     map.insert(JournalKey::Fabrication { output_seed: 1 }, "fab");
+    map.insert(JournalKey::MaterialInstance { seed: 99 }, "mat99");
+    map.insert(JournalKey::MaterialInstance { seed: 1 }, "mat1");
     map.insert(
         JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
+            classification: "cesium".into(),
         },
-        "mat99",
-    );
-    map.insert(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-        "mat1",
+        "mat-type-cesium",
     );
 
     let keys: Vec<_> = map.keys().collect();
-    // Derived Ord: enum variants ordered by declaration (Material < Fabrication),
-    // then by field values within each variant.
+    // Derived Ord: enum variants ordered by declaration order —
+    // MaterialInstance < Material < Fabrication — then by field values.
+    assert_eq!(*keys[0], JournalKey::MaterialInstance { seed: 1 });
+    assert_eq!(*keys[1], JournalKey::MaterialInstance { seed: 99 });
     assert_eq!(
-        *keys[0],
+        *keys[2],
         JournalKey::Material {
-            seed: 1,
-            planet_seed: None
+            classification: "cesium".into()
         }
     );
-    assert_eq!(
-        *keys[1],
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None
-        }
-    );
-    assert_eq!(*keys[2], JournalKey::Fabrication { output_seed: 1 });
+    assert_eq!(*keys[3], JournalKey::Fabrication { output_seed: 1 });
 }
 
 #[test]
 fn journal_shows_weight_observation_only_when_present() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 4,
-        planet_seed: None,
-    };
-    journal.record(
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 4 };
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -721,10 +604,10 @@ fn journal_shows_weight_observation_only_when_present() {
         },
     );
 
-    let without_weight = build_journal_text(&journal);
+    let without_weight = build_journal_text(&kg);
     assert!(!without_weight.contains("Carried: Heavy but manageable"));
 
-    journal.record(
+    kg.record(
         key,
         "Ferrite",
         Observation {
@@ -735,7 +618,7 @@ fn journal_shows_weight_observation_only_when_present() {
         },
     );
 
-    let with_weight = build_journal_text(&journal);
+    let with_weight = build_journal_text(&kg);
     assert!(with_weight.contains("Carried: Heavy but manageable"));
 }
 
@@ -743,12 +626,9 @@ fn journal_shows_weight_observation_only_when_present() {
 
 #[test]
 fn journal_entry_new_sets_timestamps() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let entry = JournalEntry::new(key.clone(), "Ferrite".into(), 100);
-    assert_eq!(entry.key, key);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let entry = ConceptNode::new(key.clone(), "Ferrite", 100);
+    assert_eq!(entry.id.0, key);
     assert_eq!(entry.name, "Ferrite");
     assert!(entry.observations.is_empty());
     assert_eq!(entry.first_observed_at, 100);
@@ -757,11 +637,8 @@ fn journal_entry_new_sets_timestamps() {
 
 #[test]
 fn journal_entry_add_observation_updates_timestamp() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -777,11 +654,8 @@ fn journal_entry_add_observation_updates_timestamp() {
 
 #[test]
 fn journal_entry_accumulates_multiple_observations() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -808,11 +682,8 @@ fn journal_entry_accumulates_multiple_observations() {
 
 #[test]
 fn journal_entry_observations_by_category() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -847,32 +718,52 @@ fn journal_entry_observations_by_category() {
 
 #[test]
 fn new_journal_ensure_entry_creates_and_retrieves() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
-    journal.ensure_entry(key.clone(), "Ferrite", 100);
-    journal.ensure_entry(key.clone(), "Ignored Name", 200);
+    // ensure_entry is gone; record() is idempotent for name (first wins)
+    // First call — creates the node
+    kg.record(
+        key.clone(),
+        "Ferrite",
+        Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: Confidence(0.2),
+            description: "obs".to_string(),
+            recorded_at: 100,
+        },
+    );
+    // Second call — same key, name ignored (first wins)
+    kg.record(
+        key.clone(),
+        "Ignored Name",
+        Observation {
+            category: ObservationCategory::SurfaceAppearance,
+            confidence: Confidence(0.2),
+            description: "obs2".to_string(),
+            recorded_at: 200,
+        },
+    );
 
-    assert_eq!(journal.entries.len(), 1);
-    let entry = journal.entries.get(&key).expect("entry should exist");
+    assert_eq!(kg.named_node_count(), 1);
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry should exist"),
+        )
+        .expect("node");
     // First name wins.
     assert_eq!(entry.name, "Ferrite");
-    // Timestamps unchanged by second ensure_entry call.
+    // first_observed_at set on creation tick
     assert_eq!(entry.first_observed_at, 100);
 }
 
 #[test]
 fn new_journal_record_accumulates_observations() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -882,7 +773,7 @@ fn new_journal_record_accumulates_observations() {
             recorded_at: 10,
         },
     );
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -893,7 +784,12 @@ fn new_journal_record_accumulates_observations() {
         },
     );
 
-    let entry = journal.entries.get(&key).expect("entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry should exist"),
+        )
+        .expect("node");
     assert_eq!(entry.observation_count(), 2);
     assert_eq!(entry.first_observed_at, 10);
     assert_eq!(entry.last_updated_at, 50);
@@ -901,14 +797,11 @@ fn new_journal_record_accumulates_observations() {
 
 #[test]
 fn new_journal_different_keys_coexist() {
-    let mut journal = Journal::default();
-    let mat_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let mat_key = JournalKey::MaterialInstance { seed: 1 };
     let fab_key = JournalKey::Fabrication { output_seed: 2 };
 
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Ferrite",
         Observation {
@@ -918,7 +811,7 @@ fn new_journal_different_keys_coexist() {
             recorded_at: 10,
         },
     );
-    journal.record(
+    kg.record(
         fab_key.clone(),
         "Neoite",
         Observation {
@@ -929,19 +822,16 @@ fn new_journal_different_keys_coexist() {
         },
     );
 
-    assert_eq!(journal.entries.len(), 2);
-    assert!(journal.entries.contains_key(&mat_key));
-    assert!(journal.entries.contains_key(&fab_key));
+    assert_eq!(kg.named_node_count(), 2);
+    assert!(kg.lookup(&ConceptId(mat_key.clone())).is_some());
+    assert!(kg.lookup(&ConceptId(fab_key.clone())).is_some());
 }
 
 #[test]
 fn new_journal_serde_round_trip() {
-    let mut journal = Journal::default();
-    journal.record(
-        JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        },
+    let mut kg = KnowledgeGraph::default();
+    kg.record(
+        JournalKey::MaterialInstance { seed: 42 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -950,7 +840,7 @@ fn new_journal_serde_round_trip() {
             recorded_at: 10,
         },
     );
-    journal.record(
+    kg.record(
         JournalKey::Fabrication { output_seed: 99 },
         "Neoite",
         Observation {
@@ -961,18 +851,18 @@ fn new_journal_serde_round_trip() {
         },
     );
 
-    let json = serde_json::to_string(&journal).expect("Journal should serialize to JSON");
-    let deserialized: Journal =
-        serde_json::from_str(&json).expect("Journal should deserialize from JSON");
+    let json = serde_json::to_string(&kg).expect("KG should serialize to JSON");
+    let deserialized: KnowledgeGraph =
+        serde_json::from_str(&json).expect("KnowledgeGraph should deserialize from JSON");
 
-    assert_eq!(deserialized.entries.len(), 2);
+    assert_eq!(deserialized.named_node_count(), 2);
     let ferrite = deserialized
-        .entries
-        .get(&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        })
-        .expect("Ferrite entry should exist");
+        .node(
+            deserialized
+                .lookup(&ConceptId(JournalKey::MaterialInstance { seed: 42 }))
+                .expect("Ferrite entry should exist"),
+        )
+        .expect("node");
     assert_eq!(ferrite.name, "Ferrite");
     assert_eq!(ferrite.observation_count(), 1);
     assert_eq!(ferrite.first_observed_at, 10);
@@ -980,26 +870,23 @@ fn new_journal_serde_round_trip() {
 
 #[test]
 fn new_journal_empty_default() {
-    let journal = Journal::default();
-    assert!(journal.entries.is_empty());
+    let kg = KnowledgeGraph::default();
+    assert!((kg.named_node_count() == 0));
 }
 
 #[test]
 fn empty_journal_renders_no_observations_yet() {
-    let journal = Journal::default();
-    let text = build_journal_text(&journal);
+    let kg = KnowledgeGraph::default();
+    let text = build_journal_text(&kg);
     assert_eq!(text, "Journal\n\nNo observations yet.");
 }
 
 #[test]
 fn single_observation_recorded_correctly() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 55,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 55 };
 
-    journal.record(
+    kg.record(
         key.clone(),
         "Quarite",
         Observation {
@@ -1011,11 +898,16 @@ fn single_observation_recorded_correctly() {
     );
 
     // Exactly one entry created for the key.
-    assert_eq!(journal.entries.len(), 1);
-    let entry = journal.entries.get(&key).expect("entry should exist");
+    assert_eq!(kg.named_node_count(), 1);
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry should exist"),
+        )
+        .expect("node");
 
     // Entry metadata is correct.
-    assert_eq!(entry.key, key);
+    assert_eq!(entry.id.0, key);
     assert_eq!(entry.name, "Quarite");
     assert_eq!(entry.first_observed_at, 42);
     assert_eq!(entry.last_updated_at, 42);
@@ -1031,11 +923,8 @@ fn single_observation_recorded_correctly() {
 
 #[test]
 fn duplicate_observation_same_category_and_description_is_skipped() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -1058,11 +947,8 @@ fn duplicate_observation_same_category_and_description_is_skipped() {
 
 #[test]
 fn duplicate_observation_upgrades_confidence() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::ThermalBehavior,
@@ -1089,11 +975,8 @@ fn duplicate_observation_upgrades_confidence() {
 
 #[test]
 fn duplicate_does_not_downgrade_confidence() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::Weight,
@@ -1123,11 +1006,8 @@ fn duplicate_does_not_downgrade_confidence() {
 /// be preserved (or upgraded if the second look is stronger).
 #[test]
 fn examine_same_material_twice_does_not_duplicate() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     let observation = Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -1137,10 +1017,10 @@ fn examine_same_material_twice_does_not_duplicate() {
     };
 
     // First examination.
-    journal.record(key.clone(), "Ferrite", observation.clone());
+    kg.record(key.clone(), "Ferrite", observation.clone());
 
     // Second examination — identical observation at a later tick.
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -1151,8 +1031,13 @@ fn examine_same_material_twice_does_not_duplicate() {
         },
     );
 
-    assert_eq!(journal.entries.len(), 1, "only one entry for the material");
-    let entry = journal.entries.get(&key).expect("entry must exist");
+    assert_eq!(kg.named_node_count(), 1, "only one entry for the material");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry must exist"),
+        )
+        .expect("node");
     assert_eq!(
         entry.observation_count(),
         1,
@@ -1165,13 +1050,10 @@ fn examine_same_material_twice_does_not_duplicate() {
 /// confidence upgrades the stored observation without duplicating it.
 #[test]
 fn examine_same_material_twice_upgrades_confidence() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -1183,7 +1065,7 @@ fn examine_same_material_twice_upgrades_confidence() {
     );
 
     // Second examination — same description, higher confidence.
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -1194,8 +1076,13 @@ fn examine_same_material_twice_upgrades_confidence() {
         },
     );
 
-    assert_eq!(journal.entries.len(), 1);
-    let entry = journal.entries.get(&key).expect("entry must exist");
+    assert_eq!(kg.named_node_count(), 1);
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry must exist"),
+        )
+        .expect("node");
     assert_eq!(entry.observation_count(), 1);
     assert_eq!(
         entry.observations_by_category(&ObservationCategory::SurfaceAppearance)[0].confidence,
@@ -1206,11 +1093,8 @@ fn examine_same_material_twice_upgrades_confidence() {
 
 #[test]
 fn same_category_different_description_is_not_duplicate() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -1236,11 +1120,8 @@ fn same_category_different_description_is_not_duplicate() {
 
 #[test]
 fn same_description_different_category_is_not_duplicate() {
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let mut entry = JournalEntry::new(key, "Ferrite".into(), 10);
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    let mut entry = ConceptNode::new(key, "Ferrite", 10);
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
@@ -1269,14 +1150,11 @@ fn same_description_different_category_is_not_duplicate() {
 /// observation preserves its own category, confidence, and description.
 #[test]
 fn multiple_observations_for_same_key_accumulate() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 77,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 77 };
 
     // First observation — creates the entry.
-    journal.record(
+    kg.record(
         key.clone(),
         "Volite",
         Observation {
@@ -1288,7 +1166,7 @@ fn multiple_observations_for_same_key_accumulate() {
     );
 
     // Second observation — same key, different category.
-    journal.record(
+    kg.record(
         key.clone(),
         "Volite",
         Observation {
@@ -1300,7 +1178,7 @@ fn multiple_observations_for_same_key_accumulate() {
     );
 
     // Third observation — same key, same category as first but different description.
-    journal.record(
+    kg.record(
         key.clone(),
         "Volite",
         Observation {
@@ -1312,7 +1190,7 @@ fn multiple_observations_for_same_key_accumulate() {
     );
 
     // Fourth observation — same key, yet another category.
-    journal.record(
+    kg.record(
         key.clone(),
         "Volite",
         Observation {
@@ -1324,7 +1202,7 @@ fn multiple_observations_for_same_key_accumulate() {
     );
 
     // Fifth observation — fabrication result recorded against the same material key.
-    journal.record(
+    kg.record(
         key.clone(),
         "Volite",
         Observation {
@@ -1336,8 +1214,13 @@ fn multiple_observations_for_same_key_accumulate() {
     );
 
     // Only one entry exists for the key.
-    assert_eq!(journal.entries.len(), 1, "all observations share one entry");
-    let entry = journal.entries.get(&key).expect("entry should exist");
+    assert_eq!(kg.named_node_count(), 1, "all observations share one entry");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("entry should exist"),
+        )
+        .expect("node");
 
     // Name set by the first record call is retained.
     assert_eq!(entry.name, "Volite");
@@ -1390,21 +1273,15 @@ fn multiple_observations_for_same_key_accumulate() {
 fn all_types_serde_round_trip() {
     // ── JournalKey variants ─────────────────────────────────────
     let keys = vec![
+        JournalKey::MaterialInstance { seed: 0 },
+        JournalKey::MaterialInstance { seed: u64::MAX },
+        JournalKey::MaterialInstance { seed: 1 },
+        JournalKey::MaterialInstance { seed: 7 },
         JournalKey::Material {
-            seed: 0,
-            planet_seed: None,
+            classification: "cesium".into(),
         },
         JournalKey::Material {
-            seed: u64::MAX,
-            planet_seed: None,
-        },
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
-        JournalKey::Material {
-            seed: 7,
-            planet_seed: Some(u64::MAX),
+            classification: "ferrite".into(),
         },
         JournalKey::Fabrication { output_seed: 42 },
     ];
@@ -1452,11 +1329,8 @@ fn all_types_serde_round_trip() {
     assert_eq!(rt.recorded_at, observation.recorded_at);
 
     // ── JournalEntry struct ─────────────────────────────────────
-    let mut entry = JournalEntry::new(
-        JournalKey::Material {
-            seed: 7,
-            planet_seed: None,
-        },
+    let mut entry = ConceptNode::new(
+        JournalKey::MaterialInstance { seed: 7 },
         "Ferrite".into(),
         10,
     );
@@ -1474,8 +1348,8 @@ fn all_types_serde_round_trip() {
     });
 
     let json = serde_json::to_string(&entry).expect("JournalEntry should serialize");
-    let rt: JournalEntry = serde_json::from_str(&json).expect("JournalEntry should deserialize");
-    assert_eq!(rt.key, entry.key);
+    let rt: ConceptNode = serde_json::from_str(&json).expect("JournalEntry should deserialize");
+    assert_eq!(rt.id.0, entry.id.0);
     assert_eq!(rt.name, entry.name);
     assert_eq!(rt.observation_count(), 2);
     assert_eq!(rt.first_observed_at, entry.first_observed_at);
@@ -1492,14 +1366,11 @@ fn all_types_serde_round_trip() {
     );
 
     // ── Journal with all key types and all categories ────────
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Material entry with surface, thermal, and weight observations.
-    let mat_key = JournalKey::Material {
-        seed: 100,
-        planet_seed: None,
-    };
-    journal.record(
+    let mat_key = JournalKey::MaterialInstance { seed: 100 };
+    kg.record(
         mat_key.clone(),
         "Silite",
         Observation {
@@ -1509,7 +1380,7 @@ fn all_types_serde_round_trip() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Silite",
         Observation {
@@ -1519,7 +1390,7 @@ fn all_types_serde_round_trip() {
             recorded_at: 5,
         },
     );
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Silite",
         Observation {
@@ -1532,7 +1403,7 @@ fn all_types_serde_round_trip() {
 
     // Fabrication entry with fabrication result and location note.
     let fab_key = JournalKey::Fabrication { output_seed: 200 };
-    journal.record(
+    kg.record(
         fab_key.clone(),
         "Neoite",
         Observation {
@@ -1542,7 +1413,7 @@ fn all_types_serde_round_trip() {
             recorded_at: 10,
         },
     );
-    journal.record(
+    kg.record(
         fab_key.clone(),
         "Neoite",
         Observation {
@@ -1553,16 +1424,18 @@ fn all_types_serde_round_trip() {
         },
     );
 
-    let json = serde_json::to_string(&journal).expect("Journal should serialize");
-    let rt: Journal = serde_json::from_str(&json).expect("Journal should deserialize");
+    let json = serde_json::to_string(&kg).expect("Journal should serialize");
+    let rt: KnowledgeGraph = serde_json::from_str(&json).expect("KG should deserialize");
 
     // Verify structure preserved.
-    assert_eq!(rt.entries.len(), 2);
+    assert_eq!(rt.named_node_count(), 2);
 
-    let silite = rt
-        .entries
-        .get(&mat_key)
-        .expect("Material entry should exist");
+    let silite = kg
+        .node(
+            kg.lookup(&ConceptId(mat_key.clone()))
+                .expect("Material entry should exist"),
+        )
+        .expect("node");
     assert_eq!(silite.name, "Silite");
     assert_eq!(silite.observation_count(), 3);
     assert_eq!(silite.first_observed_at, 1);
@@ -1590,10 +1463,12 @@ fn all_types_serde_round_trip() {
         1
     );
 
-    let neoite = rt
-        .entries
-        .get(&fab_key)
-        .expect("Fabrication entry should exist");
+    let neoite = kg
+        .node(
+            kg.lookup(&ConceptId(fab_key.clone()))
+                .expect("Fabrication entry should exist"),
+        )
+        .expect("node");
     assert_eq!(neoite.name, "Neoite");
     assert_eq!(neoite.observation_count(), 2);
     assert_eq!(neoite.first_observed_at, 10);
@@ -1626,23 +1501,17 @@ fn all_types_serde_round_trip() {
 /// the same observation category is used for multiple subjects.
 #[test]
 fn different_keys_stored_independently() {
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Three keys: two Material keys with different seeds and one
     // Fabrication key whose output_seed numerically equals the first
     // Material seed (verifies variant-level isolation).
-    let mat_a = JournalKey::Material {
-        seed: 10,
-        planet_seed: None,
-    };
-    let mat_b = JournalKey::Material {
-        seed: 20,
-        planet_seed: None,
-    };
+    let mat_a = JournalKey::MaterialInstance { seed: 10 };
+    let mat_b = JournalKey::MaterialInstance { seed: 20 };
     let fab_a = JournalKey::Fabrication { output_seed: 10 };
 
     // Record a surface observation on material A.
-    journal.record(
+    kg.record(
         mat_a.clone(),
         "Ferrite",
         Observation {
@@ -1654,7 +1523,7 @@ fn different_keys_stored_independently() {
     );
 
     // Record a surface observation on material B (same category, different key).
-    journal.record(
+    kg.record(
         mat_b.clone(),
         "Silite",
         Observation {
@@ -1666,7 +1535,7 @@ fn different_keys_stored_independently() {
     );
 
     // Record a fabrication result on fab_a (same numeric id as mat_a).
-    journal.record(
+    kg.record(
         fab_a.clone(),
         "Neoite",
         Observation {
@@ -1679,7 +1548,7 @@ fn different_keys_stored_independently() {
 
     // Add a second observation to material A to verify accumulation is
     // scoped to that key alone.
-    journal.record(
+    kg.record(
         mat_a.clone(),
         "Ferrite",
         Observation {
@@ -1692,16 +1561,18 @@ fn different_keys_stored_independently() {
 
     // ── Verify entry count ──────────────────────────────────────
     assert_eq!(
-        journal.entries.len(),
+        kg.named_node_count(),
         3,
         "three distinct keys = three entries"
     );
 
     // ── Verify material A ───────────────────────────────────────
-    let entry_a = journal
-        .entries
-        .get(&mat_a)
-        .expect("mat_a entry should exist");
+    let entry_a = kg
+        .node(
+            kg.lookup(&ConceptId(mat_a.clone()))
+                .expect("mat_a entry should exist"),
+        )
+        .expect("node");
     assert_eq!(entry_a.name, "Ferrite");
     assert_eq!(entry_a.observation_count(), 2);
     assert_eq!(entry_a.first_observed_at, 1);
@@ -1718,10 +1589,12 @@ fn different_keys_stored_independently() {
     );
 
     // ── Verify material B ───────────────────────────────────────
-    let entry_b = journal
-        .entries
-        .get(&mat_b)
-        .expect("mat_b entry should exist");
+    let entry_b = kg
+        .node(
+            kg.lookup(&ConceptId(mat_b.clone()))
+                .expect("mat_b entry should exist"),
+        )
+        .expect("node");
     assert_eq!(entry_b.name, "Silite");
     assert_eq!(entry_b.observation_count(), 1);
     assert_eq!(entry_b.first_observed_at, 2);
@@ -1732,10 +1605,12 @@ fn different_keys_stored_independently() {
     );
 
     // ── Verify fabrication A (same numeric id as mat_a) ─────────
-    let entry_fab = journal
-        .entries
-        .get(&fab_a)
-        .expect("fab_a entry should exist");
+    let entry_fab = kg
+        .node(
+            kg.lookup(&ConceptId(fab_a.clone()))
+                .expect("fab_a entry should exist"),
+        )
+        .expect("node");
     assert_eq!(entry_fab.name, "Neoite");
     assert_eq!(entry_fab.observation_count(), 1);
     assert_eq!(entry_fab.first_observed_at, 3);
@@ -1786,15 +1661,12 @@ fn different_keys_stored_independently() {
 /// information appears in the output.
 #[test]
 fn rendered_text_contains_same_information_as_legacy_journal() {
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // ── Material entry with surface, thermal, and weight observations ──
-    let mat_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mat_key = JournalKey::MaterialInstance { seed: 42 };
 
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Ferrite",
         Observation {
@@ -1804,7 +1676,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Ferrite",
         Observation {
@@ -1814,7 +1686,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
             recorded_at: 2,
         },
     );
-    journal.record(
+    kg.record(
         mat_key.clone(),
         "Ferrite",
         Observation {
@@ -1824,7 +1696,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
             recorded_at: 3,
         },
     );
-    journal.record(
+    kg.record(
         mat_key,
         "Ferrite",
         Observation {
@@ -1838,11 +1710,8 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
     // ── Second material with only surface observation ───────────────
     // Legacy equivalent: entry with surface_observations only (no thermal
     // or weight).
-    let mat_key_b = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
-    journal.record(
+    let mat_key_b = JournalKey::MaterialInstance { seed: 99 };
+    kg.record(
         mat_key_b,
         "Silite",
         Observation {
@@ -1855,7 +1724,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
 
     // ── Fabrication entry ───────────────────────────────────────────
     let fab_key = JournalKey::Fabrication { output_seed: 200 };
-    journal.record(
+    kg.record(
         fab_key,
         "Neoite",
         Observation {
@@ -1866,7 +1735,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         },
     );
 
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
 
     // ── Header ──────────────────────────────────────────────────────
     assert!(
@@ -1946,8 +1815,8 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
 /// journal simply displayed a header with no entries.
 #[test]
 fn empty_journal_renders_placeholder_text() {
-    let journal = Journal::default();
-    let text = build_journal_text(&journal);
+    let kg = KnowledgeGraph::default();
+    let text = build_journal_text(&kg);
     assert!(
         text.contains("Journal"),
         "empty journal must still show header"
@@ -1973,7 +1842,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
 
     let confidences = [Confidence(0.2), Confidence(0.5), Confidence(0.8)];
 
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Record 120 entries: 80 Material keys and 40 Fabrication keys,
     // each with between 1 and 3 observations across different categories.
@@ -1981,10 +1850,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         let key = if i % 3 == 0 {
             JournalKey::Fabrication { output_seed: i }
         } else {
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            }
+            JournalKey::MaterialInstance { seed: i }
         };
 
         let name = format!("Subject-{i}");
@@ -1993,7 +1859,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         // Primary observation — category and confidence rotate through variants.
         let primary_cat = &categories[i as usize % categories.len()];
         let primary_conf = confidences[i as usize % confidences.len()];
-        journal.record(
+        kg.record(
             key.clone(),
             &name,
             Observation {
@@ -2007,7 +1873,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         // Every other entry gets a second observation in a different category.
         if i % 2 == 0 {
             let secondary_cat = &categories[(i as usize + 1) % categories.len()];
-            journal.record(
+            kg.record(
                 key.clone(),
                 &name,
                 Observation {
@@ -2022,7 +1888,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         // Every third entry gets a third observation (same category as
         // primary but different description — should not deduplicate).
         if i % 3 == 0 {
-            journal.record(
+            kg.record(
                 key.clone(),
                 &name,
                 Observation {
@@ -2037,20 +1903,24 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
 
     // Verify entry count.
     assert!(
-        journal.entries.len() >= 100,
+        kg.named_node_count() >= 100,
         "expected at least 100 entries, got {}",
-        journal.entries.len()
+        kg.named_node_count()
     );
 
     // Verify both key types are present.
-    let material_count = journal
-        .entries
-        .keys()
-        .filter(|k| matches!(k, JournalKey::Material { .. }))
+    let material_count = kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter_map(|i| kg.node(i))
+        .map(|n| &n.id.0)
+        .filter(|k| matches!(k, JournalKey::MaterialInstance { .. }))
         .count();
-    let fabrication_count = journal
-        .entries
-        .keys()
+    let fabrication_count = kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter_map(|i| kg.node(i))
+        .map(|n| &n.id.0)
         .filter(|k| matches!(k, JournalKey::Fabrication { .. }))
         .count();
     assert!(material_count > 0, "must contain Material entries");
@@ -2058,7 +1928,11 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
 
     // Verify all five observation categories are represented.
     let mut seen_categories = std::collections::HashSet::new();
-    for entry in journal.entries.values() {
+    for entry in kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter_map(|i| kg.node(i))
+    {
         for cat in entry.observations.keys() {
             seen_categories.insert(cat.clone());
         }
@@ -2071,16 +1945,16 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
     }
 
     // Rendering must not panic.
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
     assert!(!text.is_empty(), "rendered text must not be empty");
 
     // Serde round-trip must not panic or lose entries.
-    let serialized = serde_json::to_string(&journal).expect("journal must serialize");
-    let deserialized: Journal =
-        serde_json::from_str(&serialized).expect("journal must deserialize");
+    let serialized = serde_json::to_string(&kg).expect("kg must serialize");
+    let deserialized: KnowledgeGraph =
+        serde_json::from_str(&serialized).expect("kg must deserialize");
     assert_eq!(
-        journal.entries.len(),
-        deserialized.entries.len(),
+        kg.named_node_count(),
+        deserialized.named_node_count(),
         "round-trip must preserve entry count"
     );
 }
@@ -2091,14 +1965,11 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
 /// own observations.
 #[test]
 fn multiple_materials_have_separate_entries_and_rendering() {
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // ── Material 1: Ferrite ─────────────────────────────────────
-    let key_ferrite = JournalKey::Material {
-        seed: 10,
-        planet_seed: None,
-    };
-    journal.record(
+    let key_ferrite = JournalKey::MaterialInstance { seed: 10 };
+    kg.record(
         key_ferrite.clone(),
         "Ferrite",
         Observation {
@@ -2108,7 +1979,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         key_ferrite.clone(),
         "Ferrite",
         Observation {
@@ -2120,11 +1991,8 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 2: Silite ──────────────────────────────────────
-    let key_silite = JournalKey::Material {
-        seed: 20,
-        planet_seed: None,
-    };
-    journal.record(
+    let key_silite = JournalKey::MaterialInstance { seed: 20 };
+    kg.record(
         key_silite.clone(),
         "Silite",
         Observation {
@@ -2134,7 +2002,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
             recorded_at: 3,
         },
     );
-    journal.record(
+    kg.record(
         key_silite.clone(),
         "Silite",
         Observation {
@@ -2146,11 +2014,8 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 3: Volite ──────────────────────────────────────
-    let key_volite = JournalKey::Material {
-        seed: 30,
-        planet_seed: None,
-    };
-    journal.record(
+    let key_volite = JournalKey::MaterialInstance { seed: 30 };
+    kg.record(
         key_volite.clone(),
         "Volite",
         Observation {
@@ -2160,7 +2025,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
             recorded_at: 5,
         },
     );
-    journal.record(
+    kg.record(
         key_volite.clone(),
         "Volite",
         Observation {
@@ -2170,7 +2035,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
             recorded_at: 6,
         },
     );
-    journal.record(
+    kg.record(
         key_volite.clone(),
         "Volite",
         Observation {
@@ -2182,11 +2047,8 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Material 4: Crystite (ensures "3+" is exceeded) ─────────
-    let key_crystite = JournalKey::Material {
-        seed: 40,
-        planet_seed: None,
-    };
-    journal.record(
+    let key_crystite = JournalKey::MaterialInstance { seed: 40 };
+    kg.record(
         key_crystite.clone(),
         "Crystite",
         Observation {
@@ -2198,26 +2060,34 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Verify entry separation ─────────────────────────────────
-    assert_eq!(journal.entries.len(), 4, "four distinct material entries");
-    assert!(journal.entries.contains_key(&key_ferrite));
-    assert!(journal.entries.contains_key(&key_silite));
-    assert!(journal.entries.contains_key(&key_volite));
-    assert!(journal.entries.contains_key(&key_crystite));
+    assert_eq!(kg.named_node_count(), 4, "four distinct material entries");
+    assert!(kg.lookup(&ConceptId(key_ferrite.clone())).is_some());
+    assert!(kg.lookup(&ConceptId(key_silite.clone())).is_some());
+    assert!(kg.lookup(&ConceptId(key_volite.clone())).is_some());
+    assert!(kg.lookup(&ConceptId(key_crystite.clone())).is_some());
 
     // ── Verify observation counts per entry ─────────────────────
-    let ferrite = journal.entries.get(&key_ferrite).unwrap();
+    let ferrite = kg
+        .node(kg.lookup(&ConceptId(key_ferrite.clone())).unwrap())
+        .unwrap();
     assert_eq!(ferrite.observation_count(), 2);
     assert_eq!(ferrite.name, "Ferrite");
 
-    let silite = journal.entries.get(&key_silite).unwrap();
+    let silite = kg
+        .node(kg.lookup(&ConceptId(key_silite.clone())).unwrap())
+        .unwrap();
     assert_eq!(silite.observation_count(), 2);
     assert_eq!(silite.name, "Silite");
 
-    let volite = journal.entries.get(&key_volite).unwrap();
+    let volite = kg
+        .node(kg.lookup(&ConceptId(key_volite.clone())).unwrap())
+        .unwrap();
     assert_eq!(volite.observation_count(), 3);
     assert_eq!(volite.name, "Volite");
 
-    let crystite = journal.entries.get(&key_crystite).unwrap();
+    let crystite = kg
+        .node(kg.lookup(&ConceptId(key_crystite.clone())).unwrap())
+        .unwrap();
     assert_eq!(crystite.observation_count(), 1);
     assert_eq!(crystite.name, "Crystite");
 
@@ -2251,7 +2121,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
     );
 
     // ── Verify rendering shows all four materials separated ─────
-    let text = build_journal_text(&journal);
+    let text = build_journal_text(&kg);
 
     // All material names appear.
     assert!(text.contains("Ferrite"));
@@ -2297,15 +2167,12 @@ fn multiple_materials_have_separate_entries_and_rendering() {
 // ── Two-panel rendering tests ───────────────────────────────────
 
 /// Helper: create a journal with N material entries named alphabetically.
-fn make_journal_with_n_entries(n: usize) -> Journal {
-    let mut journal = Journal::default();
+fn make_kg_with_n_entries(n: usize) -> KnowledgeGraph {
+    let mut kg = KnowledgeGraph::default();
     for i in 0..n {
-        let key = JournalKey::Material {
-            seed: i as u64,
-            planet_seed: None,
-        };
+        let key = JournalKey::MaterialInstance { seed: i as u64 };
         let name = format!("Material-{i:03}");
-        journal.record(
+        kg.record(
             key,
             &name,
             Observation {
@@ -2316,17 +2183,13 @@ fn make_journal_with_n_entries(n: usize) -> Journal {
             },
         );
     }
-    journal
+    kg
 }
 
 #[test]
 fn entry_list_shows_selected_entry_with_prefix() {
-    let journal = make_journal_with_n_entries(3);
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let kg = make_kg_with_n_entries(3);
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     let state = JournalUiState {
         visible: true,
@@ -2334,11 +2197,9 @@ fn entry_list_shows_selected_entry_with_prefix() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
-    let list = build_entry_list_text(&entries, &state);
+    let list = build_entry_list_text(&nodes, &kg, &state);
     let lines: Vec<&str> = list.lines().collect();
     assert_eq!(lines.len(), 3);
     assert!(
@@ -2354,12 +2215,9 @@ fn entry_list_shows_selected_entry_with_prefix() {
 
 #[test]
 fn entry_list_shows_observation_count() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    journal.record(
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -2369,7 +2227,7 @@ fn entry_list_shows_observation_count() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         key,
         "Ferrite",
         Observation {
@@ -2380,9 +2238,9 @@ fn entry_list_shows_observation_count() {
         },
     );
 
-    let entries: Vec<&JournalEntry> = journal.entries.values().collect();
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
     let state = JournalUiState::default();
-    let list = build_entry_list_text(&entries, &state);
+    let list = build_entry_list_text(&nodes, &kg, &state);
     assert!(
         list.contains("(2 obs)"),
         "entry list should show observation count"
@@ -2391,12 +2249,9 @@ fn entry_list_shows_observation_count() {
 
 #[test]
 fn detail_shows_selected_entry_observations() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    journal.record(
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    kg.record(
         key,
         "Ferrite",
         Observation {
@@ -2407,11 +2262,7 @@ fn detail_shows_selected_entry_observations() {
         },
     );
 
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     let state = JournalUiState {
         visible: true,
@@ -2419,11 +2270,14 @@ fn detail_shows_selected_entry_observations() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
+    let detail = {
+        let selected_node = nodes
+            .get(state.selected_index)
+            .and_then(|&idx| kg.node(idx));
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
+    };
     assert!(detail.contains("Ferrite"), "detail should show entry name");
     assert!(
         detail.contains("Surface"),
@@ -2437,30 +2291,23 @@ fn detail_shows_selected_entry_observations() {
 
 #[test]
 fn detail_empty_journal_shows_placeholder() {
-    let state = JournalUiState::default();
-    let entries: Vec<&JournalEntry> = vec![];
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, false));
+    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, false, None));
     assert_eq!(detail, "No observations yet.");
 }
 
 #[test]
 fn detail_filtered_empty_shows_no_matching_entries() {
-    let state = JournalUiState::default();
-    let entries: Vec<&JournalEntry> = vec![];
     // has_any_entries = true simulates the case where the journal has entries
     // but the current filter produces no results
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
+    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, true, None));
     assert_eq!(detail, "No matching entries");
 }
 
 #[test]
 fn detail_spans_have_correct_kinds() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    journal.record(
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 1 };
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -2470,7 +2317,7 @@ fn detail_spans_have_correct_kinds() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         key,
         "Ferrite",
         Observation {
@@ -2481,11 +2328,7 @@ fn detail_spans_have_correct_kinds() {
         },
     );
 
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     let state = JournalUiState {
         visible: true,
@@ -2493,11 +2336,12 @@ fn detail_spans_have_correct_kinds() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
-    let spans = build_detail_spans(&entries, &state, true);
+    let selected_node = nodes
+        .get(state.selected_index)
+        .and_then(|&idx| kg.node(idx));
+    let spans = build_detail_spans(selected_node, true, None);
     // First span: header with entry name.
     assert_eq!(spans[0].kind, DetailSpanKind::Header);
     assert_eq!(spans[0].text, "Ferrite");
@@ -2519,23 +2363,18 @@ fn detail_spans_have_correct_kinds() {
 
 #[test]
 fn detail_placeholder_span_kind() {
-    let state = JournalUiState::default();
-    let entries: Vec<&JournalEntry> = vec![];
-    let spans = build_detail_spans(&entries, &state, false);
+    let spans = build_detail_spans(None::<&ConceptNode>, false, None);
     assert_eq!(spans.len(), 1);
     assert_eq!(spans[0].kind, DetailSpanKind::Placeholder);
 }
 
 #[test]
 fn detail_panel_shows_correct_observations_for_selected_entry() {
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Create three entries with distinct observations.
-    journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 1 },
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2544,11 +2383,8 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
             recorded_at: 1,
         },
     );
-    journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 2 },
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2557,11 +2393,8 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
             recorded_at: 2,
         },
     );
-    journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 3 },
         "Neoite",
         Observation {
             category: ObservationCategory::Weight,
@@ -2571,15 +2404,11 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         },
     );
 
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
     // Sorted alphabetically: Ferrite, Neoite, Silite
-    assert_eq!(entries[0].name, "Ferrite");
-    assert_eq!(entries[1].name, "Neoite");
-    assert_eq!(entries[2].name, "Silite");
+    assert_eq!(kg.node(nodes[0]).map(|n| n.name.as_str()), Some("Ferrite"));
+    assert_eq!(kg.node(nodes[1]).map(|n| n.name.as_str()), Some("Neoite"));
+    assert_eq!(kg.node(nodes[2]).map(|n| n.name.as_str()), Some("Silite"));
 
     // Select first entry (Ferrite) — detail should show Ferrite's observations.
     let state = JournalUiState {
@@ -2588,10 +2417,13 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
+    let detail = {
+        let selected_node = nodes
+            .get(state.selected_index)
+            .and_then(|&idx| kg.node(idx));
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
+    };
     assert!(detail.contains("Ferrite"), "header should be Ferrite");
     assert!(
         detail.contains("Warm rust tone"),
@@ -2613,10 +2445,13 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
+    let detail = {
+        let selected_node = nodes
+            .get(state.selected_index)
+            .and_then(|&idx| kg.node(idx));
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
+    };
     assert!(detail.contains("Neoite"), "header should be Neoite");
     assert!(
         detail.contains("Surprisingly light"),
@@ -2638,10 +2473,13 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let detail = detail_spans_to_string(&build_detail_spans(&entries, &state, true));
+    let detail = {
+        let selected_node = nodes
+            .get(state.selected_index)
+            .and_then(|&idx| kg.node(idx));
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
+    };
     assert!(detail.contains("Silite"), "header should be Silite");
     assert!(
         detail.contains("Glassy smooth surface"),
@@ -2659,13 +2497,10 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
 
 #[test]
 fn detail_panel_shows_all_observations_for_multi_category_entry() {
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 1 };
 
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -2675,7 +2510,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
             recorded_at: 1,
         },
     );
-    journal.record(
+    kg.record(
         key.clone(),
         "Ferrite",
         Observation {
@@ -2685,7 +2520,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
             recorded_at: 2,
         },
     );
-    journal.record(
+    kg.record(
         key,
         "Ferrite",
         Observation {
@@ -2697,11 +2532,8 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
     );
 
     // Add a second entry to confirm isolation.
-    journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 2 },
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -2711,11 +2543,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         },
     );
 
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     // Select Ferrite (index 0).
     let state = JournalUiState {
@@ -2724,10 +2552,11 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let spans = build_detail_spans(&entries, &state, true);
+    let selected_node = nodes
+        .get(state.selected_index)
+        .and_then(|&idx| kg.node(idx));
+    let spans = build_detail_spans(selected_node, true, None);
     let detail = detail_spans_to_string(&spans);
 
     // Should contain the header.
@@ -2765,8 +2594,6 @@ fn navigation_clamp_up_from_first_stays_at_first() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate pressing up — selection would go to saturating_sub(1) = 0.
     state.selected_index = state.selected_index.saturating_sub(1);
@@ -2782,8 +2609,6 @@ fn navigation_clamp_down_from_last_stays_at_last() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.selected_index = (state.selected_index + 1).min(4);
     state.clamp_to_entry_count(5);
@@ -2798,8 +2623,6 @@ fn scroll_offset_adjusts_when_selection_moves_past_visible_range() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Move selection to index 4 (past the 3-entry window).
     state.selected_index = 4;
@@ -2820,8 +2643,6 @@ fn scroll_offset_adjusts_when_selection_moves_above_visible_range() {
         scroll_offset: 3,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(10);
     assert_eq!(
@@ -2838,8 +2659,6 @@ fn page_down_moves_selection_by_entries_per_page() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate PageDown: advance by entries_per_page.
     state.selected_index = (state.selected_index + state.entries_per_page).min(20 - 1);
@@ -2857,8 +2676,6 @@ fn page_down_clamps_to_last_entry() {
         scroll_offset: 5,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let entry_count = 10;
     // PageDown from index 8 with page size 5 would overshoot — should clamp to 9.
@@ -2875,8 +2692,6 @@ fn page_up_moves_selection_by_entries_per_page() {
         scroll_offset: 10,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate PageUp: go back by entries_per_page.
     state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
@@ -2895,8 +2710,6 @@ fn page_up_clamps_to_first_entry() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // PageUp from index 2 with page size 5 would underflow — saturating_sub clamps to 0.
     state.selected_index = state.selected_index.saturating_sub(state.entries_per_page);
@@ -2913,8 +2726,6 @@ fn home_jumps_to_first_entry() {
         scroll_offset: 30,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // Simulate Home key — sets selected_index to 0.
     state.selected_index = 0;
@@ -2931,8 +2742,6 @@ fn end_jumps_to_last_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     let entry_count = 50;
     // Simulate End key — sets selected_index to last entry.
@@ -2951,8 +2760,6 @@ fn page_down_adjusts_scroll_offset_past_visible_range() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     // PageDown jumps selection to index 3, which is outside window [0..3).
     state.selected_index = (state.selected_index + state.entries_per_page).min(10 - 1);
@@ -2972,8 +2779,6 @@ fn clamp_to_entry_count_zero_entries() {
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(0);
     assert_eq!(state.selected_index, 0);
@@ -2982,12 +2787,8 @@ fn clamp_to_entry_count_zero_entries() {
 
 #[test]
 fn entry_list_respects_scroll_offset_and_page_size() {
-    let journal = make_journal_with_n_entries(20);
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let kg = make_kg_with_n_entries(20);
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     let state = JournalUiState {
         visible: true,
@@ -2995,11 +2796,9 @@ fn entry_list_respects_scroll_offset_and_page_size() {
         scroll_offset: 3,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
-    let list = build_entry_list_text(&entries, &state);
+    let list = build_entry_list_text(&nodes, &kg, &state);
     let lines: Vec<&str> = list.lines().collect();
     assert_eq!(lines.len(), 5, "should show exactly entries_per_page lines");
     // The selected entry (index 5) is at position 5-3=2 in the visible window.
@@ -3017,10 +2816,8 @@ fn help_text_shows_page_indicator() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help = build_help_text(42, &state);
+    let help = build_help_text(42, &state, 0);
     assert!(
         help.contains("[1-15 of 42]"),
         "help should show page indicator, got: {help}"
@@ -3030,7 +2827,7 @@ fn help_text_shows_page_indicator() {
 #[test]
 fn help_text_empty_journal() {
     let state = JournalUiState::default();
-    let help = build_help_text(0, &state);
+    let help = build_help_text(0, &state, 0);
     assert!(help.contains("J: Close"), "help should show close hint");
     assert!(
         !help.contains("Navigate"),
@@ -3040,12 +2837,8 @@ fn help_text_empty_journal() {
 
 #[test]
 fn two_panel_rendering_100_plus_entries_does_not_panic() {
-    let journal = make_journal_with_n_entries(120);
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let kg = make_kg_with_n_entries(120);
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
 
     let mut state = JournalUiState {
         visible: true,
@@ -3053,16 +2846,20 @@ fn two_panel_rendering_100_plus_entries_does_not_panic() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    state.clamp_to_entry_count(entries.len());
+    state.clamp_to_entry_count(nodes.len());
 
-    let list = build_entry_list_text(&entries, &state);
+    let list = build_entry_list_text(&nodes, &kg, &state);
     assert!(!list.is_empty());
-    let detail = build_detail_spans(&entries, &state, true);
+    let detail = build_detail_spans(
+        nodes
+            .get(state.selected_index)
+            .and_then(|&idx| kg.node(idx)),
+        true,
+        None,
+    );
     assert!(!detail.is_empty());
-    let help = build_help_text(entries.len(), &state);
+    let help = build_help_text(nodes.len(), &state, 0);
     assert!(help.contains("of 120"));
 }
 
@@ -3089,9 +2886,10 @@ fn panels_render_without_panic() {
         ),
     );
 
-    // Spawn a player entity with an empty journal.
+    // Spawn a player entity.
+    app.init_resource::<KnowledgeGraph>();
     app.world_mut()
-        .spawn((Player, Journal::default(), Transform::default()));
+        .spawn((Player, Journal, Transform::default()));
 
     // Frame 0: run Startup (spawns UI nodes).
     app.update();
@@ -3102,20 +2900,12 @@ fn panels_render_without_panic() {
     // Frame 1: compute + sync with empty journal — should not panic.
     app.update();
 
-    // Populate the journal with a few entries and re-render.
+    // Populate the KG with a few entries and re-render.
     {
-        let mut query = app
-            .world_mut()
-            .query_filtered::<&mut Journal, With<Player>>();
-        let mut journal = query
-            .single_mut(app.world_mut())
-            .expect("player must exist");
+        let mut kg = app.world_mut().resource_mut::<KnowledgeGraph>();
         for i in 0..5u64 {
-            journal.record(
-                JournalKey::Material {
-                    seed: i,
-                    planet_seed: None,
-                },
+            kg.record(
+                JournalKey::MaterialInstance { seed: i },
                 &format!("Mat-{i}"),
                 Observation {
                     category: ObservationCategory::SurfaceAppearance,
@@ -3148,12 +2938,8 @@ fn panels_render_without_panic() {
 
 #[test]
 fn correct_entries_shown_for_given_scroll_offset() {
-    let journal = make_journal_with_n_entries(10);
-    let entries: Vec<&JournalEntry> = {
-        let mut v: Vec<_> = journal.entries.values().collect();
-        v.sort_by(|a, b| a.name.cmp(&b.name));
-        v
-    };
+    let kg = make_kg_with_n_entries(10);
+    let nodes: Vec<NodeIndex> = kg.nodes_sorted_by_name();
     // Sorted names: Material-000 .. Material-009
 
     // Page starting at offset 0, page size 3: should show entries 0, 1, 2.
@@ -3163,10 +2949,8 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 0,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let lines = build_entry_list_lines(&entries, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(lines.len(), 3);
     assert!(lines[0].text.contains("Material-000"));
     assert!(lines[1].text.contains("Material-001"));
@@ -3179,10 +2963,8 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 4,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let lines = build_entry_list_lines(&entries, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(lines.len(), 3);
     assert!(
         lines[0].text.contains("Material-004"),
@@ -3211,10 +2993,8 @@ fn correct_entries_shown_for_given_scroll_offset() {
         scroll_offset: 8,
         entries_per_page: 3,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let lines = build_entry_list_lines(&entries, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(
         lines.len(),
         2,
@@ -3233,8 +3013,6 @@ fn toggle_close_reopen_preserves_selection_and_scroll() {
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
     // Toggle closed.
@@ -3253,19 +3031,34 @@ fn toggle_close_reopen_preserves_selection_and_scroll() {
 /// that runs in-game, not just direct field manipulation.
 #[test]
 fn toggle_visibility_system_preserves_navigation_state() {
+    use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
+
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.add_message::<ToggleJournalIntent>();
+    // Start visible: the journal panel starts Active so JournalUiState.visible = true.
     app.insert_resource(JournalUiState {
         visible: true,
         selected_index: 7,
         scroll_offset: 3,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
-    app.add_systems(Update, toggle_journal_visibility);
+    // Spawn the JournalPanel with diegetic components so toggle_journal_visibility
+    // can find it.  Start Active (open) to match visible: true above.
+    app.world_mut().spawn((
+        JournalPanel,
+        DiegeticSurface,
+        DiegeticSurfaceKind::Readable {
+            perceivable_range: 0.0,
+            legible_range: 0.0,
+        },
+        DiegeticFocusState::Active,
+    ));
+    app.add_systems(
+        Update,
+        (toggle_journal_visibility, sync_journal_ui_state_from_focus).chain(),
+    );
 
     // ── Close: send one toggle intent. ──────────────────────────
     app.world_mut().write_message(ToggleJournalIntent);
@@ -3321,20 +3114,15 @@ fn navigation_ignored_when_journal_is_hidden() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     // Spawn a player with a journal containing entries so navigation
     // would normally have something to move through.
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
     for i in 0..10 {
-        journal.record(
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            },
+        kg.record(
+            JournalKey::MaterialInstance { seed: i },
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
@@ -3344,7 +3132,8 @@ fn navigation_ignored_when_journal_is_hidden() {
             },
         );
     }
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // Simulate pressing ArrowDown.
     app.world_mut()
@@ -3377,18 +3166,13 @@ fn navigation_active_when_journal_is_visible() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
     for i in 0..10 {
-        journal.record(
-            JournalKey::Material {
-                seed: i,
-                planet_seed: None,
-            },
+        kg.record(
+            JournalKey::MaterialInstance { seed: i },
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
@@ -3398,7 +3182,8 @@ fn navigation_active_when_journal_is_visible() {
             },
         );
     }
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // Simulate pressing ArrowDown.
     app.world_mut()
@@ -3431,17 +3216,14 @@ fn navigation_first_to_last_entry() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
     for i in 0..entry_count {
-        journal.record(
-            JournalKey::Material {
+        kg.record(
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3452,7 +3234,8 @@ fn navigation_first_to_last_entry() {
             },
         );
     }
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // ── End key: jump from first to last ────────────────────────────
     app.world_mut()
@@ -3553,17 +3336,12 @@ fn navigation_bounds_single_entry_journal() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
-    let mut journal = Journal::default();
-    journal.record(
-        JournalKey::Material {
-            seed: 0,
-            planet_seed: None,
-        },
+    let mut kg = KnowledgeGraph::default();
+    kg.record(
+        JournalKey::MaterialInstance { seed: 0 },
         "Sole-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -3572,7 +3350,8 @@ fn navigation_bounds_single_entry_journal() {
             recorded_at: 0,
         },
     );
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     let keys_to_test = [
         KeyCode::ArrowDown,
@@ -3620,17 +3399,14 @@ fn navigation_bounds_page_keys_at_extremes() {
         scroll_offset: 0,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
     for i in 0..entry_count {
-        journal.record(
-            JournalKey::Material {
+        kg.record(
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3641,7 +3417,8 @@ fn navigation_bounds_page_keys_at_extremes() {
             },
         );
     }
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // ── PageUp from index 0: must stay at 0 ────────────────────────
     app.world_mut()
@@ -3701,8 +3478,6 @@ fn clamp_corrects_out_of_range_selected_index() {
         scroll_offset: 20,
         entries_per_page: 5,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
     state.clamp_to_entry_count(10);
     assert_eq!(
@@ -3747,17 +3522,14 @@ fn navigation_never_exceeds_bounds_under_key_sequence() {
         scroll_offset: 0,
         entries_per_page,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
     for i in 0..entry_count {
-        journal.record(
-            JournalKey::Material {
+        kg.record(
+            JournalKey::MaterialInstance {
                 seed: i.try_into().expect("entry index fits in u64"),
-                planet_seed: None,
             },
             &format!("Mat-{i:03}"),
             Observation {
@@ -3768,7 +3540,8 @@ fn navigation_never_exceeds_bounds_under_key_sequence() {
             },
         );
     }
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // A deterministic sequence covering every navigation key, repeated
     // and interleaved so the cumulative position lands at the extremes,
@@ -3865,30 +3638,23 @@ fn make_panel_app(initial_entries_per_page: usize) -> App {
     app.add_plugins(MinimalPlugins);
     app.init_resource::<JournalRenderCache>();
     app.init_resource::<JournalSelectionTracker>();
+    app.init_resource::<KnowledgeGraph>();
     app.insert_resource(JournalUiState {
         visible: true,
         selected_index: 0,
         scroll_offset: 0,
         entries_per_page: initial_entries_per_page,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, compute_journal_panels);
     app.world_mut()
-        .spawn((Player, Journal::default(), Transform::default()));
+        .spawn((Player, Journal, Transform::default()));
     app
 }
 
-/// Helper: append an observation to the player's journal.
+/// Helper: append an observation to the KnowledgeGraph resource.
 fn record(app: &mut App, key: JournalKey, name: &str, recorded_at: u64) {
-    let mut query = app
-        .world_mut()
-        .query_filtered::<&mut Journal, With<Player>>();
-    let mut journal = query
-        .single_mut(app.world_mut())
-        .expect("player must exist");
-    journal.record(
+    app.world_mut().resource_mut::<KnowledgeGraph>().record(
         key,
         name,
         Observation {
@@ -3900,15 +3666,9 @@ fn record(app: &mut App, key: JournalKey, name: &str, recorded_at: u64) {
     );
 }
 
-/// Helper: remove an entry from the player's journal by key.
+/// Helper: remove an entry from the KnowledgeGraph resource.
 fn delete(app: &mut App, key: &JournalKey) {
-    let mut query = app
-        .world_mut()
-        .query_filtered::<&mut Journal, With<Player>>();
-    let mut journal = query
-        .single_mut(app.world_mut())
-        .expect("player must exist");
-    journal.entries.remove(key);
+    app.world_mut().resource_mut::<KnowledgeGraph>().remove(key);
 }
 
 /// Inserting an entry that sorts *before* the selected entry must
@@ -3921,28 +3681,19 @@ fn selection_follows_subject_when_entry_inserted_before_it() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Charlie",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
@@ -3959,10 +3710,7 @@ fn selection_follows_subject_when_entry_inserted_before_it() {
     // index 1 to index 2.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Alpha",
         4,
     );
@@ -3984,37 +3732,25 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Delta",
         4,
     );
@@ -4029,13 +3765,7 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
     // Delete "Bravo".  Sorted list becomes [Alpha, Charlie, Delta].
     // "Charlie" now occupies the old slot (index 1) — that is the
     // nearest entry by sort position.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 2 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4049,10 +3779,7 @@ fn deleting_selected_entry_selects_nearest_by_sort_position() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 3,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 3 }),
         "tracker must re-anchor onto the nearest entry"
     );
 }
@@ -4066,28 +3793,19 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4102,13 +3820,7 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
     // Delete "Charlie".  Sorted list becomes [Alpha, Bravo].  There
     // is no entry at the old slot (index 2), so the nearest valid
     // entry is the new last one (index 1, "Bravo").
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 3 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4119,10 +3831,7 @@ fn deleting_last_entry_while_selected_falls_back_to_new_last() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 2,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 2 }),
         "tracker must re-anchor onto Bravo"
     );
 }
@@ -4136,19 +3845,13 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
@@ -4160,20 +3863,8 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     app.update();
 
     // Delete both entries.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-    );
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 1 });
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 2 });
     app.update();
 
     let tracker = app.world().resource::<JournalSelectionTracker>();
@@ -4186,10 +3877,7 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     // the new entry rather than wait for a (deleted) prior key.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Charlie",
         10,
     );
@@ -4200,10 +3888,7 @@ fn emptying_journal_resets_tracker_then_re_anchors_on_repopulation() {
     assert_eq!(state.selected_index, 0);
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 99,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 99 }),
         "tracker must anchor onto the new sole entry"
     );
 }
@@ -4218,28 +3903,19 @@ fn selection_follows_subject_when_entry_deleted_before_it() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4253,13 +3929,7 @@ fn selection_follows_subject_when_entry_deleted_before_it() {
 
     // Delete "Alpha".  Sorted list becomes [Bravo, Charlie].
     // "Charlie" now sits at index 1.
-    delete(
-        &mut app,
-        &JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
-    );
+    delete(&mut app, &JournalKey::MaterialInstance { seed: 1 });
     app.update();
 
     let state = app.world().resource::<JournalUiState>();
@@ -4297,55 +3967,37 @@ fn new_entry_before_visible_window_keeps_visible_entries_stable() {
     // Sorted order will match insertion order since names are alphabetical.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Charlie",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Echo",
         4,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 5 },
         "Foxtrot",
         5,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 6,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 6 },
         "Golf",
         6,
     );
@@ -4373,10 +4025,7 @@ fn new_entry_before_visible_window_keeps_visible_entries_stable() {
     // from 4 to 5.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Alpha",
         7,
     );
@@ -4403,28 +4052,19 @@ fn new_entry_after_visible_window_does_not_move_view() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
@@ -4441,10 +4081,7 @@ fn new_entry_after_visible_window_does_not_move_view() {
     // past the visible window).  Nothing in view should change.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Zulu",
         4,
     );
@@ -4475,37 +4112,25 @@ fn new_entry_between_top_and_selection_shifts_only_selection() {
 
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Delta",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Echo",
         4,
     );
@@ -4523,10 +4148,7 @@ fn new_entry_between_top_and_selection_shifts_only_selection() {
     // unchanged at index 0.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 99 },
         "Charlie",
         5,
     );
@@ -4583,46 +4205,31 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // Bravo, Delta, Echo, Foxtrot, Hotel.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Bravo",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Delta",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Echo",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Foxtrot",
         4,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 5 },
         "Hotel",
         5,
     );
@@ -4664,13 +4271,9 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
         app.world().resource::<JournalRenderCache>().help.clone()
     }
 
-    // Helper: read the journal entry count via a query.
+    // Helper: read the entry count from KnowledgeGraph resource.
     fn entry_count(app: &mut App) -> usize {
-        let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-        q.single(app.world())
-            .expect("player must exist")
-            .entries
-            .len()
+        app.world().resource::<KnowledgeGraph>().named_node_count()
     }
 
     // Sanity: initial rendered state has Echo selected and all five
@@ -4697,10 +4300,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // update to reflect the new total of six.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 10,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 10 },
         "Alpha",
         10,
     );
@@ -4737,10 +4337,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // index advances by one; the highlight must follow.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 11,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 11 },
         "Charlie",
         11,
     );
@@ -4769,10 +4366,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     // indicator reflects the new total.  Echo's highlight remains.
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 12,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 12 },
         "Zulu",
         12,
     );
@@ -4780,13 +4374,10 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
 
     assert_eq!(entry_count(&mut app), 8);
     {
-        let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-        let journal = q.single(app.world()).expect("player must exist");
+        let kg = app.world().resource::<KnowledgeGraph>();
         assert!(
-            journal.entries.contains_key(&JournalKey::Material {
-                seed: 12,
-                planet_seed: None
-            }),
+            kg.lookup(&ConceptId(JournalKey::MaterialInstance { seed: 12 }))
+                .is_some(),
             "Zulu entry must be present in the journal after recording"
         );
     }
@@ -4801,19 +4392,12 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     );
 
     // ── Echo's own observation count must be untouched ──────────────
-    //
-    // Selection-stability also means the *contents* of the selected
-    // subject are unaffected by additions of unrelated subjects.
     {
-        let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-        let journal = q.single(app.world()).expect("player must exist");
-        let echo = journal
-            .entries
-            .get(&JournalKey::Material {
-                seed: 3,
-                planet_seed: None,
-            })
+        let kg = app.world().resource::<KnowledgeGraph>();
+        let echo_idx = kg
+            .lookup(&ConceptId(JournalKey::MaterialInstance { seed: 3 }))
             .expect("Echo entry must still exist");
+        let echo = kg.node(echo_idx).expect("node");
         assert_eq!(
             echo.observation_count(),
             1,
@@ -4825,10 +4409,7 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
     let tracker = app.world().resource::<JournalSelectionTracker>();
     assert_eq!(
         tracker.key,
-        Some(JournalKey::Material {
-            seed: 3,
-            planet_seed: None
-        }),
+        Some(JournalKey::MaterialInstance { seed: 3 }),
         "tracker must remain anchored on Echo across all three insertions"
     );
 }
@@ -4848,50 +4429,53 @@ fn adding_entry_while_open_updates_list_and_keeps_selection_stable() {
 /// closed and reopened."
 #[test]
 fn reopen_journal_preserves_same_selected_entry() {
+    use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
+
     let mut app = make_panel_app(15);
     app.add_message::<ToggleJournalIntent>();
-    // Run the visibility toggle before panel reconciliation so any
-    // visibility flip this frame is reflected in the same update().
+    // Spawn the JournalPanel with diegetic components.  Start Active so the
+    // initial JournalUiState.visible = true (set by make_panel_app) is consistent.
+    app.world_mut().spawn((
+        JournalPanel,
+        DiegeticSurface,
+        DiegeticSurfaceKind::Readable {
+            perceivable_range: 0.0,
+            legible_range: 0.0,
+        },
+        DiegeticFocusState::Active,
+    ));
+    // Run toggle → sync_from_focus → compute in order so visibility is consistent
+    // within each update().
     app.add_systems(
         Update,
-        toggle_journal_visibility.before(compute_journal_panels),
+        (toggle_journal_visibility, sync_journal_ui_state_from_focus)
+            .chain()
+            .before(compute_journal_panels),
     );
 
     // Populate four entries.  Sorted alphabetically the order is
     // Alpha (0), Bravo (1), Charlie (2), Delta (3).
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 1 },
         "Alpha",
         1,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 2 },
         "Bravo",
         2,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 3 },
         "Charlie",
         3,
     );
     record(
         &mut app,
-        JournalKey::Material {
-            seed: 4,
-            planet_seed: None,
-        },
+        JournalKey::MaterialInstance { seed: 4 },
         "Delta",
         4,
     );
@@ -4966,8 +4550,6 @@ fn shift_tab_cycles_context_filter() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
@@ -4980,14 +4562,11 @@ fn shift_tab_cycles_context_filter() {
     app.world_mut().insert_resource(profile);
 
     // Create a journal with entries from different planets
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Material from planet 0
-    journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 1 },
         "Planet0-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -4998,11 +4577,8 @@ fn shift_tab_cycles_context_filter() {
     );
 
     // Material from planet 1
-    journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(1),
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 2 },
         "Planet1-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5013,11 +4589,8 @@ fn shift_tab_cycles_context_filter() {
     );
 
     // Material with no planet context
-    journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: None,
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 3 },
         "Unknown-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5027,7 +4600,8 @@ fn shift_tab_cycles_context_filter() {
         },
     );
 
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // Initial state: All filter (default)
     {
@@ -5098,20 +4672,15 @@ fn tab_cycles_category_filter() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     // Create a journal with entries to test filtering
-    let mut journal = Journal::default();
+    let mut kg = KnowledgeGraph::default();
 
     // Add a material entry with SurfaceAppearance observation
-    journal.record(
-        JournalKey::Material {
-            seed: 1,
-            planet_seed: Some(0),
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 1 },
         "Surface-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
@@ -5122,11 +4691,8 @@ fn tab_cycles_category_filter() {
     );
 
     // Add a material entry with ThermalBehavior observation
-    journal.record(
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: Some(0),
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 2 },
         "Thermal-Material",
         Observation {
             category: ObservationCategory::ThermalBehavior,
@@ -5137,11 +4703,8 @@ fn tab_cycles_category_filter() {
     );
 
     // Add a material entry with Weight observation
-    journal.record(
-        JournalKey::Material {
-            seed: 3,
-            planet_seed: Some(0),
-        },
+    kg.record(
+        JournalKey::MaterialInstance { seed: 3 },
         "Heavy-Material",
         Observation {
             category: ObservationCategory::Weight,
@@ -5152,7 +4715,7 @@ fn tab_cycles_category_filter() {
     );
 
     // Add a fabrication entry with FabricationResult observation
-    journal.record(
+    kg.record(
         JournalKey::Fabrication { output_seed: 4 },
         "Alloy-Fabrication",
         Observation {
@@ -5163,7 +4726,8 @@ fn tab_cycles_category_filter() {
         },
     );
 
-    app.world_mut().spawn((Player, journal));
+    app.world_mut().insert_resource(kg);
+    app.world_mut().spawn((Player, Journal));
 
     // Initial state: All filter (no restrictions)
     {
@@ -5291,10 +4855,8 @@ fn help_text_shows_context_filter_hint_and_status() {
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_all = build_help_text(10, &state_all);
+    let help_all = build_help_text(10, &state_all, 0);
     assert!(
         help_all.contains("Shift+Tab: Context Filter"),
         "help should show Shift+Tab hint, got: {help_all}"
@@ -5313,10 +4875,8 @@ fn help_text_shows_context_filter_hint_and_status() {
             category: None,
             context: Some(JournalContext::CurrentPlanet { planet_seed: 42 }),
         },
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_planet = build_help_text(10, &state_planet);
+    let help_planet = build_help_text(10, &state_planet, 0);
     assert!(
         help_planet.contains("Shift+Tab: Context Filter"),
         "help should show Shift+Tab hint with filter active, got: {help_planet}"
@@ -5335,10 +4895,8 @@ fn help_text_shows_context_filter_hint_and_status() {
             category: Some(ObservationCategory::SurfaceAppearance),
             context: Some(JournalContext::CurrentPlanet { planet_seed: 42 }),
         },
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
-    let help_combined = build_help_text(10, &state_combined);
+    let help_combined = build_help_text(10, &state_combined, 0);
     assert!(
         help_combined.contains("[Filter: Category | Current Planet]"),
         "help should show combined filter status, got: {help_combined}"
@@ -5421,19 +4979,18 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.init_resource::<ButtonInput<KeyCode>>();
+    app.init_resource::<KnowledgeGraph>();
     app.insert_resource(JournalUiState {
         visible: true,
         selected_index: 0,
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     });
     app.add_systems(Update, journal_navigation);
 
     // Create a Player entity with an empty Journal component
-    app.world_mut().spawn((Player, Journal::default()));
+    app.world_mut().spawn((Player, Journal));
 
     // Apply a category filter to the empty journal
     {
@@ -5448,18 +5005,21 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     app.update();
 
     // Verify that empty journal with filter shows "No observations yet."
-    let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-    let journal = q.single(app.world()).expect("player must exist");
     let state = app.world().resource::<JournalUiState>();
-
-    // Build the detail spans using the same logic as the UI
-    let filtered_entries: Vec<&JournalEntry> = journal
-        .entries
-        .values()
-        .filter(|entry| matches_filter(entry, state.filter()))
+    let kg = app.world().resource::<KnowledgeGraph>();
+    let filtered_nodes: Vec<NodeIndex> = kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter(|&idx| {
+            kg.node(idx)
+                .is_some_and(|n| matches_filter_node(n, state.filter()))
+        })
         .collect();
-
-    let detail_spans = build_detail_spans(&filtered_entries, state, !journal.entries.is_empty());
+    let detail_spans = build_detail_spans(
+        filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
+        kg.named_node_count() > 0,
+        None,
+    );
     let detail_text = detail_spans_to_string(&detail_spans);
 
     assert_eq!(
@@ -5479,17 +5039,21 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     app.update();
 
     // Verify context filter on empty journal also shows "No observations yet."
-    let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-    let journal = q.single(app.world()).expect("player must exist");
     let state = app.world().resource::<JournalUiState>();
-
-    let filtered_entries: Vec<&JournalEntry> = journal
-        .entries
-        .values()
-        .filter(|entry| matches_filter(entry, state.filter()))
+    let kg = app.world().resource::<KnowledgeGraph>();
+    let filtered_nodes: Vec<NodeIndex> = kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter(|&idx| {
+            kg.node(idx)
+                .is_some_and(|n| matches_filter_node(n, state.filter()))
+        })
         .collect();
-
-    let detail_spans = build_detail_spans(&filtered_entries, state, !journal.entries.is_empty());
+    let detail_spans = build_detail_spans(
+        filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
+        kg.named_node_count() > 0,
+        None,
+    );
     let detail_text = detail_spans_to_string(&detail_spans);
 
     assert_eq!(
@@ -5509,17 +5073,21 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     app.update();
 
     // Verify combined filter on empty journal also shows "No observations yet."
-    let mut q = app.world_mut().query_filtered::<&Journal, With<Player>>();
-    let journal = q.single(app.world()).expect("player must exist");
     let state = app.world().resource::<JournalUiState>();
-
-    let filtered_entries: Vec<&JournalEntry> = journal
-        .entries
-        .values()
-        .filter(|entry| matches_filter(entry, state.filter()))
+    let kg = app.world().resource::<KnowledgeGraph>();
+    let filtered_nodes: Vec<NodeIndex> = kg
+        .nodes_sorted_by_name()
+        .into_iter()
+        .filter(|&idx| {
+            kg.node(idx)
+                .is_some_and(|n| matches_filter_node(n, state.filter()))
+        })
         .collect();
-
-    let detail_spans = build_detail_spans(&filtered_entries, state, !journal.entries.is_empty());
+    let detail_spans = build_detail_spans(
+        filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
+        kg.named_node_count() > 0,
+        None,
+    );
     let detail_text = detail_spans_to_string(&detail_spans);
 
     assert_eq!(
@@ -5539,7 +5107,7 @@ fn test_planet_switch_updates_context_filter() {
         .init_resource::<ButtonInput<KeyCode>>();
 
     // Create a Player entity with an empty Journal component
-    app.world_mut().spawn((Player, Journal::default()));
+    app.world_mut().spawn((Player, Journal));
 
     // Set up initial WorldProfile with planet seed 42
     let initial_config = WorldGenerationConfig {
@@ -5702,11 +5270,8 @@ fn test_confidence_accumulation_in_journal_entry() {
     use crate::observation::{Confidence, ConfidenceConfig};
 
     // Create a test journal entry
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(123),
-    };
-    let mut entry = JournalEntry::new(key, "Test Material".to_string(), 0);
+    let key = JournalKey::MaterialInstance { seed: 42 };
+    let mut entry = ConceptNode::new(key, "Test Material", 0);
 
     // Create a confidence config
     let config = ConfidenceConfig {
@@ -5803,11 +5368,8 @@ fn test_confidence_accumulation_different_descriptions() {
     use crate::observation::{Confidence, ConfidenceConfig};
 
     // Create a test journal entry
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(123),
-    };
-    let mut entry = JournalEntry::new(key, "Test Material".to_string(), 0);
+    let key = JournalKey::MaterialInstance { seed: 42 };
+    let mut entry = ConceptNode::new(key, "Test Material", 0);
 
     // Create a confidence config
     let config = ConfidenceConfig {
@@ -5862,11 +5424,8 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     use crate::descriptions::describe_thermal_observation;
     use crate::observation::{Confidence, ConfidenceConfig};
 
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     // Create a confidence config with a reasonable accumulation weight
     let config = ConfidenceConfig {
@@ -5883,10 +5442,15 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     };
 
     // Record the first observation
-    journal.record_with_accumulation(key.clone(), "Test Material", initial_observation, &config);
+    kg.record_with_accumulation(key.clone(), "Test Material", initial_observation, &config);
 
     // Verify initial state
-    let entry = journal.entries.get(&key).expect("Entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("Entry should exist"),
+        )
+        .expect("node");
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(observations.len(), 1, "Should have exactly one observation");
     assert_eq!(
@@ -5910,10 +5474,15 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
         recorded_at: 2000,
     };
 
-    journal.record_with_accumulation(key.clone(), "Test Material", repeat_observation, &config);
+    kg.record_with_accumulation(key.clone(), "Test Material", repeat_observation, &config);
 
     // Verify confidence has increased
-    let entry = journal.entries.get(&key).expect("Entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("Entry should exist"),
+        )
+        .expect("node");
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(
         observations.len(),
@@ -5960,10 +5529,15 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
         recorded_at: 3000,
     };
 
-    journal.record_with_accumulation(key.clone(), "Test Material", third_observation, &config);
+    kg.record_with_accumulation(key.clone(), "Test Material", third_observation, &config);
 
     // Verify confidence has increased further
-    let entry = journal.entries.get(&key).expect("Entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("Entry should exist"),
+        )
+        .expect("node");
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
 
     // Calculate expected confidence after second accumulation
@@ -5985,10 +5559,15 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
         recorded_at: 4000,
     };
 
-    journal.record_with_accumulation(key.clone(), "Test Material", fourth_observation, &config);
+    kg.record_with_accumulation(key.clone(), "Test Material", fourth_observation, &config);
 
     // Verify we've reached Confident tier
-    let entry = journal.entries.get(&key).expect("Entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("Entry should exist"),
+        )
+        .expect("node");
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
 
     // Calculate expected confidence after third accumulation
@@ -6027,11 +5606,8 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
 fn journal_entry_shows_confident_language_after_sufficient_observations() {
     use crate::observation::{Confidence, DescriptorVocabulary};
 
-    let mut journal = Journal::default();
-    let key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let key = JournalKey::MaterialInstance { seed: 42 };
 
     // Create a descriptor vocabulary to generate confident language
     let vocab = DescriptorVocabulary::default();
@@ -6057,10 +5633,15 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
         recorded_at: 1000,
     };
 
-    journal.record(key.clone(), "Test Material", observation);
+    kg.record(key.clone(), "Test Material", observation);
 
     // Verify the observation has confident tier
-    let entry = journal.entries.get(&key).expect("Entry should exist");
+    let entry = kg
+        .node(
+            kg.lookup(&ConceptId(key.clone()))
+                .expect("Entry should exist"),
+        )
+        .expect("node");
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(observations.len(), 1, "Should have exactly one observation");
     assert_eq!(
@@ -6070,18 +5651,15 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
     );
 
     // Now test that the journal detail display shows confident language
-    let entries: Vec<&JournalEntry> = vec![entry];
     let state = JournalUiState {
         visible: true,
         selected_index: 0,
         scroll_offset: 0,
         entries_per_page: 15,
         filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
     };
 
-    let detail_spans = build_detail_spans(&entries, &state, true);
+    let detail_spans = build_detail_spans(Some(entry), true, None);
     let detail_text = detail_spans_to_string(&detail_spans);
 
     // Verify the detail display contains confident language
@@ -6138,19 +5716,14 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         domain_recovery_multiplier: 2.0,
         passive_recovery_multiplier: 0.8,
         base_observation_weight: 0.25, // Reasonable accumulation rate
+        similarity_threshold: 0.85,
     };
 
     // ── Phase 1: Establish confident language ──────────────────────────────
 
-    let mut journal = Journal::default();
-    let thermal_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: None,
-    };
-    let weight_key = JournalKey::Material {
-        seed: 99,
-        planet_seed: None,
-    };
+    let mut kg = KnowledgeGraph::default();
+    let thermal_key = JournalKey::MaterialInstance { seed: 42 };
+    let weight_key = JournalKey::MaterialInstance { seed: 99 };
 
     // Create observations with confident-level confidence (≥0.7)
     let confident_thermal = Observation {
@@ -6173,13 +5746,18 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         recorded_at: 1100,
     };
 
-    journal.record(thermal_key.clone(), "Thermal Material", confident_thermal);
-    journal.record(weight_key.clone(), "Heavy Material", confident_weight);
+    kg.record(thermal_key.clone(), "Thermal Material", confident_thermal);
+    kg.record(weight_key.clone(), "Heavy Material", confident_weight);
 
     // Verify initial confident language
-    let thermal_obs =
-        &journal.entries[&thermal_key].observations[&ObservationCategory::ThermalBehavior][0];
-    let weight_obs = &journal.entries[&weight_key].observations[&ObservationCategory::Weight][0];
+    let thermal_obs = &kg
+        .node(kg.lookup(&ConceptId(thermal_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::ThermalBehavior)[0];
+    let weight_obs = &kg
+        .node(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::Weight)[0];
 
     assert_eq!(thermal_obs.confidence.tier(), ConfidenceTier::Confident);
     assert_eq!(weight_obs.confidence.tier(), ConfidenceTier::Confident);
@@ -6197,7 +5775,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     // ── Phase 2: Simulate death causing language regression ────────────────
 
     // Manually apply death degradation to simulate what handle_player_death does
-    for entry in journal.entries.values_mut() {
+    for entry in kg.graph_mut().node_weights_mut() {
         for observations in entry.observations.values_mut() {
             for obs in observations.iter_mut() {
                 obs.confidence
@@ -6207,9 +5785,14 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     }
 
     // Verify confidence has degraded and language has regressed
-    let thermal_obs =
-        &journal.entries[&thermal_key].observations[&ObservationCategory::ThermalBehavior][0];
-    let weight_obs = &journal.entries[&weight_key].observations[&ObservationCategory::Weight][0];
+    let thermal_obs = &kg
+        .node(kg.lookup(&ConceptId(thermal_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::ThermalBehavior)[0];
+    let weight_obs = &kg
+        .node(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::Weight)[0];
 
     // Expected confidence after death: original * 0.5, but not below 0.15 floor
     let expected_thermal_confidence = 0.8 * 0.5; // 0.4 (Observed tier: 0.3-0.7)
@@ -6251,7 +5834,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     let current_time = 1500; // Within recovery window
 
     // Record new thermal observation (death-relevant domain - should recover faster)
-    let recovery_thermal = Observation {
+    let _recovery_thermal = Observation {
         category: ObservationCategory::ThermalBehavior,
         confidence: Confidence(0.2), // New observation confidence
         description: thermal_obs.description.clone(), // Same description to trigger accumulation
@@ -6259,7 +5842,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     };
 
     // Record new weight observation (unrelated domain - should recover slower)
-    let recovery_weight = Observation {
+    let _recovery_weight = Observation {
         category: ObservationCategory::Weight,
         confidence: Confidence(0.2),
         description: weight_obs.description.clone(),
@@ -6277,7 +5860,9 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
 
     // Manually simulate record_with_accumulation with domain-weighted recovery
     // For thermal (death-relevant domain)
-    let thermal_entry = journal.entries.get_mut(&thermal_key).unwrap();
+    let thermal_entry = kg
+        .node_mut(kg.lookup(&ConceptId(thermal_key.clone())).unwrap())
+        .unwrap();
     let thermal_obs_mut = &mut thermal_entry
         .observations
         .get_mut(&ObservationCategory::ThermalBehavior)
@@ -6287,7 +5872,9 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         .accumulate(config.base_observation_weight * thermal_multiplier);
 
     // For weight (unrelated domain)
-    let weight_entry = journal.entries.get_mut(&weight_key).unwrap();
+    let weight_entry = kg
+        .node_mut(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
+        .unwrap();
     let weight_obs_mut = &mut weight_entry
         .observations
         .get_mut(&ObservationCategory::Weight)
@@ -6298,9 +5885,14 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
 
     // ── Phase 4: Verify domain-weighted recovery ───────────────────────────
 
-    let thermal_obs =
-        &journal.entries[&thermal_key].observations[&ObservationCategory::ThermalBehavior][0];
-    let weight_obs = &journal.entries[&weight_key].observations[&ObservationCategory::Weight][0];
+    let thermal_obs = &kg
+        .node(kg.lookup(&ConceptId(thermal_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::ThermalBehavior)[0];
+    let weight_obs = &kg
+        .node(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::Weight)[0];
 
     // Thermal (death-relevant) should recover faster due to domain_recovery_multiplier = 2.0
     // Expected: 0.4 + (1.0 - 0.4) * (0.25 * 2.0) = 0.4 + 0.6 * 0.5 = 0.4 + 0.3 = 0.7
@@ -6377,9 +5969,8 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
 
     // Apply multiple accumulations to push weight back to confident
     // Weight gets passive recovery (0.8x multiplier), so needs more observations
-    let weight_obs_mut = &mut journal
-        .entries
-        .get_mut(&weight_key)
+    let weight_obs_mut = &mut kg
+        .node_mut(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
         .unwrap()
         .observations
         .get_mut(&ObservationCategory::Weight)
@@ -6392,7 +5983,10 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
             .accumulate(config.base_observation_weight * weight_multiplier);
     }
 
-    let weight_obs = &journal.entries[&weight_key].observations[&ObservationCategory::Weight][0];
+    let weight_obs = &kg
+        .node(kg.lookup(&ConceptId(weight_key.clone())).unwrap())
+        .unwrap()
+        .observations_by_category(&ObservationCategory::Weight)[0];
 
     // Should now be confident again
     assert!(
@@ -6408,506 +6002,5 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         final_weight_desc.contains("among the"),
         "Weight language should have recovered to confident: '{}'",
         final_weight_desc
-    );
-}
-
-// ── Cross-reference link navigation tests ───────────────────────────────
-
-#[test]
-fn navigation_stack_push_and_pop() {
-    let mut stack = JournalNavigationStack::new();
-    assert!(!stack.can_go_back(), "empty stack has no history");
-
-    let key_a = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let key_b = JournalKey::Material {
-        seed: 2,
-        planet_seed: None,
-    };
-
-    stack.push(key_a.clone());
-    assert!(stack.can_go_back());
-
-    stack.push(key_b.clone());
-    assert_eq!(stack.pop(), Some(key_b));
-    assert_eq!(stack.pop(), Some(key_a));
-    assert_eq!(stack.pop(), None);
-    assert!(!stack.can_go_back());
-}
-
-#[test]
-fn navigation_stack_respects_max_depth() {
-    let mut stack = JournalNavigationStack {
-        history: Vec::new(),
-        max_depth: 3,
-    };
-
-    for seed in 0..5u64 {
-        stack.push(JournalKey::Material {
-            seed,
-            planet_seed: None,
-        });
-    }
-
-    // Only the last 3 entries should remain.
-    assert_eq!(stack.history.len(), 3);
-    // The oldest retained entry should be seed=2.
-    assert_eq!(
-        stack.history[0],
-        JournalKey::Material {
-            seed: 2,
-            planet_seed: None
-        }
-    );
-}
-
-#[test]
-fn selected_link_index_defaults_to_none() {
-    let state = JournalUiState::default();
-    assert_eq!(state.selected_link_index(), None);
-    assert!(!state.can_go_back());
-}
-
-#[test]
-fn cross_reference_link_selected_span_kind_is_distinct() {
-    // Verify that CrossReferenceLinkSelected is a distinct variant from
-    // CrossReferenceLink so the renderer can apply a different color.
-    assert_ne!(
-        DetailSpanKind::CrossReferenceLinkSelected,
-        DetailSpanKind::CrossReferenceLink
-    );
-}
-
-#[test]
-fn help_text_shows_link_hints_when_link_focused() {
-    let mut state = JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: Some(0),
-        navigation_stack: JournalNavigationStack::new(),
-    };
-
-    let help = build_help_text(5, &state);
-    assert!(
-        help.contains("Enter: Follow"),
-        "help should show Enter hint when link focused, got: {help}"
-    );
-    assert!(
-        help.contains("Move link"),
-        "help should show move-link hint when link focused, got: {help}"
-    );
-
-    // With navigation history, Backspace hint should appear.
-    state.navigation_stack.push(JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    });
-    let help_with_back = build_help_text(5, &state);
-    assert!(
-        help_with_back.contains("Backspace"),
-        "help should show Backspace hint when history exists, got: {help_with_back}"
-    );
-}
-
-#[test]
-fn help_text_shows_back_hint_when_history_exists() {
-    let mut state = JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
-    };
-
-    // No history — no back hint.
-    let help_no_back = build_help_text(5, &state);
-    assert!(
-        !help_no_back.contains("Backspace: Back"),
-        "help should not show back hint when no history, got: {help_no_back}"
-    );
-
-    // With history — back hint appears.
-    state.navigation_stack.push(JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    });
-    let help_with_back = build_help_text(5, &state);
-    assert!(
-        help_with_back.contains("Backspace: Back"),
-        "help should show back hint when history exists, got: {help_with_back}"
-    );
-}
-
-/// Cross-reference links appear in the detail panel render cache when the
-/// selected journal entry has relationships in the `KnowledgeGraph`.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1) and "Volcanic Plains"
-///     (Location planet_seed=42).
-///   - A `FoundOn` edge from Ignium → Volcanic Plains in the KnowledgeGraph.
-///   - Journal is visible with Ignium selected (index 0, alphabetically first).
-///
-/// Expected: after running `compute_journal_panels` then
-/// `append_cross_reference_spans`, the render cache contains at least one
-/// `CrossReferenceLink` span whose text includes "Found on" and "Volcanic
-/// Plains".
-#[test]
-fn cross_reference_links_appear_for_entries_with_relationships() {
-    use crate::knowledge_graph::{
-        ConceptCategory, ConceptEdge, ConceptId, KnowledgeGraph, RelationshipType,
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<JournalRenderCache>();
-    app.init_resource::<JournalSelectionTracker>();
-    app.init_resource::<KnowledgeGraph>();
-    app.insert_resource(JournalUiState {
-        visible: true,
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: JournalNavigationStack::new(),
-    });
-    app.add_systems(
-        Update,
-        (
-            compute_journal_panels,
-            append_cross_reference_spans.after(compute_journal_panels),
-        ),
-    );
-
-    // Spawn a player with a journal containing two entries.
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    // JournalKey has no Location variant yet; represent a location concept
-    // using a Material key with a planet_seed (same convention as knowledge_graph tests).
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    app.world_mut().spawn((
-        Player,
-        {
-            let mut journal = Journal::default();
-            journal.record(
-                material_key.clone(),
-                "Ignium",
-                Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.6),
-                    description: "Reliably withstands heat".to_string(),
-                    recorded_at: 1,
-                },
-            );
-            journal.record(
-                location_key.clone(),
-                "Volcanic Plains",
-                Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.6),
-                    description: "Scorched terrain".to_string(),
-                    recorded_at: 2,
-                },
-            );
-            journal
-        },
-        Transform::default(),
-    ));
-
-    // Build the cross-reference relationship in the KnowledgeGraph.
-    {
-        let mut graph = app.world_mut().resource_mut::<KnowledgeGraph>();
-        let material_node =
-            graph.ensure_concept(ConceptId::new(material_key), ConceptCategory::Material, 1);
-        let location_node =
-            graph.ensure_concept(ConceptId::new(location_key), ConceptCategory::Location, 2);
-        graph.relate(
-            material_node,
-            location_node,
-            ConceptEdge {
-                relationship: RelationshipType::FoundOn,
-                confidence: crate::observation::Confidence(0.8),
-                discovered_at: 1,
-            },
-        );
-    }
-
-    // Run one frame so both systems execute.
-    app.update();
-
-    // Verify the render cache contains a CrossReferenceLink span for the
-    // FoundOn relationship pointing at "Volcanic Plains".
-    let cache = app.world().resource::<JournalRenderCache>();
-
-    let link_spans: Vec<&DetailSpan> = cache
-        .detail_spans
-        .iter()
-        .filter(|s| {
-            matches!(
-                s.kind,
-                DetailSpanKind::CrossReferenceLink | DetailSpanKind::CrossReferenceLinkSelected
-            )
-        })
-        .collect();
-
-    assert!(
-        !link_spans.is_empty(),
-        "expected at least one CrossReferenceLink span in the detail panel, got none. \
-         Full spans: {:?}",
-        cache.detail_spans
-    );
-
-    let combined_text: String = link_spans.iter().map(|s| s.text.as_str()).collect();
-    assert!(
-        combined_text.contains("Found on"),
-        "expected 'Found on' in cross-reference link text, got: {combined_text:?}"
-    );
-    assert!(
-        combined_text.contains("Volcanic Plains"),
-        "expected 'Volcanic Plains' in cross-reference link text, got: {combined_text:?}"
-    );
-
-    // Also verify the "Related" section header is present.
-    let has_related_header = cache
-        .detail_spans
-        .iter()
-        .any(|s| s.kind == DetailSpanKind::CrossReferenceHeader && s.text.contains("Related"));
-    assert!(
-        has_related_header,
-        "expected a CrossReferenceHeader span containing 'Related', got: {:?}",
-        cache.detail_spans
-    );
-}
-
-/// Pressing Enter while a cross-reference link is focused jumps the journal
-/// selection to the related entry.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1) and "Volcanic Plains"
-///     (Material seed=42, planet_seed=Some(42)).
-///   - A `FoundOn` edge from Ignium → Volcanic Plains in the KnowledgeGraph.
-///   - Journal is visible with Ignium selected (index 0, alphabetically first
-///     since "I" < "V").
-///   - `selected_link_index` is `Some(0)` — the FoundOn link is focused.
-///
-/// Expected: after pressing Enter and running `journal_navigation`, the
-/// `selected_index` advances to the position of "Volcanic Plains" in the
-/// sorted, filtered entry list, and `selected_link_index` is cleared.
-#[test]
-fn navigation_enter_on_link_jumps_to_related_entry() {
-    use crate::knowledge_graph::{
-        ConceptCategory, ConceptEdge, ConceptId, KnowledgeGraph, RelationshipType,
-    };
-
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    // Represent the location using a Material key with planet_seed (same
-    // convention used throughout the knowledge_graph tests).
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<ButtonInput<KeyCode>>();
-    app.init_resource::<KnowledgeGraph>();
-    app.insert_resource(JournalUiState {
-        visible: true,
-        // "Ignium" sorts before "Volcanic Plains", so it is at index 0.
-        selected_index: 0,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        // Link 0 (the FoundOn → Volcanic Plains link) is focused.
-        selected_link_index: Some(0),
-        navigation_stack: JournalNavigationStack::new(),
-    });
-    app.add_systems(Update, journal_navigation);
-
-    // Build the KnowledgeGraph relationship before spawning the player.
-    {
-        let mut graph = app.world_mut().resource_mut::<KnowledgeGraph>();
-        let material_node = graph.ensure_concept(
-            ConceptId::new(material_key.clone()),
-            ConceptCategory::Material,
-            1,
-        );
-        let location_node = graph.ensure_concept(
-            ConceptId::new(location_key.clone()),
-            ConceptCategory::Location,
-            2,
-        );
-        graph.relate(
-            material_node,
-            location_node,
-            ConceptEdge {
-                relationship: RelationshipType::FoundOn,
-                confidence: crate::observation::Confidence(0.8),
-                discovered_at: 1,
-            },
-        );
-    }
-
-    // Spawn a player with both journal entries.
-    let mut journal = Journal::default();
-    journal.record(
-        material_key.clone(),
-        "Ignium",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Reliably withstands heat".to_string(),
-            recorded_at: 1,
-        },
-    );
-    journal.record(
-        location_key.clone(),
-        "Volcanic Plains",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Scorched terrain".to_string(),
-            recorded_at: 2,
-        },
-    );
-    app.world_mut()
-        .spawn((Player, journal, Transform::default()));
-
-    // Press Enter to follow the focused link.
-    app.world_mut()
-        .resource_mut::<ButtonInput<KeyCode>>()
-        .press(KeyCode::Enter);
-
-    app.update();
-
-    let state = app.world().resource::<JournalUiState>();
-
-    // "Volcanic Plains" sorts after "Ignium", so its index in the
-    // alphabetically-sorted two-entry list is 1.
-    assert_eq!(
-        state.selected_index, 1,
-        "Enter on FoundOn link should jump selection to 'Volcanic Plains' at index 1, \
-          got index {}",
-        state.selected_index
-    );
-
-    // The link cursor should be cleared after following the link.
-    assert_eq!(
-        state.selected_link_index, None,
-        "selected_link_index should be cleared after following a cross-reference link"
-    );
-
-    // The previous entry (Ignium) should have been pushed onto the navigation stack.
-    assert!(
-        state.navigation_stack.can_go_back(),
-        "navigation stack should contain the previous entry after following a link"
-    );
-}
-
-/// Pressing Backspace while the navigation stack has history returns the
-/// journal selection to the previously-visited entry.
-///
-/// Setup:
-///   - Two journal entries: "Ignium" (Material seed=1, index 0) and
-///     "Volcanic Plains" (Material seed=42, planet_seed=Some(42), index 1).
-///   - The navigation stack already contains the Ignium key (simulating that
-///     the player followed a link from Ignium to Volcanic Plains).
-///   - Journal is visible with "Volcanic Plains" selected (index 1).
-///   - No link is focused (`selected_link_index` is `None`).
-///
-/// Expected: after pressing Backspace and running `journal_navigation`, the
-/// `selected_index` returns to 0 ("Ignium") and the navigation stack is
-/// empty.
-#[test]
-fn back_navigation_returns_to_previous_entry() {
-    let material_key = JournalKey::Material {
-        seed: 1,
-        planet_seed: None,
-    };
-    let location_key = JournalKey::Material {
-        seed: 42,
-        planet_seed: Some(42),
-    };
-
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.init_resource::<ButtonInput<KeyCode>>();
-    app.init_resource::<KnowledgeGraph>();
-
-    // Start with "Volcanic Plains" selected (index 1) and Ignium on the stack.
-    let mut nav_stack = JournalNavigationStack::new();
-    nav_stack.push(material_key.clone());
-    app.insert_resource(JournalUiState {
-        visible: true,
-        selected_index: 1,
-        scroll_offset: 0,
-        entries_per_page: 15,
-        filter: JournalFilter::default(),
-        selected_link_index: None,
-        navigation_stack: nav_stack,
-    });
-    app.add_systems(Update, journal_navigation);
-
-    // Spawn a player with both journal entries.
-    let mut journal = Journal::default();
-    journal.record(
-        material_key.clone(),
-        "Ignium",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Reliably withstands heat".to_string(),
-            recorded_at: 1,
-        },
-    );
-    journal.record(
-        location_key.clone(),
-        "Volcanic Plains",
-        Observation {
-            category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.6),
-            description: "Scorched terrain".to_string(),
-            recorded_at: 2,
-        },
-    );
-    app.world_mut()
-        .spawn((Player, journal, Transform::default()));
-
-    // Press Backspace to go back.
-    app.world_mut()
-        .resource_mut::<ButtonInput<KeyCode>>()
-        .press(KeyCode::Backspace);
-
-    app.update();
-
-    let state = app.world().resource::<JournalUiState>();
-
-    // Selection should have returned to "Ignium" at index 0.
-    assert_eq!(
-        state.selected_index, 0,
-        "Backspace should return selection to 'Ignium' at index 0, got index {}",
-        state.selected_index
-    );
-
-    // The navigation stack should now be empty.
-    assert!(
-        !state.navigation_stack.can_go_back(),
-        "navigation stack should be empty after back-navigation"
     );
 }

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -1,766 +1,795 @@
-//! Knowledge graph types — concept nodes, edges, and the graph resource for
-//! the cross-reference system.
+//! Knowledge graph — the player's associative web of discovered concepts.
 //!
-//! The knowledge graph is the player's associative web of discovered concepts.
-//! Each concept corresponds to a journal entry (identified by [`JournalKey`]) and
-//! carries metadata about when it was discovered and how confident the player is
-//! in their understanding of it.
+//! This module implements the `KnowledgeGraph` resource backed by
+//! [`petgraph::Graph`] as specified in the data-architecture decision.
+//! The graph stores concept nodes ([`ConceptNode`]) and typed relationship
+//! edges ([`ConceptEdge`]) that are accumulated as the player observes
+//! the world.
 //!
-//! This module defines the node-level types, edge types, the [`KnowledgeGraph`]
-//! resource backed by `petgraph::Graph`, and the [`KnowledgeGraphPlugin`] that
-//! wires the [`update_knowledge_graph`] system into the Bevy app.
+//! # Design principles
+//!
+//! * **Observation-gated:** No edge or node is ever created without an
+//!   observation event. The graph never infers connections the player
+//!   hasn't personally made.
+//! * **Deterministic:** BFS traversal order follows petgraph's stable
+//!   internal edge order. Timeline entries are appended in tick order,
+//!   which is guaranteed monotone by the game clock.
+//! * **Serializable:** The full graph round-trips through serde via
+//!   petgraph's `serde-1` feature plus hand-implemented index maps.
 
-use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::Path;
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use bevy::prelude::*;
-use petgraph::graph::NodeIndex;
+use petgraph::Direction;
+use petgraph::graph::{Graph, NodeIndex};
 use petgraph::visit::EdgeRef;
-use petgraph::{Direction, Graph};
 use serde::{Deserialize, Serialize};
 
-use crate::journal::{JournalKey, RecordObservation};
-use crate::materials::{MaterialCatalog, cosine_similarity};
-use crate::observation::Confidence;
+use crate::journal::JournalKey;
+use crate::observation::{Confidence, ConfidenceConfig};
 
 // ── Plugin ────────────────────────────────────────────────────────────────
 
-/// Plugin that initialises the [`KnowledgeGraph`] resource and registers the
-/// [`update_knowledge_graph`] system.
-///
-/// Must be added after [`crate::journal::JournalPlugin`] because it reads
-/// [`RecordObservation`] messages that the journal plugin registers.
+/// Registers the [`KnowledgeGraph`] resource and the
+/// [`update_knowledge_graph`] system that populates it from
+/// [`crate::observation::RecordObservation`] messages.
 pub struct KnowledgeGraphPlugin;
-
-/// Path to the knowledge-graph tuning configuration file.
-const KNOWLEDGE_GRAPH_CONFIG_PATH: &str = "assets/config/knowledge_graph.toml";
 
 impl Plugin for KnowledgeGraphPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<KnowledgeGraph>()
-            .add_systems(PreStartup, load_knowledge_graph_config)
-            .add_systems(Update, update_knowledge_graph);
+        app.init_resource::<KnowledgeGraph>().add_systems(
+            Update,
+            (
+                update_knowledge_graph.in_set(crate::journal::JournalSet::Navigate),
+                detect_similar_on_observation
+                    .in_set(crate::journal::JournalSet::Navigate)
+                    .after(update_knowledge_graph),
+            ),
+        );
     }
 }
 
-// ── System ────────────────────────────────────────────────────────────────
+// ── Concept identity ──────────────────────────────────────────────────────
 
-/// Map a [`JournalKey`] to its [`ConceptCategory`].
+/// Unique concept identifier — wraps a [`JournalKey`] so the graph and the
+/// journal share the same identity space with no mapping step.
 ///
-/// Materials map to [`ConceptCategory::Material`], fabrication outputs map to
-/// [`ConceptCategory::Fabrication`]. Location keys (when they exist) will map
-/// to [`ConceptCategory::Location`]; for now any key passed as a
-/// `context_location` is treated as a location concept.
-fn category_from_key(key: &JournalKey) -> ConceptCategory {
-    match key {
-        JournalKey::Material { .. } => ConceptCategory::Material,
-        JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
-    }
-}
-
-/// Default minimum cosine similarity score required to create a
-/// [`RelationshipType::SimilarTo`] edge.
-///
-/// Two materials must share at least 85% directional similarity across their
-/// five-dimensional property vector (density, thermal_resistance, reactivity,
-/// conductivity, toxicity) before the system considers them "similar."
-///
-/// This value is the fallback used when `assets/config/knowledge_graph.toml`
-/// is absent or malformed. The live value is stored in [`KnowledgeGraphConfig`].
-const DEFAULT_SIMILARITY_SCORE_THRESHOLD: f32 = 0.85;
-
-/// Default minimum concept node confidence required on BOTH materials before a
-/// [`RelationshipType::SimilarTo`] edge is created.
-///
-/// This maps to the `Observed` tier boundary (≥ 0.3). The player must have
-/// gathered enough evidence about both materials before the system surfaces
-/// the connection — no free inferences from a single tentative observation.
-///
-/// This value is the fallback used when `assets/config/knowledge_graph.toml`
-/// is absent or malformed. The live value is stored in [`KnowledgeGraphConfig`].
-const DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD: f32 = 0.3;
-
-// ── Config resource ───────────────────────────────────────────────────────
-
-fn default_similarity_score_threshold() -> f32 {
-    DEFAULT_SIMILARITY_SCORE_THRESHOLD
-}
-
-fn default_similarity_confidence_threshold() -> f32 {
-    DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD
-}
-
-/// Runtime tuning configuration for the knowledge-graph system.
-///
-/// Loaded from `assets/config/knowledge_graph.toml` during `PreStartup`.
-/// Falls back to compiled-in defaults if the file is absent or malformed so
-/// that the game always starts cleanly.
-///
-/// All thresholds are data-driven to allow tuning without recompilation.
-#[derive(Resource, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct KnowledgeGraphConfig {
-    /// Minimum cosine similarity score (0.0–1.0) required to create a
-    /// [`RelationshipType::SimilarTo`] edge between two materials.
-    ///
-    /// Higher values require materials to be more alike before the journal
-    /// surfaces the connection. Typical range: 0.7–0.95.
-    #[serde(default = "default_similarity_score_threshold")]
-    pub similarity_score_threshold: f32,
-
-    /// Minimum [`Confidence`] value required on BOTH material concept nodes
-    /// before a [`RelationshipType::SimilarTo`] edge is created.
-    ///
-    /// Prevents the system from surfacing connections the player hasn't earned
-    /// through observation. Maps to the `Observed` tier boundary. Typical
-    /// range: 0.2–0.5.
-    #[serde(default = "default_similarity_confidence_threshold")]
-    pub similarity_confidence_threshold: f32,
-}
-
-impl Default for KnowledgeGraphConfig {
-    fn default() -> Self {
-        Self {
-            similarity_score_threshold: DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-            similarity_confidence_threshold: DEFAULT_SIMILARITY_CONFIDENCE_THRESHOLD,
-        }
-    }
-}
-
-/// Load [`KnowledgeGraphConfig`] from `assets/config/knowledge_graph.toml`.
-///
-/// Follows the standard pattern used throughout the codebase: attempt to load
-/// from the config file, fall back to defaults if the file is missing or
-/// malformed. Logs appropriate warnings for debugging.
-fn load_knowledge_graph_config(mut commands: Commands) {
-    let config = if Path::new(KNOWLEDGE_GRAPH_CONFIG_PATH).exists() {
-        match fs::read_to_string(KNOWLEDGE_GRAPH_CONFIG_PATH) {
-            Ok(contents) => match toml::from_str::<KnowledgeGraphConfig>(&contents) {
-                Ok(cfg) => {
-                    info!("Loaded knowledge graph config from {KNOWLEDGE_GRAPH_CONFIG_PATH}");
-                    cfg
-                }
-                Err(error) => {
-                    warn!("Malformed {KNOWLEDGE_GRAPH_CONFIG_PATH}, using defaults: {error}");
-                    KnowledgeGraphConfig::default()
-                }
-            },
-            Err(error) => {
-                warn!("Could not read {KNOWLEDGE_GRAPH_CONFIG_PATH}, using defaults: {error}");
-                KnowledgeGraphConfig::default()
-            }
-        }
-    } else {
-        info!("{KNOWLEDGE_GRAPH_CONFIG_PATH} not found, using defaults");
-        KnowledgeGraphConfig::default()
-    };
-
-    commands.insert_resource(config);
-}
-
-/// Compare `subject` against every material in `catalog` and return the seeds
-/// and similarity scores of materials that exceed `threshold`.
-///
-/// The subject seed is included in the catalog but the caller is responsible
-/// for skipping self-comparisons (seed == subject_seed).
-///
-/// Returns a `Vec<(seed, similarity_score)>` sorted by descending similarity.
-pub fn detect_similarity(
-    subject_seed: u64,
-    subject: &crate::materials::GameMaterial,
-    catalog: &MaterialCatalog,
-    threshold: f32,
-) -> Vec<(u64, f32)> {
-    let subject_vec = subject.property_vector();
-    let mut results: Vec<(u64, f32)> = catalog
-        .seeds()
-        .filter(|&&seed| seed != subject_seed)
-        .filter_map(|&seed| {
-            let other = catalog.get_by_seed(seed)?;
-            let sim = cosine_similarity(&subject_vec, &other.property_vector());
-            if sim >= threshold {
-                Some((seed, sim))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Deterministic ordering: highest similarity first, then by seed for ties.
-    results.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(a.0.cmp(&b.0))
-    });
-    results
-}
-
-/// System that processes [`RecordObservation`] messages and builds cross-references
-/// in the [`KnowledgeGraph`].
-///
-/// For each observation the system:
-///
-/// 1. Ensures a concept node exists for the observation subject.
-/// 2. If the observation carries a `context_location`, creates a `FoundOn` edge
-///    (for materials) or `ObservedAt` edge (for other subjects) between the
-///    subject and the location concept.
-/// 3. If the observation is for a [`JournalKey::Fabrication`] output and
-///    `input_seeds` are provided, creates `DerivedFrom` edges from the output
-///    concept to each input material concept, and `CombinedWith` edges between
-///    each pair of input materials.
-///
-/// All edges are bidirectional (enforced by [`KnowledgeGraph::relate`]).
-/// No cross-reference is created without an observation event — the system
-/// never infers connections the player hasn't made.
-pub fn update_knowledge_graph(
-    mut observations: MessageReader<RecordObservation>,
-    mut graph: ResMut<KnowledgeGraph>,
-    time: Res<Time>,
-    catalog: Res<MaterialCatalog>,
-    kg_config: Res<KnowledgeGraphConfig>,
-) {
-    let tick = time.elapsed().as_millis() as u64;
-
-    for obs in observations.read() {
-        let subject_category = category_from_key(&obs.key);
-        let subject_node =
-            graph.ensure_concept(ConceptId::new(obs.key.clone()), subject_category, tick);
-
-        // Update the concept node's confidence to reflect the latest observation.
-        // This is required so that the SimilarTo check can gate on both materials
-        // being at Observed tier or above (confidence ≥ 0.3).
-        if let Some(node) = graph.node_mut(subject_node) {
-            node.confidence.accumulate(obs.observation.confidence.0);
-        }
-
-        // ── Location cross-reference ──────────────────────────────────────
-        // If the observation has a location context, link the subject to that
-        // location. Materials use FoundOn; other subjects use ObservedAt.
-        if let Some(location_key) = &obs.context_location {
-            let location_node = graph.ensure_concept(
-                ConceptId::new(location_key.clone()),
-                ConceptCategory::Location,
-                tick,
-            );
-
-            let relationship = match &obs.key {
-                JournalKey::Material { .. } => RelationshipType::FoundOn,
-                JournalKey::Fabrication { .. } => RelationshipType::ObservedAt,
-            };
-
-            graph.relate(
-                subject_node,
-                location_node,
-                ConceptEdge::new(relationship, obs.observation.confidence, tick),
-            );
-        }
-
-        // ── Fabrication cross-references ──────────────────────────────────
-        // For fabrication outputs, create DerivedFrom edges to each input
-        // material and CombinedWith edges between each pair of inputs.
-        if let JournalKey::Fabrication { .. } = &obs.key {
-            // Collect NodeIndexes for all input materials first so we can
-            // create CombinedWith edges between them without borrowing issues.
-            let mut input_nodes: Vec<NodeIndex> = Vec::with_capacity(obs.input_seeds.len());
-
-            for &input_seed in &obs.input_seeds {
-                let input_key = JournalKey::Material {
-                    seed: input_seed,
-                    planet_seed: None,
-                };
-                let input_node = graph.ensure_concept(
-                    ConceptId::new(input_key),
-                    ConceptCategory::Material,
-                    tick,
-                );
-                input_nodes.push(input_node);
-
-                // Fabrication is directly observed — confidence is 1.0.
-                graph.relate(
-                    subject_node,
-                    input_node,
-                    ConceptEdge::new(RelationshipType::DerivedFrom, Confidence(1.0), tick),
-                );
-            }
-
-            // CombinedWith edges between every pair of input materials.
-            // For two inputs A and B: A CombinedWith B (and B CombinedWith A
-            // via relate's bidirectionality).
-            for i in 0..input_nodes.len() {
-                for j in (i + 1)..input_nodes.len() {
-                    graph.relate(
-                        input_nodes[i],
-                        input_nodes[j],
-                        ConceptEdge::new(RelationshipType::CombinedWith, Confidence(1.0), tick),
-                    );
-                }
-            }
-        }
-
-        // ── Similarity cross-references ───────────────────────────────────
-        // For material observations, compare the subject against all known
-        // materials in the catalog. SimilarTo edges are only created when
-        // BOTH materials are at Observed tier or above (confidence ≥ 0.3),
-        // ensuring the player has earned the connection through observation.
-        if let JournalKey::Material {
-            seed: subject_seed, ..
-        } = &obs.key
-        {
-            let subject_confidence = graph
-                .node(subject_node)
-                .map(|n| n.confidence)
-                .unwrap_or(Confidence(0.0));
-
-            // Only proceed if the subject material itself is at Observed tier.
-            if subject_confidence.0 >= kg_config.similarity_confidence_threshold {
-                let subject_mat = catalog.get_by_seed(*subject_seed).cloned();
-
-                if let Some(subject_mat) = subject_mat {
-                    let similar_pairs = detect_similarity(
-                        *subject_seed,
-                        &subject_mat,
-                        &catalog,
-                        kg_config.similarity_score_threshold,
-                    );
-
-                    for (other_seed, similarity_score) in similar_pairs {
-                        // Skip self-comparison.
-                        if other_seed == *subject_seed {
-                            continue;
-                        }
-
-                        let other_key = JournalKey::Material {
-                            seed: other_seed,
-                            planet_seed: None,
-                        };
-                        let other_id = ConceptId::new(other_key.clone());
-
-                        // Only create the edge if the other material is also
-                        // known to the graph at Observed tier or above.
-                        // The player must have earned confidence in both.
-                        let other_node_opt = graph.lookup(&other_id);
-                        let other_confidence = other_node_opt
-                            .and_then(|n| graph.node(n))
-                            .map(|n| n.confidence)
-                            .unwrap_or(Confidence(0.0));
-
-                        if other_confidence.0 < kg_config.similarity_confidence_threshold {
-                            continue;
-                        }
-
-                        let other_node =
-                            graph.ensure_concept(other_id, ConceptCategory::Material, tick);
-
-                        graph.relate(
-                            subject_node,
-                            other_node,
-                            ConceptEdge::new(
-                                RelationshipType::SimilarTo,
-                                Confidence(similarity_score),
-                                tick,
-                            ),
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ── Concept identity ─────────────────────────────────────────────────────
-
-/// Unique concept identifier — wraps a [`JournalKey`] so every journal entry
-/// has a corresponding concept node in the knowledge graph.
-///
-/// The one-to-one mapping between `ConceptId` and `JournalKey` means that
-/// creating a concept node for a journal entry is always unambiguous: the
-/// concept's identity *is* the journal key. This avoids a separate ID space
-/// that could drift out of sync with the journal.
+/// Equality and hashing match those of the wrapped key, giving O(1) map
+/// lookups in [`KnowledgeGraph::concept_index`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConceptId(pub JournalKey);
 
-impl ConceptId {
-    /// Create a new concept identifier from a journal key.
-    pub fn new(key: JournalKey) -> Self {
-        Self(key)
-    }
+// ── Concept categories ────────────────────────────────────────────────────
 
-    /// Borrow the underlying journal key.
-    pub fn key(&self) -> &JournalKey {
-        &self.0
-    }
-}
-
-impl From<JournalKey> for ConceptId {
-    fn from(key: JournalKey) -> Self {
-        Self(key)
-    }
-}
-
-// ── Concept category ─────────────────────────────────────────────────────
-
-/// Encyclopedia-style grouping for concept nodes.
+/// High-level classification used for encyclopedia-style grouping and BFS
+/// category filtering.
 ///
-/// Categories allow the journal's encyclopedia view to group related concepts
-/// together (all materials, all locations, etc.) and let the bounded BFS
-/// traversal optionally filter results to a single category.
-///
-/// **Extensibility:** new categories (Language, Culture, Trade, Species, …)
-/// are added as variants here when their underlying game systems are
-/// implemented. Existing match arms do not need to change because the
-/// category is used for grouping and filtering, not for exhaustive dispatch.
+/// Variants map 1-to-1 onto [`JournalKey`] discriminants — [`ConceptId`]
+/// creation always supplies the correct category, so the graph never
+/// stores an inconsistent category for a node.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ConceptCategory {
-    /// Raw or fabricated materials the player has encountered.
+    /// A raw or discovered material.
     Material,
-    /// Planets, biomes, and other spatial locations.
+    /// A planetary or regional location.
     Location,
-    /// Outputs and processes from the fabrication system.
+    /// A fabrication output.
     Fabrication,
     // Future: Language, Culture, Trade, Species, etc.
 }
 
-// ── Concept node ─────────────────────────────────────────────────────────
+// ── Graph node ────────────────────────────────────────────────────────────
 
-/// A node in the knowledge graph — represents a concept the player has
-/// discovered and accumulated knowledge about.
+/// A node in the knowledge graph — represents a known concept.
 ///
-/// Each node corresponds to exactly one [`JournalEntry`] (via [`ConceptId`]).
-/// The node carries a snapshot of the player's current understanding:
-/// how confident they are overall, when they first encountered the concept,
-/// and which properties they have personally revealed through observation.
+/// Each node is created by [`KnowledgeGraph::ensure_concept`] on first
+/// encounter and is never removed (the graph accumulates monotonically).
 ///
-/// `revealed_properties` is a set of string keys rather than a typed enum
-/// so that new game systems can add property names without modifying this
-/// struct. The strings match the property names used by the observation
-/// system (e.g., `"thermal_resistance"`, `"density"`).
-///
-/// [`JournalEntry`]: crate::journal::JournalEntry
+/// As of Story 387 this node is the **sole storage location** for all
+/// player knowledge about a concept: the display name, every observation
+/// ever recorded, confidence, timestamps, and planet provenance all live
+/// here. The `Journal` component is now a pure query/UI layer — it holds
+/// no data between frames.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConceptNode {
-    /// The unique identifier for this concept, linking it to its journal entry.
+    /// Stable identity linking this node to the corresponding journal key.
     pub id: ConceptId,
-    /// Encyclopedia category for grouping and BFS filtering.
+    /// Coarse classification for encyclopedia grouping and BFS filtering.
     pub category: ConceptCategory,
-    /// Overall confidence in this concept, aggregated from all observations.
+    /// Player-facing display name for this concept (e.g. "Ferrite").
     ///
-    /// Starts at the confidence of the first observation and accumulates
-    /// as the player gathers more evidence. Used by the `SimilarTo` edge
-    /// creation logic: similarity edges are only created when both concepts
-    /// are at `Observed` tier or above (confidence ≥ 0.3).
+    /// Set on first observation and never overwritten — first observer wins,
+    /// matching the behaviour of the old `Journal::ensure_entry`.
+    pub name: String,
+    /// Overall confidence that this concept is real and correctly identified.
+    ///
+    /// Accumulated from every observation's confidence value. Used by the
+    /// similarity system to gate `SimilarTo` edge creation (must be at
+    /// `Observed` tier or above before cross-material comparisons fire).
     pub confidence: Confidence,
-    /// Game-time tick when the player first encountered this concept.
-    pub discovered_at: u64,
-    /// Set of property keys the player has personally revealed through
-    /// observation (e.g., `"thermal_resistance"`, `"density"`).
+    /// Game-time tick (whole seconds elapsed) when this concept was first
+    /// encountered. Immutable after creation.
+    pub first_observed_at: u64,
+    /// Game-time tick of the most recent observation recorded for this node.
+    /// Updated every time [`Self::add_observation`] or its accumulating
+    /// variants are called.
+    pub last_updated_at: u64,
+    /// Planet on which this concept was first observed.
     ///
-    /// Only properties the player has *observed* appear here — the system
-    /// never pre-populates this set from hidden material data. This enforces
-    /// the acceptance criterion that no cross-reference is created without
-    /// an observation event.
-    pub revealed_properties: HashSet<String>,
+    /// Populated from [`crate::observation::RecordObservation::planet_seed`] on
+    /// the first observation that carries a planet seed. `None` for fabricated
+    /// materials and concepts recorded without planetary context. Used by the
+    /// `CurrentPlanet` journal filter.
+    pub origin_planet_seed: Option<u64>,
+    /// Which named properties the player has directly observed on this concept.
+    ///
+    /// Keys match [`crate::journal::ObservationCategory::display_label`] so
+    /// the inspect panel and encyclopedia can check revealed status without
+    /// additional mapping.
+    pub revealed_properties: HashMap<crate::journal::ObservationCategory, f32>,
+    /// All observations recorded about this concept, grouped by category.
+    ///
+    /// Each category group is in chronological insertion order. Observations
+    /// within a group are deduplicated by description — a second identical
+    /// observation strengthens confidence rather than appending a duplicate.
+    ///
+    /// `BTreeMap` gives deterministic iteration order (important for
+    /// save/load reproducibility and test stability).
+    pub observations:
+        BTreeMap<crate::journal::ObservationCategory, Vec<crate::journal::Observation>>,
 }
 
+// ── ConceptNode observation methods ──────────────────────────────────────
+
 impl ConceptNode {
-    /// Create a new concept node with no revealed properties.
+    /// Construct a bare `ConceptNode` with no observations.
     ///
-    /// The `confidence` is set to the initial observation's confidence value.
-    /// `revealed_properties` starts empty and is populated as the player
-    /// makes observations.
-    pub fn new(
-        id: ConceptId,
-        category: ConceptCategory,
-        confidence: Confidence,
-        discovered_at: u64,
-    ) -> Self {
-        Self {
-            id,
+    /// Used by tests that need a `ConceptNode` value without going through
+    /// the full `KnowledgeGraph` machinery.
+    pub fn new(key: JournalKey, name: &str, tick: u64) -> Self {
+        let category = key.concept_category();
+        ConceptNode {
+            id: ConceptId(key),
             category,
-            confidence,
-            discovered_at,
-            revealed_properties: HashSet::new(),
+            name: name.to_string(),
+            confidence: Confidence(0.3),
+            first_observed_at: tick,
+            last_updated_at: tick,
+            origin_planet_seed: None,
+            revealed_properties: HashMap::new(),
+            observations: BTreeMap::new(),
         }
     }
 
-    /// Mark a property as revealed by the player.
+    /// Record an observation on this node, deduplicating by description within
+    /// the same category.
     ///
-    /// Idempotent — calling this multiple times with the same key is safe.
-    pub fn reveal_property(&mut self, property: impl Into<String>) {
-        self.revealed_properties.insert(property.into());
+    /// When an observation with the same category **and** the same description
+    /// already exists, the duplicate is not appended — instead the existing
+    /// observation's confidence is upgraded to the higher of the two values and
+    /// `last_updated_at` is advanced. This prevents the node from bloating when
+    /// systems repeatedly report the same finding (e.g. picking up the same
+    /// material multiple times).
+    ///
+    /// When the observation is genuinely new (different category or different
+    /// description), it is appended to the appropriate category group and
+    /// `last_updated_at` is advanced unconditionally.
+    pub fn add_observation(&mut self, observation: crate::journal::Observation) {
+        self.last_updated_at = observation.recorded_at;
+
+        let group = self
+            .observations
+            .entry(observation.category.clone())
+            .or_default();
+
+        if let Some(existing) = group
+            .iter_mut()
+            .find(|o| o.description == observation.description)
+        {
+            // Upgrade confidence if the new evidence is stronger.
+            if observation.confidence.0 > existing.confidence.0 {
+                existing.confidence = observation.confidence;
+            }
+            return;
+        }
+
+        group.push(observation);
     }
 
-    /// Whether the player has revealed the named property.
-    pub fn has_property(&self, property: &str) -> bool {
-        self.revealed_properties.contains(property)
+    /// Record an observation with confidence accumulation for existing
+    /// observations.
+    ///
+    /// When an observation with the same category and description already
+    /// exists, [`Confidence::accumulate`] is called with
+    /// `base_observation_weight * recovery_multiplier`. This gives diminishing
+    /// returns as evidence builds, matching Story 10.4's confidence model.
+    ///
+    /// `recovery_multiplier` should be:
+    /// - `> 1.0` when the player is engaging with the domain they died in
+    ///   (faster recovery)
+    /// - `< 1.0` for unrelated domains after a death
+    /// - `= 1.0` for normal play without death context
+    ///
+    /// When the observation is genuinely new it is appended as-is.
+    pub fn add_observation_with_accumulation(
+        &mut self,
+        observation: crate::journal::Observation,
+        config: &crate::observation::ConfidenceConfig,
+    ) {
+        self.add_observation_with_domain_weighted_accumulation(observation, config, 1.0);
+    }
+
+    /// When the observation is genuinely new it is appended as-is.
+    pub fn add_observation_with_domain_weighted_accumulation(
+        &mut self,
+        observation: crate::journal::Observation,
+        config: &crate::observation::ConfidenceConfig,
+        recovery_multiplier: f32,
+    ) {
+        self.last_updated_at = observation.recorded_at;
+
+        let group = self
+            .observations
+            .entry(observation.category.clone())
+            .or_default();
+
+        if let Some(existing) = group
+            .iter_mut()
+            .find(|o| o.description == observation.description)
+        {
+            let adjusted_weight = config.base_observation_weight * recovery_multiplier;
+            existing.confidence.accumulate(adjusted_weight);
+            return;
+        }
+
+        group.push(observation);
+    }
+
+    /// Return all observations for a given category, in insertion order.
+    ///
+    /// Returns an empty slice when no observations for that category exist yet.
+    pub fn observations_by_category(
+        &self,
+        category: &crate::journal::ObservationCategory,
+    ) -> &[crate::journal::Observation] {
+        self.observations
+            .get(category)
+            .map_or(&[], |v| v.as_slice())
+    }
+
+    /// Total observation count across all categories.
+    pub fn observation_count(&self) -> usize {
+        self.observations.values().map(|v| v.len()).sum()
+    }
+
+    /// Iterator over all observations across all categories, in deterministic
+    /// category order (driven by `BTreeMap`) then insertion order within each
+    /// category.
+    pub fn all_observations(&self) -> impl Iterator<Item = &crate::journal::Observation> {
+        self.observations.values().flat_map(|v| v.iter())
     }
 }
 
-// ── Relationship type ─────────────────────────────────────────────────────
+// ── Relationship types ────────────────────────────────────────────────────
 
-/// The typed relationship between two concept nodes in the knowledge graph.
+/// Types of relationships between journal subjects.
 ///
-/// Each variant describes *how* one concept relates to another. Relationships
-/// are directional: the edge goes from a source concept to a target concept,
-/// and the variant names are written from the source's perspective
-/// (e.g., `FoundOn` means "source was found on target").
-///
-/// **Extensibility:** new relationship types (SpokenBy, TradedAt, UsedIn, …)
-/// are added as variants here when their underlying game systems are
-/// implemented. The `ConceptEdge` struct is unchanged by new variants.
+/// Every edge in the knowledge graph is one of these typed relationships.
+/// The set is exhaustive for Story 10.5 and deliberately extensible —
+/// future systems (language, trade, culture) add variants here without
+/// touching existing match arms.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RelationshipType {
-    /// Source material was found on the target location.
-    ///
-    /// Created automatically when a material observation is recorded with a
-    /// planet/location context.
+    /// A material was found on a specific planet or location.
     FoundOn,
-    /// Source material was combined with the target material in the fabricator.
-    ///
-    /// Created when a fabrication event records both input materials.
+    /// Two materials were combined in the fabricator.
     CombinedWith,
-    /// Source material was derived from the target input material.
-    ///
-    /// Created for fabrication outputs: the output concept links back to each
-    /// input material via `DerivedFrom`.
+    /// An output material was derived from one or more input materials.
     DerivedFrom,
-    /// Source material has similar properties to the target material.
-    ///
-    /// Created automatically when cosine similarity between property vectors
-    /// meets or exceeds the configured threshold, but only when both concepts
-    /// are at `Observed` confidence tier or above. The system never surfaces
-    /// this connection before the player has earned it.
+    /// Two materials share similar measured properties above the similarity
+    /// threshold. Only created when both materials are at `Observed` tier
+    /// or above so the player has earned the insight.
     SimilarTo,
-    /// Source observation was made at the target location.
-    ///
-    /// More general than `FoundOn` — used when the observation subject is not
-    /// a material (e.g., a fabrication event observed at a specific outpost).
+    /// An observation was made at a specific location (weaker than `FoundOn`
+    /// — records a connection without implying the subject originated there).
     ObservedAt,
     // Future: SpokenBy, TradedAt, UsedIn, etc.
 }
 
-// ── Concept edge ──────────────────────────────────────────────────────────
+impl RelationshipType {
+    /// Player-facing label used in the journal "Related" section header
+    /// for each cross-reference link.
+    ///
+    /// These labels are deliberately factual and terse — no flavour text.
+    /// The player draws their own conclusions from the connection.
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            RelationshipType::FoundOn => "Found on",
+            RelationshipType::CombinedWith => "Combined with",
+            RelationshipType::DerivedFrom => "Derived from",
+            RelationshipType::SimilarTo => "Similar to",
+            RelationshipType::ObservedAt => "Observed at",
+        }
+    }
+}
 
-/// A typed, weighted edge in the knowledge graph between two concept nodes.
+// ── Graph edge ────────────────────────────────────────────────────────────
+
+/// A typed, confidence-bearing relationship between two concept nodes.
 ///
-/// Edges are directional (from source to target) and carry a [`RelationshipType`]
-/// that describes the nature of the connection. The `confidence` field
-/// accumulates as the player gathers repeated evidence for the same
-/// relationship — the same edge strengthens rather than duplicating.
-///
-/// `discovered_at` records the game-time tick of the *first* observation that
-/// established this relationship. Subsequent observations that strengthen the
-/// edge do not update this field, preserving the discovery timeline.
-///
-/// Edges are serializable so the full knowledge graph can be saved and
-/// restored across play sessions.
+/// Edges are directional in petgraph but are interpreted as bidirectional
+/// by [`KnowledgeGraph::relationships`], which walks both incoming and
+/// outgoing edges. This keeps storage at half the edges while giving the
+/// UI the "bidirectional links" behaviour specified in the acceptance
+/// criteria.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConceptEdge {
-    /// The nature of the relationship from source concept to target concept.
+    /// The nature of the relationship between the two concepts.
     pub relationship: RelationshipType,
-    /// Accumulated confidence in this relationship.
-    ///
-    /// Starts at the confidence of the first observation that created the edge
-    /// and increases as the player makes additional observations that confirm
-    /// the same connection. Capped at `1.0`.
+    /// How certain the player is that this relationship is real, accumulated
+    /// each time a new observation confirms the same connection.
     pub confidence: Confidence,
-    /// Game-time tick when this relationship was first observed.
+    /// Game-time tick (whole seconds elapsed) when this relationship was
+    /// first established.
     pub discovered_at: u64,
 }
 
-impl ConceptEdge {
-    /// Create a new edge with the given relationship type, confidence, and
-    /// discovery tick.
-    pub fn new(relationship: RelationshipType, confidence: Confidence, discovered_at: u64) -> Self {
-        Self {
-            relationship,
-            confidence,
-            discovered_at,
-        }
-    }
+// ── Knowledge graph resource ──────────────────────────────────────────────
 
-    /// Strengthen this edge by incorporating additional evidence.
-    ///
-    /// The new confidence is the maximum of the current value and the incoming
-    /// value, capped at `1.0`. This ensures that repeated observations of the
-    /// same relationship monotonically increase (or maintain) confidence and
-    /// never decrease it due to a weaker subsequent observation.
-    ///
-    /// `discovered_at` is intentionally *not* updated — the edge retains the
-    /// tick of its first observation.
-    pub fn strengthen(&mut self, additional_confidence: Confidence) {
-        let combined = (self.confidence.0 + additional_confidence.0).min(1.0);
-        self.confidence = Confidence(combined);
-    }
-}
-
-// ── KnowledgeGraph resource ───────────────────────────────────────────────
-
-/// The player's knowledge graph — backed by `petgraph::Graph`.
+/// The player's knowledge graph — per architecture decision, backed by
+/// [`petgraph::Graph`].
 ///
-/// Every concept the player has discovered is a node; every observed
-/// relationship between two concepts is a directed edge. The graph is
-/// undirected in spirit (cross-references are bidirectional) but implemented
-/// as a directed graph so that each edge carries its own [`RelationshipType`]
-/// and the direction encodes the semantic role (e.g., "Material → FoundOn →
-/// Location" vs. "Location → FoundOn → Material" would be two separate edges).
+/// The graph is a directed multigraph: each concept is a node and each
+/// observed relationship is an edge. Most queries treat edges as
+/// undirected (relationships are symmetric in the player's mental model)
+/// but petgraph stores them directed so we can reach them efficiently with
+/// `edges_directed` in both directions.
 ///
-/// Bidirectionality is enforced by [`KnowledgeGraph::relate`], which always
-/// inserts both the forward and reverse edge when a relationship is recorded.
+/// Three indexes give O(1) lookups on top of the O(log n) petgraph
+/// internal structures:
 ///
-/// # Indexes
+/// * `concept_index` — `ConceptId → NodeIndex` for idempotent node creation
+///   and edge wiring.
+/// * `category_index` — `ConceptCategory → Vec<NodeIndex>` for encyclopedia
+///   view ("all known materials") and BFS filtering.
+/// * `timeline` — `(tick, NodeIndex)` pairs in discovery order for the event
+///   log view.
 ///
-/// Three auxiliary indexes are maintained alongside the graph for O(1) or
-/// O(k) lookups that would otherwise require a full graph scan:
-///
-/// - `concept_index`: maps [`ConceptId`] → [`NodeIndex`] for O(1) node lookup.
-/// - `category_index`: maps [`ConceptCategory`] → `Vec<NodeIndex>` for
-///   encyclopedia-style listing of all concepts in a category.
-/// - `timeline`: ordered list of `(tick, NodeIndex)` pairs recording the
-///   discovery order of concepts.
-///
-/// # Serialization
-///
-/// The `petgraph::Graph` type serializes its node and edge weights directly
-/// when the `serde-1` feature is enabled. The auxiliary indexes are derived
-/// from the graph and are therefore re-derived on deserialization rather than
-/// stored, keeping the save file compact and avoiding index/graph drift.
-#[derive(Resource)]
+/// **Serialization strategy:** `petgraph::Graph` serializes cleanly with the
+/// `serde-1` feature. The three indexes are rebuilt from the graph on
+/// deserialization — they are not stored explicitly — ensuring the indexes
+/// always stay consistent with the canonical graph data.
+#[derive(Resource, Clone, Debug, Default)]
 pub struct KnowledgeGraph {
-    /// The underlying directed graph. Nodes are [`ConceptNode`]s; edges are
-    /// [`ConceptEdge`]s. Directed so that edge semantics are preserved.
+    /// Core petgraph directed graph with typed nodes and edges.
     graph: Graph<ConceptNode, ConceptEdge>,
-    /// O(1) lookup: [`ConceptId`] → [`NodeIndex`].
-    ///
-    /// Not serialized — rebuilt from the graph on load.
-    #[allow(clippy::zero_sized_map_values)]
+    /// Primary index: `ConceptId → NodeIndex` for O(1) lookups.
     concept_index: HashMap<ConceptId, NodeIndex>,
-    /// Category index for encyclopedia view: category → list of node indexes.
-    ///
-    /// Not serialized — rebuilt from the graph on load.
+    /// Category index: `ConceptCategory → Vec<NodeIndex>` for encyclopedia view.
     category_index: HashMap<ConceptCategory, Vec<NodeIndex>>,
-    /// Timeline of concept discoveries in insertion order: `(tick, NodeIndex)`.
-    ///
-    /// Not serialized — rebuilt from the graph on load.
+    /// Timeline of discoveries in insertion order (monotone by tick).
     timeline: Vec<(u64, NodeIndex)>,
 }
 
-impl Default for KnowledgeGraph {
-    fn default() -> Self {
-        Self {
-            graph: Graph::new(),
-            concept_index: HashMap::new(),
-            category_index: HashMap::new(),
-            timeline: Vec::new(),
-        }
-    }
-}
-
 impl KnowledgeGraph {
-    /// Create an empty knowledge graph.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    // ── Node operations ───────────────────────────────────────────────────
 
-    /// Get or create a concept node for the given [`ConceptId`].
+    /// Get or create a concept node and return its [`NodeIndex`].
     ///
-    /// If the concept already exists, its [`NodeIndex`] is returned unchanged
-    /// and no new node is inserted. If it does not exist, a new node is created
-    /// with the given `category`, an initial confidence of `0.0`, and the
-    /// provided `tick` as its discovery time.
+    /// Idempotent: calling this twice with the same `id` returns the same
+    /// `NodeIndex` and does NOT overwrite the existing node's data. The
+    /// node's `discovered_at` and `confidence` are set only on creation.
     ///
-    /// The concept is also registered in the category index and timeline on
-    /// first insertion.
+    /// Maintains [`Self::concept_index`], [`Self::category_index`], and
+    /// [`Self::timeline`] atomically — all three are always in sync.
     pub fn ensure_concept(
         &mut self,
         id: ConceptId,
         category: ConceptCategory,
         tick: u64,
     ) -> NodeIndex {
-        if let Some(&idx) = self.concept_index.get(&id) {
-            return idx;
+        if let Some(&existing) = self.concept_index.get(&id) {
+            return existing;
         }
 
-        let node = ConceptNode::new(id.clone(), category.clone(), Confidence(0.0), tick);
-        let idx = self.graph.add_node(node);
+        let node = ConceptNode {
+            id: id.clone(),
+            category: category.clone(),
+            name: String::new(),
+            confidence: Confidence(0.3), // Start at Tentative/Observed boundary
+            first_observed_at: tick,
+            last_updated_at: tick,
+            origin_planet_seed: None,
+            revealed_properties: HashMap::new(),
+            observations: BTreeMap::new(),
+        };
 
+        let idx = self.graph.add_node(node);
         self.concept_index.insert(id, idx);
         self.category_index.entry(category).or_default().push(idx);
         self.timeline.push((tick, idx));
-
         idx
     }
 
-    /// Add or strengthen a typed relationship between two concept nodes.
+    /// Look up a concept by its [`ConceptId`].
     ///
-    /// Cross-references are **bidirectional**: calling `relate(from, to, edge)`
-    /// inserts both a forward edge (`from → to`) and a reverse edge
-    /// (`to → from`) with the same relationship type and confidence. This
-    /// satisfies the acceptance criterion that "if Material X links to Planet Y,
-    /// Planet Y links back to Material X."
-    ///
-    /// If an edge with the same [`RelationshipType`] already exists between the
-    /// two nodes in a given direction, it is **strengthened** (confidence
-    /// accumulates) rather than duplicated. This satisfies the criterion that
-    /// "cross-references accumulate — the same relationship strengthens with
-    /// repeated evidence."
-    ///
-    /// # Panics
-    ///
-    /// Panics if `from` or `to` are not valid node indexes in this graph.
-    pub fn relate(&mut self, from: NodeIndex, to: NodeIndex, edge: ConceptEdge) {
-        // Forward edge: from → to
-        Self::upsert_edge(&mut self.graph, from, to, edge.clone());
-        // Reverse edge: to → from (same relationship type, same confidence)
-        Self::upsert_edge(&mut self.graph, to, from, edge);
+    /// Returns `None` when the concept has not yet been observed. Callers
+    /// use [`ensure_concept`](Self::ensure_concept) to create on first
+    /// encounter and `lookup` only when they need to assert existence.
+    pub fn lookup(&self, id: &ConceptId) -> Option<NodeIndex> {
+        self.concept_index.get(id).copied()
     }
 
-    /// Insert a new edge or strengthen an existing one with the same
-    /// relationship type between the same pair of nodes.
-    fn upsert_edge(
-        graph: &mut Graph<ConceptNode, ConceptEdge>,
-        from: NodeIndex,
-        to: NodeIndex,
-        new_edge: ConceptEdge,
+    /// Get a reference to the node data for a given index.
+    ///
+    /// Returns `None` if the index is invalid (should not happen during
+    /// normal gameplay since indexes are never removed).
+    pub fn node(&self, idx: NodeIndex) -> Option<&ConceptNode> {
+        self.graph.node_weight(idx)
+    }
+
+    /// Mutable access to a concept node by index.
+    ///
+    /// Used by test helpers and save-migration code that need to directly
+    /// patch a node's fields. Production write paths go through the message
+    /// pipeline and `update_knowledge_graph`.
+    pub fn node_mut(&mut self, idx: NodeIndex) -> Option<&mut ConceptNode> {
+        self.graph.node_weight_mut(idx)
+    }
+
+    /// Count of nodes that have a non-empty name.
+    ///
+    /// Location nodes and any concept created before its first `RecordObservation`
+    /// arrives have an empty `name`; the journal list panel skips those.
+    /// This count mirrors the entry count the old `journal.entries.len()` produced.
+    pub fn named_node_count(&self) -> usize {
+        self.graph
+            .node_indices()
+            .filter_map(|idx| self.graph.node_weight(idx))
+            .filter(|n| !n.name.is_empty())
+            .count()
+    }
+
+    /// Count of named nodes that pass a journal filter.
+    pub fn named_node_count_filtered(&self, filter: &crate::journal::JournalFilter) -> usize {
+        self.graph
+            .node_indices()
+            .filter_map(|idx| self.graph.node_weight(idx))
+            .filter(|n| !n.name.is_empty())
+            .filter(|n| crate::journal::matches_filter_node(n, filter))
+            .count()
+    }
+
+    /// Record a named observation on a concept node.  Test helper for any test
+    /// that used to call `journal.record(key, name, obs)`.
+    ///
+    /// Creates the concept if it doesn't exist, stamps the name on first call,
+    /// and delegates to [`ConceptNode::add_observation`].
+    pub fn record(
+        &mut self,
+        key: crate::journal::JournalKey,
+        name: &str,
+        observation: crate::journal::Observation,
     ) {
-        // Search for an existing edge with the same relationship type.
-        let existing = graph
-            .edges_directed(from, Direction::Outgoing)
-            .find(|e| e.target() == to && e.weight().relationship == new_edge.relationship)
+        let category = key.concept_category();
+        let tick = observation.recorded_at;
+        let id = ConceptId(key);
+        let idx = self.ensure_concept(id, category, tick);
+        let node = self.graph.node_weight_mut(idx).expect("just created");
+        if node.name.is_empty() {
+            node.name = name.to_string();
+        }
+        node.add_observation(observation);
+    }
+
+    /// Convenience: record with domain-weighted accumulation. Test helper.
+    pub fn record_with_accumulation(
+        &mut self,
+        key: crate::journal::JournalKey,
+        name: &str,
+        observation: crate::journal::Observation,
+        config: &crate::observation::ConfidenceConfig,
+    ) {
+        self.record_with_domain_weighted_accumulation(key, name, observation, config, 1.0);
+    }
+
+    /// Convenience: record with domain-weighted accumulation. Test helper.
+    pub fn record_with_domain_weighted_accumulation(
+        &mut self,
+        key: crate::journal::JournalKey,
+        name: &str,
+        observation: crate::journal::Observation,
+        config: &crate::observation::ConfidenceConfig,
+        recovery_multiplier: f32,
+    ) {
+        let category = key.concept_category();
+        let tick = observation.recorded_at;
+        let id = ConceptId(key);
+        let idx = self.ensure_concept(id, category, tick);
+        let node = self.graph.node_weight_mut(idx).expect("just created");
+        if node.name.is_empty() {
+            node.name = name.to_string();
+        }
+        node.add_observation_with_domain_weighted_accumulation(
+            observation,
+            config,
+            recovery_multiplier,
+        );
+    }
+
+    /// Remove a concept node by key. Returns `true` if the node existed.
+    ///
+    /// Used by test helpers that simulate deletion. The internal indexes
+    /// are updated; edges connected to the removed node are dropped by petgraph.
+    pub fn remove(&mut self, key: &crate::journal::JournalKey) {
+        let id = ConceptId(key.clone());
+        let Some(idx) = self.concept_index.remove(&id) else {
+            return;
+        };
+        // Remove from category index.
+        if let Some(cat_vec) = self
+            .category_index
+            .get_mut(&self.graph[idx].category.clone())
+        {
+            cat_vec.retain(|&i| i != idx);
+        }
+        // Remove from timeline.
+        self.timeline.retain(|(_, i)| *i != idx);
+        // Remove from graph (also removes connected edges).
+        self.graph.remove_node(idx);
+        // NOTE: removing a node invalidates the NodeIndex values stored in
+        // concept_index for nodes with higher internal indices.  Rebuild the
+        // concept_index from scratch to keep it consistent.
+        let mut new_index = std::collections::HashMap::new();
+        for (id_key, &stored_idx) in &self.concept_index {
+            new_index.insert(id_key.clone(), stored_idx);
+        }
+        // Actually petgraph's `remove_node` uses swap_remove semantics, so
+        // re-scan the graph to rebuild.
+        let mut rebuilt: std::collections::HashMap<ConceptId, NodeIndex> =
+            std::collections::HashMap::new();
+        let mut rebuilt_cat: std::collections::HashMap<ConceptCategory, Vec<NodeIndex>> =
+            std::collections::HashMap::new();
+        let mut rebuilt_tl: Vec<(u64, NodeIndex)> = Vec::new();
+        for ni in self.graph.node_indices() {
+            let n = &self.graph[ni];
+            rebuilt.insert(n.id.clone(), ni);
+            rebuilt_cat.entry(n.category.clone()).or_default().push(ni);
+            rebuilt_tl.push((n.first_observed_at, ni));
+        }
+        rebuilt_tl.sort_by_key(|(t, _)| *t);
+        self.concept_index = rebuilt;
+        self.category_index = rebuilt_cat;
+        self.timeline = rebuilt_tl;
+    }
+
+    // ── Edge operations ───────────────────────────────────────────────────
+
+    /// Add or strengthen a relationship between two concepts.
+    ///
+    /// If an edge of the same [`RelationshipType`] already exists between
+    /// `from` and `to`, its confidence is accumulated (diminishing returns)
+    /// rather than a duplicate edge being added. This satisfies the
+    /// acceptance criterion that "cross-references accumulate — the same
+    /// relationship strengthens with repeated evidence".
+    ///
+    /// Direction: `from → to`. [`Self::relationships`] exposes both
+    /// directions to callers, so the UI sees the edge regardless of which
+    /// side it queries from.
+    pub fn relate(&mut self, from: NodeIndex, to: NodeIndex, edge: ConceptEdge) {
+        // Look for an existing edge of the same type to strengthen.
+        let existing = self
+            .graph
+            .edges_connecting(from, to)
+            .find(|e| e.weight().relationship == edge.relationship)
             .map(|e| e.id());
 
         if let Some(edge_id) = existing {
-            graph[edge_id].strengthen(new_edge.confidence);
+            // Accumulate evidence rather than duplicating.
+            if let Some(existing_edge) = self.graph.edge_weight_mut(edge_id) {
+                existing_edge.confidence.accumulate(0.2);
+            }
         } else {
-            graph.add_edge(from, to, new_edge);
+            self.graph.add_edge(from, to, edge);
         }
     }
 
-    /// Get all relationships for a concept node — returns `(neighbor NodeIndex,
-    /// &ConceptEdge)` pairs for every outgoing edge from this node.
+    /// All relationships for a concept, in both directions.
     ///
-    /// Because [`KnowledgeGraph::relate`] always inserts both a forward and a
-    /// reverse edge, iterating outgoing edges is sufficient to enumerate all
-    /// connections: every relationship the node participates in appears as an
-    /// outgoing edge in at least one direction. Callers that need to display
-    /// "all connections" for a concept should call this method; the result
-    /// already includes the reverse direction because `relate` inserted it.
+    /// Returns `(neighbor_index, edge)` pairs for every edge incident on
+    /// `node` whether it points outward (the concept is the `from` side)
+    /// or inward (it is the `to` side). This gives the caller a
+    /// bidirectional view without storing duplicate edges in the graph.
+    ///
+    /// The order follows petgraph's stable edge-list iteration, which is
+    /// insertion order within each direction for the same node.
     pub fn relationships(&self, node: NodeIndex) -> Vec<(NodeIndex, &ConceptEdge)> {
-        self.graph
+        let outgoing = self
+            .graph
             .edges_directed(node, Direction::Outgoing)
-            .map(|e| (e.target(), e.weight()))
-            .collect()
+            .map(|e| (e.target(), e.weight()));
+
+        let incoming = self
+            .graph
+            .edges_directed(node, Direction::Incoming)
+            .map(|e| (e.source(), e.weight()));
+
+        outgoing.chain(incoming).collect()
     }
 
-    /// Bounded BFS from a concept node, returning all reachable nodes within
-    /// `depth` hops along with their hop distance from the center.
+    // ── Category queries ──────────────────────────────────────────────────
+
+    /// All concept node indexes in a given category.
     ///
-    /// The center node itself is **not** included in the result. If
-    /// `category_filter` is `Some`, only nodes whose category matches are
-    /// included in the result (but the BFS still traverses through nodes of
-    /// other categories to find matching ones within the depth limit).
+    /// Returns an empty slice when no concepts of that category have been
+    /// registered yet. Insertion order within each category matches the
+    /// order in which [`ensure_concept`](Self::ensure_concept) was first
+    /// called.
+    pub fn by_category(&self, category: &ConceptCategory) -> &[NodeIndex] {
+        self.category_index
+            .get(category)
+            .map_or(&[], |v| v.as_slice())
+    }
+
+    // ── Timeline ─────────────────────────────────────────────────────────
+
+    /// Look up a material concept node by seed alone, ignoring `planet_seed`.
     ///
-    /// This method is the data-model foundation for the future associative web
-    /// view. It does not perform any rendering or UI work.
+    /// Returns the first [`NodeIndex`] found whose [`ConceptId`] wraps a
+    /// [`crate::journal::JournalKey::Material`] with the given `seed`, regardless
+    /// of what `planet_seed` that node was stored with.
+    ///
+    /// This exists to resolve the "identity mismatch" where a material is first
+    /// observed on a planet (key = `Material { seed: X, planet_seed: Some(Y) }`) but
+    /// is later referenced via fabrication input with `planet_seed: None`. Using
+    /// `lookup` directly would create a second, disconnected node — this method
+    /// prevents that by finding the existing node by seed.
+    ///
+    /// Returns `None` when no material with that seed exists in the graph yet.
+    pub fn lookup_material_by_seed(&self, seed: u64) -> Option<NodeIndex> {
+        self.concept_index.iter().find_map(|(id, &idx)| {
+            if matches!(&id.0, crate::journal::JournalKey::MaterialInstance { seed: s } if *s == seed) {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the concept node at the given index, or `None` if the index
+    /// is invalid.  Exposes read-only access to node data without making
+    /// the internal `petgraph::Graph` field public.
+    pub fn node_weight(&self, idx: NodeIndex) -> Option<&ConceptNode> {
+        self.graph.node_weight(idx)
+    }
+
+    /// Mark a property as revealed on the given concept node.
+    ///
+    /// Called each time the player makes an observation of a specific category
+    /// on this concept. The `property_name` should be the
+    /// Record that the player has observed a specific property on this concept
+    /// and store the raw measured value.
+    ///
+    /// `category` is the typed observation kind; `value` is the underlying
+    /// float from [`crate::materials::GameMaterial`] at the moment of
+    /// revelation — stored so the classification system can compare against
+    /// asset-defined ranges without reaching back into world entities.
+    ///
+    /// No-ops when the node index is invalid.
+    pub fn reveal_property(
+        &mut self,
+        node: NodeIndex,
+        category: crate::journal::ObservationCategory,
+        value: f32,
+    ) {
+        if let Some(n) = self.graph.node_weight_mut(node) {
+            n.revealed_properties.insert(category, value);
+        }
+    }
+
+    /// Mutable access to the underlying petgraph `Graph` — exposed only for
+    /// test code that needs to directly populate node fields (e.g. seeding
+    /// confidence or observation data without going through the message
+    /// pipeline). Production code should use the typed accessors instead.
+    ///
+    /// Marked `pub` because the observation module's tests are in a sibling
+    /// module and need to seed graph state for death-degradation assertions.
+    pub fn graph_mut(&mut self) -> &mut Graph<ConceptNode, ConceptEdge> {
+        &mut self.graph
+    }
+    /// Timeline of all discovered concepts in chronological order.
+    ///
+    /// Each entry is `(discovered_at_tick, node_index)`. Because
+    /// [`ensure_concept`](Self::ensure_concept) only appends to this
+    /// vec and the game clock is monotonically increasing, the timeline
+    /// is guaranteed to be in non-decreasing tick order.
+    pub fn timeline(&self) -> &[(u64, NodeIndex)] {
+        &self.timeline
+    }
+
+    /// All concept nodes sorted by name, for stable alphabetical display in the journal.
+    ///
+    /// Returns an empty vec when the graph has no nodes yet. Nodes with empty
+    /// names (location concepts that have never had a name stamped) sort to the
+    /// front — the UI skips them via `name.is_empty()` checks.
+    pub fn nodes_sorted_by_name(&self) -> Vec<NodeIndex> {
+        let mut pairs: Vec<(NodeIndex, &str)> = self
+            .graph
+            .node_indices()
+            .filter_map(|idx| self.graph.node_weight(idx))
+            .filter(|n| !n.name.is_empty())
+            // Location nodes are not player-facing journal entries — they exist
+            // only as cross-reference targets for FoundOn/ObservedAt edges.
+            // Exclude them from the sorted list so they don't appear in the
+            // main journal entry panel.
+            .filter(|n| n.category != ConceptCategory::Location)
+            .map(|n| {
+                let idx = self.concept_index[&n.id];
+                (idx, n.name.as_str())
+            })
+            .collect();
+        pairs.sort_by(|(_, a), (_, b)| a.cmp(b));
+        pairs.into_iter().map(|(idx, _)| idx).collect()
+    }
+
+    /// All concept nodes in a given category, sorted by name.
+    ///
+    /// Convenience wrapper over [`by_category`](Self::by_category) +
+    /// [`node`](Self::node) that also sorts alphabetically — the same
+    /// ordering used by the journal list panel.
+    pub fn nodes_in_category_sorted_by_name(&self, category: &ConceptCategory) -> Vec<NodeIndex> {
+        let mut pairs: Vec<(NodeIndex, &str)> = self
+            .by_category(category)
+            .iter()
+            .filter_map(|&idx| self.graph.node_weight(idx).map(|n| (idx, n.name.as_str())))
+            .collect();
+        pairs.sort_by(|(_, a), (_, b)| a.cmp(b));
+        pairs.into_iter().map(|(idx, _)| idx).collect()
+    }
+
+    /// Apply death confidence degradation to every observation and node
+    /// confidence in the graph.
+    ///
+    /// Called by the observation system's `handle_player_death` handler.
+    /// Iterates all nodes and degrades both the per-observation confidence
+    /// and the overall node confidence using the same factor/floor values
+    /// loaded from `assets/config/confidence.toml`.
+    pub fn degrade_all(&mut self, factor: f32, floor: f32) {
+        for idx in self.graph.node_indices().collect::<Vec<_>>() {
+            if let Some(node) = self.graph.node_weight_mut(idx) {
+                node.confidence.degrade(factor, floor);
+                for obs_group in node.observations.values_mut() {
+                    for obs in obs_group.iter_mut() {
+                        obs.confidence.degrade(factor, floor);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Bounded BFS from a center node, returning `(node_index, depth)`
+    /// pairs for all reachable nodes within `depth` hops.
+    ///
+    /// The center node itself is NOT included in the result — callers
+    /// already have it. Edges are traversed in both directions (the graph
+    /// is treated as undirected for BFS purposes), so the result is a
+    /// neighbourhood in the graph-theoretic sense rather than a directed
+    /// reachability set.
+    ///
+    /// # Arguments
+    ///
+    /// - `center` — Starting node index.
+    /// - `depth` — Maximum hop count. `depth = 1` returns only direct neighbours;
+    ///   `depth = 0` returns an empty vec (the center is excluded).
+    /// - `category_filter` — When `Some(category)`, only nodes that belong to that
+    ///   category are included in the result. Filtered-out nodes still participate in
+    ///   BFS traversal so their neighbours can be reached — the filter is applied at
+    ///   result collection time, not during graph traversal.
+    ///
+    /// # Cycle safety
+    ///
+    /// BFS uses a `visited` set to prevent re-queuing already-seen nodes,
+    /// so cycles in the graph never cause infinite loops.
     pub fn neighborhood(
         &self,
         center: NodeIndex,
@@ -771,28 +800,26 @@ impl KnowledgeGraph {
             return Vec::new();
         }
 
-        // BFS state: visited set and queue of (node, current_depth).
         let mut visited: HashSet<NodeIndex> = HashSet::new();
-        let mut queue: std::collections::VecDeque<(NodeIndex, usize)> =
-            std::collections::VecDeque::new();
+        let mut queue: VecDeque<(NodeIndex, usize)> = VecDeque::new();
         let mut result: Vec<(NodeIndex, usize)> = Vec::new();
 
         visited.insert(center);
         queue.push_back((center, 0));
 
-        while let Some((current, current_depth)) = queue.pop_front() {
+        while let Some((node, current_depth)) = queue.pop_front() {
             if current_depth >= depth {
                 continue;
             }
 
-            // Traverse all neighbors (both directions) from the current node.
+            // Walk both outgoing and incoming edges (undirected BFS).
             let neighbors: Vec<NodeIndex> = self
                 .graph
-                .edges_directed(current, Direction::Outgoing)
+                .edges_directed(node, Direction::Outgoing)
                 .map(|e| e.target())
                 .chain(
                     self.graph
-                        .edges_directed(current, Direction::Incoming)
+                        .edges_directed(node, Direction::Incoming)
                         .map(|e| e.source()),
                 )
                 .collect();
@@ -802,1361 +829,739 @@ impl KnowledgeGraph {
                     continue;
                 }
                 visited.insert(neighbor);
-                let hop = current_depth + 1;
+                let neighbor_depth = current_depth + 1;
+                queue.push_back((neighbor, neighbor_depth));
 
-                // Apply category filter to the result set, but always enqueue
-                // the neighbor so BFS can traverse through it.
-                let node_data = &self.graph[neighbor];
-                let passes_filter = category_filter
-                    .map(|cat| &node_data.category == cat)
-                    .unwrap_or(true);
+                // Apply category filter at collection time, not traversal time.
+                let include = category_filter.is_none_or(|cat| {
+                    self.graph
+                        .node_weight(neighbor)
+                        .is_some_and(|n| &n.category == cat)
+                });
 
-                if passes_filter {
-                    result.push((neighbor, hop));
+                if include {
+                    result.push((neighbor, neighbor_depth));
                 }
-
-                queue.push_back((neighbor, hop));
             }
         }
 
         result
     }
+}
 
-    /// All concept nodes in a given category, in insertion order.
-    ///
-    /// Returns an empty slice if no concepts of that category have been
-    /// discovered yet.
-    pub fn by_category(&self, category: &ConceptCategory) -> &[NodeIndex] {
-        self.category_index
-            .get(category)
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
+// ── Serialization ─────────────────────────────────────────────────────────
+
+/// Serializable snapshot of the graph, used for save/load.
+///
+/// We serialize the full node and edge data from petgraph directly (via the
+/// `serde-1` feature), then rebuild the three in-memory indexes on
+/// deserialization. This avoids storing redundant index data that could
+/// drift out of sync with the graph.
+///
+/// `petgraph::Graph` serializes as `{ nodes: [...], edges: [...] }` which
+/// is stable across petgraph minor versions, matching the versioning
+/// contract in the asset-pipeline architecture decision.
+impl Serialize for KnowledgeGraph {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Delegate entirely to petgraph's built-in serde support.
+        self.graph.serialize(serializer)
     }
+}
 
-    /// Timeline of concept discoveries: `(tick, NodeIndex)` pairs in
-    /// insertion order (earliest discovery first).
-    pub fn timeline(&self) -> &[(u64, NodeIndex)] {
-        &self.timeline
-    }
+impl<'de> Deserialize<'de> for KnowledgeGraph {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Restore the petgraph graph from saved data.
+        let graph: Graph<ConceptNode, ConceptEdge> = Graph::deserialize(deserializer)?;
 
-    /// Look up a concept node by its [`ConceptId`].
-    ///
-    /// Returns `None` if the concept has not been added to the graph yet.
-    pub fn lookup(&self, id: &ConceptId) -> Option<NodeIndex> {
-        self.concept_index.get(id).copied()
-    }
-
-    /// Borrow the [`ConceptNode`] data for a given [`NodeIndex`].
-    ///
-    /// Returns `None` if the index is not valid (e.g., after a node was
-    /// removed, though the current implementation never removes nodes).
-    pub fn node(&self, idx: NodeIndex) -> Option<&ConceptNode> {
-        self.graph.node_weight(idx)
-    }
-
-    /// Mutably borrow the [`ConceptNode`] data for a given [`NodeIndex`].
-    pub fn node_mut(&mut self, idx: NodeIndex) -> Option<&mut ConceptNode> {
-        self.graph.node_weight_mut(idx)
-    }
-
-    /// Serialize the knowledge graph to a JSON string for save/load.
-    ///
-    /// The auxiliary indexes (`concept_index`, `category_index`, `timeline`)
-    /// are **not** serialized — they are rebuilt from the graph on
-    /// deserialization via [`KnowledgeGraph::from_serializable`].
-    pub fn to_serializable(&self) -> SerializableKnowledgeGraph {
-        SerializableKnowledgeGraph {
-            graph: self.graph.clone(),
-        }
-    }
-
-    /// Reconstruct a `KnowledgeGraph` from its serialized form, rebuilding
-    /// all auxiliary indexes from the graph data.
-    pub fn from_serializable(serializable: SerializableKnowledgeGraph) -> Self {
-        let graph = serializable.graph;
-
-        let mut concept_index: HashMap<ConceptId, NodeIndex> = HashMap::new();
+        // Rebuild all three indexes from the restored graph — they are
+        // derivable from the node data so we never store them separately,
+        // eliminating any risk of index/graph divergence across save files.
+        let mut concept_index = HashMap::new();
         let mut category_index: HashMap<ConceptCategory, Vec<NodeIndex>> = HashMap::new();
         let mut timeline: Vec<(u64, NodeIndex)> = Vec::new();
 
         for idx in graph.node_indices() {
-            let node = &graph[idx];
-            concept_index.insert(node.id.clone(), idx);
-            category_index
-                .entry(node.category.clone())
-                .or_default()
-                .push(idx);
-            timeline.push((node.discovered_at, idx));
+            if let Some(node) = graph.node_weight(idx) {
+                concept_index.insert(node.id.clone(), idx);
+                category_index
+                    .entry(node.category.clone())
+                    .or_default()
+                    .push(idx);
+                timeline.push((node.first_observed_at, idx));
+            }
         }
 
-        // Sort timeline by tick to restore discovery order after round-trip.
+        // Restore chronological order — petgraph node iteration order is
+        // insertion order (stable), but after deserialization we cannot
+        // assume the original tick order was preserved without sorting.
         timeline.sort_by_key(|(tick, _)| *tick);
 
-        Self {
+        Ok(KnowledgeGraph {
             graph,
             concept_index,
             category_index,
             timeline,
+        })
+    }
+}
+
+// ── Automatic cross-reference system ─────────────────────────────────────
+
+/// Processes [`crate::observation::RecordObservation`] messages and populates
+/// the [`KnowledgeGraph`] with typed relationship edges.
+///
+/// As of Story 387 this is the **sole** observation write path.
+///
+/// # Edges created
+///
+/// * **`FoundOn`** — when a `Material` observation carries a `planet_seed`
+///   in its key, a `material → location` edge is created.
+/// * **`DerivedFrom`** — for `Fabrication` observations, an edge is created
+///   from the output concept to each input material listed in
+///   [`RecordObservation::input_seeds`].
+/// * **`ObservedAt`** — when the observation message includes a
+///   [`RecordObservation::context_location`], an `ObservedAt` edge is
+///   created from subject → location.
+///
+/// Processes [`crate::observation::RecordObservation`] messages, populates the
+/// [`KnowledgeGraph`] with observation data, and wires typed relationship edges.
+///
+/// This system is the **sole write path** for observation storage as of Story 387.
+/// The journal's `apply_observations` system has been removed; all data lives here.
+///
+/// Runs in [`crate::journal::JournalSet::Navigate`].
+///
+/// # What it does per message
+///
+/// 1. Ensures the subject concept node exists.
+/// 2. Stamps the display `name` on first encounter (first-observer-wins).
+/// 3. Stamps `origin_planet_seed` on first planet-seeded observation.
+/// 4. Records the observation onto the node with domain-weighted confidence
+///    accumulation (mirrors the old `JournalEntry` accumulation logic).
+/// 5. Marks the property category as revealed on the node.
+/// 6. Wires graph edges: `FoundOn`, `DerivedFrom`, `CombinedWith`, `ObservedAt`.
+fn update_knowledge_graph(
+    mut reader: MessageReader<crate::observation::RecordObservation>,
+    mut graph: ResMut<KnowledgeGraph>,
+    time: Res<Time>,
+    config: Res<ConfidenceConfig>,
+    catalog: Option<Res<crate::materials::MaterialCatalog>>,
+) {
+    let tick = time.elapsed().as_millis() as u64;
+
+    // Drain messages into a vec first so we can release the reader borrow
+    // before mutably borrowing the graph.
+    let messages: Vec<_> = reader.read().cloned().collect();
+
+    for obs in messages {
+        // Determine category for the observed subject.
+        let subject_category = category_from_key(&obs.key);
+
+        // Ensure the subject node exists.
+        let subject_node = graph.ensure_concept(ConceptId(obs.key.clone()), subject_category, tick);
+
+        // ── Stamp name on first encounter ──────────────────────────────
+        // First-observer-wins: never overwrite an existing name.
+        if let Some(node) = graph.graph.node_weight_mut(subject_node) {
+            if node.name.is_empty() {
+                node.name = obs.name.clone();
+            }
+
+            // ── Stamp origin_planet_seed on first planet observation ───
+            if node.origin_planet_seed.is_none()
+                && let Some(ps) = obs.planet_seed
+            {
+                node.origin_planet_seed = Some(ps);
+            }
+
+            // ── Record observation with domain-weighted accumulation ───
+            // Using accumulation (not simple add) so repeated identical
+            // observations strengthen confidence with diminishing returns,
+            // matching the Story 10.4 confidence model.
+            // Recovery multiplier is 1.0 here; DeathContext-adjusted writes
+            // come from the observation sites that know the death domain.
+            let mut observation = obs.observation.clone();
+            observation.recorded_at = tick;
+            node.add_observation_with_domain_weighted_accumulation(observation, &config, 1.0);
+
+            // ── Accumulate overall node confidence ────────────────────
+            node.confidence.accumulate(obs.observation.confidence.0);
+
+            // ── Mark property as revealed, storing the raw float value ──
+            // Look up the material's property value from the catalog so the
+            // classification system can compare against asset-defined ranges
+            // without reaching back into world entities at query time.
+            let category = obs.observation.category.clone();
+            let prop_value: f32 = obs
+                .material_seed
+                .and_then(|seed| catalog.as_ref()?.get_by_seed(seed))
+                .map(|mat| property_value_for_category(mat, &category))
+                .unwrap_or(0.0);
+            node.revealed_properties.insert(category, prop_value);
+        }
+
+        // ── FoundOn edge ──────────────────────────────────────────────
+        // If the observation carries a planet_seed, wire a FoundOn edge
+        // from the material to the location concept.
+        if let Some(planet_seed) = obs.planet_seed {
+            let location_key = crate::journal::JournalKey::Location { planet_seed };
+            let location_node =
+                graph.ensure_concept(ConceptId(location_key), ConceptCategory::Location, tick);
+            graph.relate(
+                subject_node,
+                location_node,
+                ConceptEdge {
+                    relationship: RelationshipType::FoundOn,
+                    confidence: obs.observation.confidence,
+                    discovered_at: tick,
+                },
+            );
+        }
+
+        // ── DerivedFrom edges ────────────────────────────────────────
+        // For fabrication outputs, link the output concept back to each
+        // input material that the player put into the fabricator.
+        if matches!(&obs.key, crate::journal::JournalKey::Fabrication { .. }) {
+            for &input_seed in &obs.input_seeds {
+                let input_node = graph
+                    .lookup_material_by_seed(input_seed)
+                    .unwrap_or_else(|| {
+                        let input_key =
+                            crate::journal::JournalKey::MaterialInstance { seed: input_seed };
+                        graph.ensure_concept(ConceptId(input_key), ConceptCategory::Material, tick)
+                    });
+                graph.relate(
+                    subject_node,
+                    input_node,
+                    ConceptEdge {
+                        relationship: RelationshipType::DerivedFrom,
+                        // Fabrication is directly observed — full confidence.
+                        confidence: Confidence(1.0),
+                        discovered_at: tick,
+                    },
+                );
+            }
+        }
+
+        // ── CombinedWith edges ───────────────────────────────────────
+        // For fabrication outputs with exactly 2 inputs, wire a symmetric
+        // CombinedWith edge between the two input materials so the player
+        // can see that these materials were used together, independent of
+        // what they produced.
+        if matches!(&obs.key, crate::journal::JournalKey::Fabrication { .. })
+            && obs.input_seeds.len() == 2
+        {
+            let seed_a = obs.input_seeds[0];
+            let seed_b = obs.input_seeds[1];
+
+            let node_a = graph.lookup_material_by_seed(seed_a).unwrap_or_else(|| {
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_a };
+                graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
+            });
+            let node_b = graph.lookup_material_by_seed(seed_b).unwrap_or_else(|| {
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_b };
+                graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
+            });
+
+            let edge = ConceptEdge {
+                relationship: RelationshipType::CombinedWith,
+                confidence: Confidence(1.0),
+                discovered_at: tick,
+            };
+            graph.relate(node_a, node_b, edge);
+        }
+
+        // ── ObservedAt edge ──────────────────────────────────────────
+        // When the observation message supplies an explicit context
+        // location (e.g. a biome landmark), wire a subject→location edge.
+        if let Some(context_location) = &obs.context_location {
+            let location_category = category_from_key(context_location);
+            let location_node =
+                graph.ensure_concept(ConceptId(context_location.clone()), location_category, tick);
+            graph.relate(
+                subject_node,
+                location_node,
+                ConceptEdge {
+                    relationship: RelationshipType::ObservedAt,
+                    confidence: obs.observation.confidence,
+                    discovered_at: tick,
+                },
+            );
         }
     }
 }
 
-/// Serializable form of [`KnowledgeGraph`] for save/load.
+/// Map a [`JournalKey`] discriminant to the corresponding
+/// [`ConceptCategory`].
 ///
-/// The auxiliary indexes are omitted and rebuilt on deserialization via
-/// [`KnowledgeGraph::from_serializable`].
-#[derive(Serialize, Deserialize)]
-pub struct SerializableKnowledgeGraph {
-    /// The underlying petgraph graph with all concept nodes and edges.
-    pub graph: Graph<ConceptNode, ConceptEdge>,
+/// This mapping is the single place where the journal and knowledge-graph
+/// category systems are joined. Adding a new `JournalKey` variant will
+/// produce a non-exhaustive match error here, forcing the developer to
+/// declare the correct category.
+fn category_from_key(key: &crate::journal::JournalKey) -> ConceptCategory {
+    match key {
+        crate::journal::JournalKey::MaterialInstance { .. } => ConceptCategory::Material,
+        crate::journal::JournalKey::Material { .. } => ConceptCategory::Material,
+        crate::journal::JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
+        crate::journal::JournalKey::Location { .. } => ConceptCategory::Location,
+    }
 }
+
+/// Extract the raw property float for a given observation category from a
+/// [`crate::materials::GameMaterial`].
+///
+/// This is the bridge between the typed `ObservationCategory` enum and the
+/// named fields of `GameMaterial` — used by `update_knowledge_graph` to store
+/// observed property values on `ConceptNode::revealed_properties` without
+/// string keys. `SurfaceAppearance`, `FabricationResult`, and `LocationNote`
+/// have no direct float analogue, so they return `0.0`.
+fn property_value_for_category(
+    mat: &crate::materials::GameMaterial,
+    category: &crate::journal::ObservationCategory,
+) -> f32 {
+    use crate::journal::ObservationCategory;
+    match category {
+        ObservationCategory::Weight => mat.density.value(),
+        ObservationCategory::ThermalBehavior => mat.thermal_resistance.value(),
+        // Reactivity, conductivity, and toxicity observation systems are not
+        // wired yet (Story N.4+). Return 0.0 as a safe sentinel — the value
+        // will be overwritten when those systems fire a RecordObservation.
+        ObservationCategory::SurfaceAppearance => mat.reactivity.value(),
+        ObservationCategory::FabricationResult => 0.0,
+        ObservationCategory::LocationNote => 0.0,
+    }
+}
+
+// ── SimilarTo detection ───────────────────────────────────────────────────
+
+/// Detect materials with similar property profiles and wire `SimilarTo`
+/// edges in the knowledge graph when both materials are known with at least
+/// `Observed` confidence.
+///
+/// Called by the material catalog after a new material is registered
+/// (Story 10.5, Phase 4). The caller passes in the full catalog so we can
+/// compare the new material against every previously-known entry.
+///
+/// # Arguments
+///
+/// - `new_seed` — The seed of the newly registered material.
+/// - `new_material` — Reference to the [`crate::materials::GameMaterial`] that was just registered.
+/// - `catalog` — The full [`crate::materials::MaterialCatalog`] for comparison. The new material is
+///   already in it.
+/// - `journal` — The player's [`crate::journal::Journal`] — used to check confidence tiers on both
+///   materials.
+/// - `graph` — Mutable reference to the [`KnowledgeGraph`] where `SimilarTo` edges are added.
+/// - `threshold` — Cosine similarity threshold above which two materials are considered "similar"
+///   (loaded from config, typically ~0.85).
+/// - `tick` — Current game-time tick for edge timestamps.
+pub fn detect_and_wire_similar_materials(
+    new_seed: u64,
+    new_material: &crate::materials::GameMaterial,
+    catalog: &crate::materials::MaterialCatalog,
+    graph_read: &KnowledgeGraph,
+    graph: &mut KnowledgeGraph,
+    threshold: f32,
+    tick: u64,
+) {
+    let new_vec = new_material.property_vector();
+
+    for existing in catalog.values() {
+        if existing.seed == new_seed {
+            continue;
+        }
+
+        let sim = cosine_similarity(&new_vec, &existing.property_vector());
+        if sim < threshold {
+            continue;
+        }
+
+        let new_key = crate::journal::JournalKey::MaterialInstance { seed: new_seed };
+        let existing_key = crate::journal::JournalKey::MaterialInstance {
+            seed: existing.seed,
+        };
+
+        let new_confident = is_at_least_observed(graph_read, &new_key);
+        let existing_confident = is_at_least_observed(graph_read, &existing_key);
+
+        if !new_confident || !existing_confident {
+            continue;
+        }
+
+        let new_node =
+            graph.ensure_concept(ConceptId(new_key.clone()), ConceptCategory::Material, tick);
+        let existing_node =
+            graph.ensure_concept(ConceptId(existing_key), ConceptCategory::Material, tick);
+
+        let edge = ConceptEdge {
+            relationship: RelationshipType::SimilarTo,
+            confidence: Confidence(sim),
+            discovered_at: tick,
+        };
+        graph.relate(new_node, existing_node, edge);
+    }
+}
+
+/// Compute the cosine similarity between two property vectors.
+///
+/// Returns a value in [-1.0, 1.0] — in practice always [0.0, 1.0] for
+/// non-negative property vectors derived from material seeds. A return
+/// value of `1.0` means identical profiles; `0.0` means orthogonal
+/// (no property overlap).
+///
+/// Returns `0.0` when either vector has zero magnitude (degenerate case
+/// that cannot arise from [`crate::materials::GameMaterial::property_vector`]
+/// since property values are in [0.0, 1.0] and seeds span the full range).
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(
+        a.len(),
+        b.len(),
+        "cosine_similarity: vectors must have the same length"
+    );
+
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if mag_a == 0.0 || mag_b == 0.0 {
+        return 0.0;
+    }
+
+    (dot / (mag_a * mag_b)).clamp(-1.0, 1.0)
+}
+
+/// Returns `true` when the graph contains a concept node for `key` with
+/// overall confidence at or above [`crate::observation::ConfidenceTier::Observed`]
+/// (i.e. confidence ≥ 0.3).
+///
+/// "At least Observed" is the threshold at which the player has
+/// accumulated enough evidence to treat an observation as factual
+/// rather than tentative. `SimilarTo` edges are only wired when both
+/// materials meet this bar, ensuring the connection is earned.
+///
+/// Reads confidence from the KnowledgeGraph node — no Journal access needed.
+fn is_at_least_observed(graph: &KnowledgeGraph, key: &crate::journal::JournalKey) -> bool {
+    let id = ConceptId(key.clone());
+    graph
+        .lookup(&id)
+        .and_then(|idx| graph.node(idx))
+        .is_some_and(|node| node.confidence.0 >= 0.3)
+}
+
+/// Detects and wires `SimilarTo` edges for newly observed materials.
+///
+/// Runs in [`crate::journal::JournalSet::Navigate`] after
+/// [`update_knowledge_graph`]. For each [`RecordObservation`] message that
+/// carries a [`crate::journal::JournalKey::Material`] key, compares the
+/// material against all others in the catalog and wires `SimilarTo` edges
+/// when both materials are at or above `Observed` confidence and their
+/// property vectors exceed the configured similarity threshold.
+///
+/// Uses an independent [`MessageReader`] cursor — both this system and
+/// [`update_knowledge_graph`] receive all messages without consuming each
+/// other's reads.
+fn detect_similar_on_observation(
+    mut reader: MessageReader<crate::observation::RecordObservation>,
+    mut graph: ResMut<KnowledgeGraph>,
+    catalog: Res<crate::materials::MaterialCatalog>,
+    time: Res<Time>,
+    config: Res<crate::observation::ConfidenceConfig>,
+) {
+    let tick = time.elapsed().as_secs();
+
+    for obs in reader.read() {
+        let crate::journal::JournalKey::MaterialInstance { seed } = obs.key else {
+            continue;
+        };
+        let Some(material) = catalog.get_by_seed(seed) else {
+            continue;
+        };
+        detect_and_wire_similar_materials(
+            seed,
+            material,
+            &catalog,
+            &graph.as_ref().clone(),
+            &mut graph,
+            config.similarity_threshold,
+            tick,
+        );
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::journal::JournalKey;
 
-    fn material_key(seed: u64) -> JournalKey {
-        JournalKey::Material {
-            seed,
-            planet_seed: None,
-        }
+    fn mat_id(seed: u64) -> ConceptId {
+        ConceptId(JournalKey::MaterialInstance { seed })
     }
 
-    #[test]
-    fn concept_id_wraps_journal_key() {
-        let key = material_key(42);
-        let id = ConceptId::new(key.clone());
-        assert_eq!(id.key(), &key);
+    fn loc_id(planet_seed: u64) -> ConceptId {
+        ConceptId(JournalKey::Location { planet_seed })
     }
 
-    #[test]
-    fn concept_id_from_journal_key() {
-        let key = material_key(7);
-        let id: ConceptId = key.clone().into();
-        assert_eq!(id.0, key);
-    }
-
-    #[test]
-    fn concept_node_starts_with_no_revealed_properties() {
-        let id = ConceptId::new(material_key(1));
-        let node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.2), 100);
-        assert!(node.revealed_properties.is_empty());
-        assert!(!node.has_property("density"));
-    }
-
-    #[test]
-    fn concept_node_reveal_property_is_idempotent() {
-        let id = ConceptId::new(material_key(2));
-        let mut node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.5), 200);
-        node.reveal_property("density");
-        node.reveal_property("density"); // second call is a no-op
-        assert!(node.has_property("density"));
-        assert_eq!(node.revealed_properties.len(), 1);
-    }
-
-    #[test]
-    fn concept_node_multiple_properties() {
-        let id = ConceptId::new(material_key(3));
-        let mut node = ConceptNode::new(id, ConceptCategory::Material, Confidence(0.8), 300);
-        node.reveal_property("density");
-        node.reveal_property("thermal_resistance");
-        assert!(node.has_property("density"));
-        assert!(node.has_property("thermal_resistance"));
-        assert!(!node.has_property("reactivity"));
-    }
-
-    #[test]
-    fn concept_category_equality() {
-        assert_eq!(ConceptCategory::Material, ConceptCategory::Material);
-        assert_ne!(ConceptCategory::Material, ConceptCategory::Location);
-        assert_ne!(ConceptCategory::Location, ConceptCategory::Fabrication);
-    }
-
-    #[test]
-    fn concept_node_stores_metadata() {
-        let id = ConceptId::new(material_key(99));
-        let node = ConceptNode::new(id.clone(), ConceptCategory::Location, Confidence(0.6), 999);
-        assert_eq!(node.id, id);
-        assert_eq!(node.category, ConceptCategory::Location);
-        assert_eq!(node.confidence.0, 0.6);
-        assert_eq!(node.discovered_at, 999);
-    }
-
-    // ── ConceptEdge / RelationshipType tests ─────────────────────────────
-
-    #[test]
-    fn concept_edge_new_stores_fields() {
-        let edge = ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.4), 50);
-        assert_eq!(edge.relationship, RelationshipType::FoundOn);
-        assert_eq!(edge.confidence.0, 0.4);
-        assert_eq!(edge.discovered_at, 50);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_accumulates_confidence() {
-        let mut edge = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.3), 10);
-        edge.strengthen(Confidence(0.4));
-        // 0.3 + 0.4 = 0.7
-        assert!((edge.confidence.0 - 0.7).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_caps_at_one() {
-        let mut edge = ConceptEdge::new(RelationshipType::DerivedFrom, Confidence(0.8), 20);
-        edge.strengthen(Confidence(0.5));
-        // 0.8 + 0.5 = 1.3, capped at 1.0
-        assert_eq!(edge.confidence.0, 1.0);
-    }
-
-    #[test]
-    fn concept_edge_strengthen_does_not_update_discovered_at() {
-        let mut edge = ConceptEdge::new(RelationshipType::ObservedAt, Confidence(0.2), 100);
-        edge.strengthen(Confidence(0.3));
-        assert_eq!(edge.discovered_at, 100);
-    }
-
-    #[test]
-    fn relationship_type_equality() {
-        assert_eq!(RelationshipType::FoundOn, RelationshipType::FoundOn);
-        assert_ne!(RelationshipType::FoundOn, RelationshipType::ObservedAt);
-        assert_ne!(
-            RelationshipType::CombinedWith,
-            RelationshipType::DerivedFrom
-        );
-        assert_ne!(RelationshipType::SimilarTo, RelationshipType::FoundOn);
-    }
-
-    #[test]
-    fn relationship_type_all_variants_constructible() {
-        // Ensure all five required variants exist and are distinct.
-        let variants = [
-            RelationshipType::FoundOn,
-            RelationshipType::CombinedWith,
-            RelationshipType::DerivedFrom,
-            RelationshipType::SimilarTo,
-            RelationshipType::ObservedAt,
-        ];
-        // All five must be pairwise distinct.
-        for i in 0..variants.len() {
-            for j in 0..variants.len() {
-                if i == j {
-                    assert_eq!(variants[i], variants[j]);
-                } else {
-                    assert_ne!(variants[i], variants[j]);
-                }
-            }
-        }
-    }
-
-    // ── KnowledgeGraph tests ──────────────────────────────────────────────
-
-    fn location_key(seed: u64) -> JournalKey {
-        // JournalKey has no Location variant yet; use a Material with a
-        // planet_seed to represent a location concept in tests.
-        JournalKey::Material {
-            seed,
-            planet_seed: Some(seed),
-        }
-    }
-
-    fn make_graph() -> KnowledgeGraph {
-        KnowledgeGraph::new()
-    }
-
-    #[test]
-    fn ensure_concept_creates_new_node() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(1));
-        let idx = graph.ensure_concept(id.clone(), ConceptCategory::Material, 10);
-        assert_eq!(graph.lookup(&id), Some(idx));
-    }
+    // ── Phase 1 tests ─────────────────────────────────────────────────
 
     #[test]
     fn ensure_concept_is_idempotent() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 10);
-        let idx2 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 20);
-        // Same node returned both times.
-        assert_eq!(idx1, idx2);
-        // Timeline should only have one entry.
-        assert_eq!(graph.timeline().len(), 1);
-    }
-
-    #[test]
-    fn lookup_returns_none_for_unknown_concept() {
-        let graph = make_graph();
-        let id = ConceptId::new(material_key(99));
-        assert_eq!(graph.lookup(&id), None);
-    }
-
-    #[test]
-    fn by_category_returns_inserted_nodes() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id, ConceptCategory::Material, 1);
-        let loc_idx = graph.ensure_concept(loc_id, ConceptCategory::Location, 2);
-
-        let materials = graph.by_category(&ConceptCategory::Material);
-        assert_eq!(materials, &[mat_idx]);
-
-        let locations = graph.by_category(&ConceptCategory::Location);
-        assert_eq!(locations, &[loc_idx]);
-    }
-
-    #[test]
-    fn by_category_returns_empty_for_unknown_category() {
-        let graph = make_graph();
-        assert!(graph.by_category(&ConceptCategory::Fabrication).is_empty());
-    }
-
-    #[test]
-    fn timeline_records_discovery_order() {
-        let mut graph = make_graph();
-        let id1 = ConceptId::new(material_key(1));
-        let id2 = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id1, ConceptCategory::Material, 5);
-        let idx2 = graph.ensure_concept(id2, ConceptCategory::Material, 10);
-
-        let tl = graph.timeline();
-        assert_eq!(tl.len(), 2);
-        assert_eq!(tl[0], (5, idx1));
-        assert_eq!(tl[1], (10, idx2));
-    }
-
-    #[test]
-    fn relate_creates_bidirectional_edges() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id, ConceptCategory::Material, 1);
-        let loc_idx = graph.ensure_concept(loc_id, ConceptCategory::Location, 2);
-
-        let edge = ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.5), 3);
-        graph.relate(mat_idx, loc_idx, edge);
-
-        // Forward: material → location
-        let mat_rels = graph.relationships(mat_idx);
-        assert!(
-            mat_rels
-                .iter()
-                .any(|(n, e)| { *n == loc_idx && e.relationship == RelationshipType::FoundOn })
-        );
-
-        // Reverse: location → material
-        let loc_rels = graph.relationships(loc_idx);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| { *n == mat_idx && e.relationship == RelationshipType::FoundOn })
-        );
-    }
-
-    #[test]
-    fn relate_strengthens_existing_edge_on_repeat() {
-        let mut graph = make_graph();
-        let id1 = ConceptId::new(material_key(1));
-        let id2 = ConceptId::new(material_key(2));
-        let idx1 = graph.ensure_concept(id1, ConceptCategory::Material, 1);
-        let idx2 = graph.ensure_concept(id2, ConceptCategory::Material, 2);
-
-        let edge1 = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.3), 5);
-        let edge2 = ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.4), 10);
-        graph.relate(idx1, idx2, edge1);
-        graph.relate(idx1, idx2, edge2);
-
-        // relationships() returns both outgoing and incoming edges.
-        // Filter to only edges pointing toward idx2 (the forward direction).
-        let rels = graph.relationships(idx1);
-        let forward: Vec<_> = rels
-            .iter()
-            .filter(|(n, e)| *n == idx2 && e.relationship == RelationshipType::SimilarTo)
-            .collect();
-        // Exactly one forward edge (strengthened, not duplicated).
-        assert_eq!(forward.len(), 1);
-        // 0.3 + 0.4 = 0.7
-        assert!((forward[0].1.confidence.0 - 0.7).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn neighborhood_returns_nodes_within_depth() {
-        let mut graph = make_graph();
-        // A — B — C — D (linear chain)
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
+        let mut graph = KnowledgeGraph::default();
+        let id = mat_id(42);
+        let idx1 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 100);
+        let idx2 = graph.ensure_concept(id.clone(), ConceptCategory::Material, 200);
+        assert_eq!(idx1, idx2, "same ID must always return the same NodeIndex");
+        assert_eq!(
+            graph.timeline().len(),
             1,
+            "idempotent call must not append to timeline"
         );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-        let d = graph.ensure_concept(
-            ConceptId::new(material_key(4)),
-            ConceptCategory::Material,
-            4,
-        );
-
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        graph.relate(a, b, edge());
-        graph.relate(b, c, edge());
-        graph.relate(c, d, edge());
-
-        // From A with depth=2: should reach B (hop 1) and C (hop 2), not D.
-        let neighbors = graph.neighborhood(a, 2, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert!(nodes.contains(&b));
-        assert!(nodes.contains(&c));
-        assert!(!nodes.contains(&d));
-        assert!(!nodes.contains(&a)); // center excluded
     }
 
     #[test]
-    fn neighborhood_depth_zero_returns_empty() {
-        let mut graph = make_graph();
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
+    fn relate_creates_new_edge() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(loc_id(999), ConceptCategory::Location, 0);
         graph.relate(
             a,
             b,
-            ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1),
+            ConceptEdge {
+                relationship: RelationshipType::FoundOn,
+                confidence: Confidence(0.5),
+                discovered_at: 0,
+            },
         );
-
-        assert!(graph.neighborhood(a, 0, None).is_empty());
+        let rels = graph.relationships(a);
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].1.relationship, RelationshipType::FoundOn);
     }
 
     #[test]
-    fn neighborhood_depth_one_returns_only_direct_neighbors() {
-        let mut graph = make_graph();
-        // A — B — C — D (linear chain)
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-        let d = graph.ensure_concept(
-            ConceptId::new(material_key(4)),
-            ConceptCategory::Material,
-            4,
-        );
+    fn relate_strengthens_existing_edge() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(loc_id(999), ConceptCategory::Location, 0);
 
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        graph.relate(a, b, edge());
-        graph.relate(b, c, edge());
-        graph.relate(c, d, edge());
+        let initial_edge = ConceptEdge {
+            relationship: RelationshipType::FoundOn,
+            confidence: Confidence(0.3),
+            discovered_at: 0,
+        };
+        graph.relate(a, b, initial_edge.clone());
 
-        // depth=1: only direct neighbors of A (i.e., B). C and D are too far.
-        let neighbors = graph.neighborhood(a, 1, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert_eq!(
-            nodes.len(),
-            1,
-            "depth=1 must return exactly one direct neighbor"
-        );
-        assert!(nodes.contains(&b), "B must be in depth=1 neighborhood of A");
+        // Second relate with same type should strengthen, not duplicate.
+        graph.relate(a, b, initial_edge);
+        let rels = graph.relationships(a);
+        assert_eq!(rels.len(), 1, "no duplicate edge");
         assert!(
-            !nodes.contains(&c),
-            "C must not be in depth=1 neighborhood of A"
-        );
-        assert!(
-            !nodes.contains(&d),
-            "D must not be in depth=1 neighborhood of A"
-        );
-        assert!(
-            !nodes.contains(&a),
-            "center node must not appear in its own neighborhood"
-        );
-
-        // Verify hop distance is reported as 1.
-        let hop = neighbors.iter().find(|(n, _)| *n == b).map(|(_, h)| *h);
-        assert_eq!(hop, Some(1), "B must be reported at hop distance 1");
-    }
-
-    #[test]
-    fn neighborhood_category_filter_excludes_non_matching() {
-        let mut graph = make_graph();
-        let mat = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
-        );
-        let loc = graph.ensure_concept(
-            ConceptId::new(location_key(2)),
-            ConceptCategory::Location,
-            2,
-        );
-        let mat2 = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
-        );
-
-        let edge = || ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.5), 1);
-        graph.relate(mat, loc, edge());
-        graph.relate(loc, mat2, edge());
-
-        // From mat with depth=2, filter to Material only: should see mat2 (hop 2) but not loc.
-        let neighbors = graph.neighborhood(mat, 2, Some(&ConceptCategory::Material));
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
-        assert!(!nodes.contains(&loc));
-        assert!(nodes.contains(&mat2));
-    }
-
-    #[test]
-    fn neighborhood_disconnected_node_returns_empty() {
-        // A node with no edges should have an empty neighborhood at any depth.
-        let mut graph = make_graph();
-        let isolated = graph.ensure_concept(
-            ConceptId::new(material_key(99)),
-            ConceptCategory::Material,
-            1,
-        );
-        assert!(
-            graph.neighborhood(isolated, 3, None).is_empty(),
-            "disconnected node must have no neighbors"
+            rels[0].1.confidence.0 > 0.3,
+            "confidence must increase on repeated observation"
         );
     }
 
     #[test]
-    fn neighborhood_handles_cycles_without_infinite_loop() {
-        // Build a cycle: A — B — C — A (triangle).
-        // BFS must visit each node at most once and terminate cleanly.
-        let mut graph = make_graph();
-        let a = graph.ensure_concept(
-            ConceptId::new(material_key(1)),
-            ConceptCategory::Material,
-            1,
+    fn by_category_returns_correct_nodes() {
+        let mut graph = KnowledgeGraph::default();
+        let m1 = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let m2 = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 1);
+        let _l1 = graph.ensure_concept(loc_id(1), ConceptCategory::Location, 2);
+
+        let materials = graph.by_category(&ConceptCategory::Material);
+        assert_eq!(materials.len(), 2);
+        assert!(materials.contains(&m1));
+        assert!(materials.contains(&m2));
+
+        let locations = graph.by_category(&ConceptCategory::Location);
+        assert_eq!(locations.len(), 1);
+    }
+
+    #[test]
+    fn timeline_is_ordered_by_discovery_tick() {
+        let mut graph = KnowledgeGraph::default();
+        graph.ensure_concept(mat_id(10), ConceptCategory::Material, 100);
+        graph.ensure_concept(mat_id(20), ConceptCategory::Material, 50);
+        graph.ensure_concept(mat_id(30), ConceptCategory::Material, 200);
+
+        // Timeline should be in insertion order (ticks 100, 50, 200 for
+        // in-memory; deserialized would be sorted).
+        let ticks: Vec<u64> = graph.timeline().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![100, 50, 200]);
+    }
+
+    // ── Phase 2 tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn bfs_depth_one_returns_only_direct_neighbors() {
+        let mut graph = KnowledgeGraph::default();
+        let center = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let neighbor = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let far = graph.ensure_concept(mat_id(3), ConceptCategory::Material, 0);
+
+        graph.relate(
+            center,
+            neighbor,
+            ConceptEdge {
+                relationship: RelationshipType::SimilarTo,
+                confidence: Confidence(0.9),
+                discovered_at: 0,
+            },
         );
-        let b = graph.ensure_concept(
-            ConceptId::new(material_key(2)),
-            ConceptCategory::Material,
-            2,
-        );
-        let c = graph.ensure_concept(
-            ConceptId::new(material_key(3)),
-            ConceptCategory::Material,
-            3,
+        graph.relate(
+            neighbor,
+            far,
+            ConceptEdge {
+                relationship: RelationshipType::SimilarTo,
+                confidence: Confidence(0.9),
+                discovered_at: 0,
+            },
         );
 
-        let edge = || ConceptEdge::new(RelationshipType::SimilarTo, Confidence(0.5), 1);
-        // A → B → C → A forms a directed cycle; relate() also adds the reverse edge,
-        // so the undirected traversal sees a fully-connected triangle.
+        let results = graph.neighborhood(center, 1, None);
+        let indices: Vec<NodeIndex> = results.iter().map(|(idx, _)| *idx).collect();
+        assert!(
+            indices.contains(&neighbor),
+            "direct neighbor must be included"
+        );
+        assert!(
+            !indices.contains(&far),
+            "2-hop node must be excluded at depth=1"
+        );
+    }
+
+    #[test]
+    fn bfs_with_category_filter_excludes_non_matching() {
+        let mut graph = KnowledgeGraph::default();
+        let center = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let mat_neighbor = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let loc_neighbor = graph.ensure_concept(loc_id(42), ConceptCategory::Location, 0);
+
+        let edge = || ConceptEdge {
+            relationship: RelationshipType::FoundOn,
+            confidence: Confidence(0.5),
+            discovered_at: 0,
+        };
+        graph.relate(center, mat_neighbor, edge());
+        graph.relate(center, loc_neighbor, edge());
+
+        let results = graph.neighborhood(center, 1, Some(&ConceptCategory::Location));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, loc_neighbor);
+    }
+
+    #[test]
+    fn bfs_on_disconnected_node_returns_empty() {
+        let mut graph = KnowledgeGraph::default();
+        let island = graph.ensure_concept(mat_id(99), ConceptCategory::Material, 0);
+        let results = graph.neighborhood(island, 5, None);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn bfs_handles_cycles_without_infinite_loop() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 0);
+        let b = graph.ensure_concept(mat_id(2), ConceptCategory::Material, 0);
+        let c = graph.ensure_concept(mat_id(3), ConceptCategory::Material, 0);
+
+        let edge = || ConceptEdge {
+            relationship: RelationshipType::SimilarTo,
+            confidence: Confidence(0.9),
+            discovered_at: 0,
+        };
+        // Create a cycle: a → b → c → a
         graph.relate(a, b, edge());
         graph.relate(b, c, edge());
         graph.relate(c, a, edge());
 
-        // With depth=10 (well beyond the 3-node cycle), BFS must still return exactly
-        // the two other nodes (B and C) and must not loop or panic.
-        let neighbors = graph.neighborhood(a, 10, None);
-        let nodes: Vec<NodeIndex> = neighbors.iter().map(|(n, _)| *n).collect();
+        // Should terminate and return b and c (depth=5 more than covers the cycle).
+        let results = graph.neighborhood(a, 5, None);
+        assert_eq!(results.len(), 2);
+    }
 
-        assert_eq!(
-            nodes.len(),
-            2,
-            "cycle graph must yield exactly 2 unique neighbors for A (B and C), got {nodes:?}"
-        );
-        assert!(nodes.contains(&b), "B must be reachable from A");
-        assert!(nodes.contains(&c), "C must be reachable from A");
+    // ── Phase 3 tests (integration-level — graph wiring via system) ───
+
+    #[test]
+    fn no_edge_when_no_planet_seed() {
+        // Material key without planet_seed must not create a FoundOn edge.
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed: 42 };
+        let subject = graph.ensure_concept(ConceptId(key.clone()), ConceptCategory::Material, 0);
+        // Simulate what update_knowledge_graph does: only wire FoundOn when
+        // planet_seed is Some. With None, no location node is created.
+        let rels = graph.relationships(subject);
+        assert!(rels.is_empty(), "no FoundOn edge without planet_seed");
+    }
+
+    // ── Phase 4 tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn cosine_similarity_identical_vectors_is_one() {
+        let v = vec![0.3, 0.7, 0.5, 0.1, 0.9];
+        let sim = cosine_similarity(&v, &v);
         assert!(
-            !nodes.contains(&a),
-            "center node A must not appear in its own neighborhood"
+            (sim - 1.0).abs() < 1e-5,
+            "identical vectors → similarity 1.0"
         );
-
-        // Hop distances: B is 1 hop away, C is 1 hop away (direct edge via relate's reverse).
-        // Both must be ≤ depth and must be the shortest path distance.
-        let hop_b = neighbors.iter().find(|(n, _)| *n == b).map(|(_, h)| *h);
-        let hop_c = neighbors.iter().find(|(n, _)| *n == c).map(|(_, h)| *h);
-        assert_eq!(hop_b, Some(1), "B must be at hop distance 1 from A");
-        assert_eq!(hop_c, Some(1), "C must be at hop distance 1 from A");
     }
 
     #[test]
-    fn node_accessor_returns_concept_data() {
-        let mut graph = make_graph();
-        let id = ConceptId::new(material_key(42));
-        let idx = graph.ensure_concept(id.clone(), ConceptCategory::Material, 7);
-        let node = graph.node(idx).expect("node must exist");
-        assert_eq!(node.id, id);
-        assert_eq!(node.category, ConceptCategory::Material);
-        assert_eq!(node.discovered_at, 7);
+    fn cosine_similarity_orthogonal_vectors_is_zero() {
+        let a = vec![1.0, 0.0, 0.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0, 0.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-5, "orthogonal vectors → similarity ~0.0");
     }
 
+    // ── Phase 6 tests ─────────────────────────────────────────────────
+
     #[test]
-    fn serialization_round_trip_preserves_graph() {
-        let mut graph = make_graph();
-        let mat_id = ConceptId::new(material_key(1));
-        let loc_id = ConceptId::new(location_key(2));
-        let mat_idx = graph.ensure_concept(mat_id.clone(), ConceptCategory::Material, 10);
-        let loc_idx = graph.ensure_concept(loc_id.clone(), ConceptCategory::Location, 20);
+    fn knowledge_graph_round_trips_via_serde() {
+        let mut graph = KnowledgeGraph::default();
+        let a = graph.ensure_concept(mat_id(1), ConceptCategory::Material, 10);
+        let b = graph.ensure_concept(loc_id(99), ConceptCategory::Location, 20);
         graph.relate(
-            mat_idx,
-            loc_idx,
-            ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.6), 15),
+            a,
+            b,
+            ConceptEdge {
+                relationship: RelationshipType::FoundOn,
+                confidence: Confidence(0.6),
+                discovered_at: 10,
+            },
         );
 
-        // Serialize to JSON bytes and deserialize back to exercise serde.
-        let serializable = graph.to_serializable();
-        let json = serde_json::to_string(&serializable).expect("serialization must succeed");
-        let restored_serializable: SerializableKnowledgeGraph =
-            serde_json::from_str(&json).expect("deserialization must succeed");
-        let restored = KnowledgeGraph::from_serializable(restored_serializable);
+        let json = serde_json::to_string(&graph).expect("serialize");
+        let restored: KnowledgeGraph = serde_json::from_str(&json).expect("deserialize");
 
-        // Indexes are rebuilt.
-        let restored_mat = restored.lookup(&mat_id).expect("material must be found");
-        let restored_loc = restored.lookup(&loc_id).expect("location must be found");
+        // Indexes are rebuilt: concept lookup should work.
+        assert!(restored.lookup(&mat_id(1)).is_some());
+        assert!(restored.lookup(&loc_id(99)).is_some());
 
-        // Relationships are preserved.
-        let rels = restored.relationships(restored_mat);
-        assert!(
-            rels.iter().any(|(n, e)| {
-                *n == restored_loc && e.relationship == RelationshipType::FoundOn
-            })
-        );
+        // Category index is rebuilt.
+        assert_eq!(restored.by_category(&ConceptCategory::Material).len(), 1);
+        assert_eq!(restored.by_category(&ConceptCategory::Location).len(), 1);
 
-        // Timeline is rebuilt.
+        // Timeline is sorted and contains both nodes.
         assert_eq!(restored.timeline().len(), 2);
-    }
-
-    /// Round-trip serialize→deserialize preserves all three in-memory indexes:
-    /// `concept_index` (O(1) lookup by ConceptId), `category_index` (lookup by
-    /// ConceptCategory), and `timeline` (ordered discovery log).
-    ///
-    /// This test uses two materials and one location so that `by_category` must
-    /// return the correct count for each category, and the timeline must reflect
-    /// the original insertion order.
-    #[test]
-    fn serialization_round_trip_preserves_all_indexes() {
-        let mut graph = make_graph();
-
-        // Insert two materials and one location at distinct ticks so the
-        // timeline order is deterministic.
-        let mat1_id = ConceptId::new(material_key(10));
-        let mat2_id = ConceptId::new(material_key(20));
-        let loc_id = ConceptId::new(location_key(30));
-
-        let mat1_idx = graph.ensure_concept(mat1_id.clone(), ConceptCategory::Material, 1);
-        let mat2_idx = graph.ensure_concept(mat2_id.clone(), ConceptCategory::Material, 2);
-        let loc_idx = graph.ensure_concept(loc_id.clone(), ConceptCategory::Location, 3);
-
-        // Add a relationship so the edge survives the round-trip too.
-        graph.relate(
-            mat1_idx,
-            loc_idx,
-            ConceptEdge::new(RelationshipType::FoundOn, Confidence(0.7), 4),
-        );
-
-        // ── Round-trip ──────────────────────────────────────────────────────
-        let serializable = graph.to_serializable();
-        let json = serde_json::to_string(&serializable).expect("serialization must succeed");
-        let restored_serializable: SerializableKnowledgeGraph =
-            serde_json::from_str(&json).expect("deserialization must succeed");
-        let restored = KnowledgeGraph::from_serializable(restored_serializable);
-
-        // ── concept_index: O(1) lookup by ConceptId ─────────────────────────
-        let r_mat1 = restored
-            .lookup(&mat1_id)
-            .expect("mat1 must be found via concept_index");
-        let r_mat2 = restored
-            .lookup(&mat2_id)
-            .expect("mat2 must be found via concept_index");
-        let r_loc = restored
-            .lookup(&loc_id)
-            .expect("loc must be found via concept_index");
-
-        // Verify the node data is intact (not just that an index exists).
-        let mat1_node = restored.node(r_mat1).expect("mat1 node must exist");
-        assert_eq!(
-            mat1_node.id, mat1_id,
-            "concept_index must map to the correct node"
-        );
-        assert_eq!(mat1_node.category, ConceptCategory::Material);
-
-        // ── category_index: lookup by ConceptCategory ───────────────────────
-        let materials = restored.by_category(&ConceptCategory::Material);
-        assert_eq!(
-            materials.len(),
-            2,
-            "category_index must contain exactly 2 Material nodes after round-trip"
-        );
-        assert!(
-            materials.contains(&r_mat1),
-            "category_index must include mat1"
-        );
-        assert!(
-            materials.contains(&r_mat2),
-            "category_index must include mat2"
-        );
-
-        let locations = restored.by_category(&ConceptCategory::Location);
-        assert_eq!(
-            locations.len(),
-            1,
-            "category_index must contain exactly 1 Location node after round-trip"
-        );
-        assert!(
-            locations.contains(&r_loc),
-            "category_index must include loc"
-        );
-
-        // ── timeline: ordered discovery log ─────────────────────────────────
-        let tl = restored.timeline();
-        assert_eq!(
-            tl.len(),
-            3,
-            "timeline must contain all 3 discovered concepts"
-        );
-
-        // Timeline must be ordered by discovery tick (ascending).
-        let ticks: Vec<u64> = tl.iter().map(|(t, _)| *t).collect();
-        assert_eq!(
-            ticks,
-            vec![1, 2, 3],
-            "timeline must be ordered by discovery tick after round-trip"
-        );
-
-        // Each timeline entry must point to the correct node.
-        assert_eq!(tl[0].1, r_mat1, "timeline[0] must reference mat1");
-        assert_eq!(tl[1].1, r_mat2, "timeline[1] must reference mat2");
-        assert_eq!(tl[2].1, r_loc, "timeline[2] must reference loc");
-    }
-
-    // ── update_knowledge_graph system tests ──────────────────────────────
-
-    use crate::journal::{Observation, ObservationCategory, RecordObservation};
-    use crate::materials::MaterialCatalog;
-
-    /// Build a minimal Bevy App with the message channel and system under test.
-    fn build_test_app() -> App {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
-        app.add_message::<RecordObservation>();
-        app.init_resource::<KnowledgeGraph>();
-        app.init_resource::<MaterialCatalog>();
-        app.init_resource::<KnowledgeGraphConfig>();
-        app.add_systems(Update, update_knowledge_graph);
-        app
-    }
-
-    /// Inject a single [`RecordObservation`] message via a one-shot system.
-    fn inject_observation(app: &mut App, obs: RecordObservation) {
-        fn write_obs(
-            input: bevy::ecs::system::In<RecordObservation>,
-            mut writer: MessageWriter<RecordObservation>,
-        ) {
-            writer.write(input.0.clone());
-        }
-        app.world_mut()
-            .run_system_cached_with(write_obs, obs)
-            .expect("one-shot system must run");
-    }
-
-    /// Construct a minimal [`RecordObservation`] for a material with no
-    /// cross-reference metadata.
-    fn material_obs(seed: u64) -> RecordObservation {
-        RecordObservation {
-            key: JournalKey::Material {
-                seed,
-                planet_seed: None,
-            },
-            name: format!("Mat-{seed}"),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: None,
-        }
+        assert!(restored.timeline()[0].0 <= restored.timeline()[1].0);
     }
 
     #[test]
-    fn material_observation_creates_concept_node() {
-        let mut app = build_test_app();
-        inject_observation(&mut app, material_obs(42));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id = ConceptId::new(JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        });
-        assert!(
-            graph.lookup(&id).is_some(),
-            "concept node must be created for observed material"
-        );
-    }
-
-    #[test]
-    fn material_with_context_location_creates_found_on_edge() {
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 999,
-            planet_seed: Some(999),
-        };
-
-        let obs = RecordObservation {
-            key: JournalKey::Material {
-                seed: 1,
-                planet_seed: None,
-            },
-            name: "Mat-1".to_string(),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: Some(location_key.clone()),
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let mat_id = ConceptId::new(JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        });
-        let loc_id = ConceptId::new(location_key);
-
-        let mat_node = graph.lookup(&mat_id).expect("material concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // Forward edge: material → FoundOn → location
-        let rels = graph.relationships(mat_node);
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == loc_node && e.relationship == RelationshipType::FoundOn),
-            "material must have FoundOn edge to location"
-        );
-
-        // Reverse edge: location → FoundOn → material (bidirectional)
-        let loc_rels = graph.relationships(loc_node);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| *n == mat_node && e.relationship == RelationshipType::FoundOn),
-            "location must have reverse FoundOn edge back to material"
-        );
-    }
-
-    #[test]
-    fn non_material_with_context_location_creates_observed_at_edge() {
-        // A Fabrication observation with a context_location must produce an
-        // ObservedAt edge (not FoundOn) between the fabrication concept and the
-        // location concept, and the reverse edge must also exist.
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 77,
-            planet_seed: None,
-        };
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 55 },
-            name: "Output-55".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(0.9),
-                description: "fabricated at location".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: Some(location_key.clone()),
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-
-        let fab_id = ConceptId::new(JournalKey::Fabrication { output_seed: 55 });
-        let loc_id = ConceptId::new(location_key);
-
-        let fab_node = graph
-            .lookup(&fab_id)
-            .expect("fabrication concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // Forward edge: fabrication → ObservedAt → location
-        let fab_rels = graph.relationships(fab_node);
-        assert!(
-            fab_rels
-                .iter()
-                .any(|(n, e)| *n == loc_node && e.relationship == RelationshipType::ObservedAt),
-            "fabrication must have ObservedAt edge to location"
-        );
-
-        // Reverse edge: location → ObservedAt → fabrication (bidirectional)
-        let loc_rels = graph.relationships(loc_node);
-        assert!(
-            loc_rels
-                .iter()
-                .any(|(n, e)| *n == fab_node && e.relationship == RelationshipType::ObservedAt),
-            "location must have reverse ObservedAt edge back to fabrication"
-        );
-    }
-
-    #[test]
-    fn fabrication_observation_creates_derived_from_edges() {
-        let mut app = build_test_app();
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 100 },
-            name: "Output-100".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(1.0),
-                description: "fabricated".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![10, 20],
-            context_location: None,
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let output_id = ConceptId::new(JournalKey::Fabrication { output_seed: 100 });
-        let input_a_id = ConceptId::new(JournalKey::Material {
-            seed: 10,
-            planet_seed: None,
-        });
-        let input_b_id = ConceptId::new(JournalKey::Material {
-            seed: 20,
-            planet_seed: None,
-        });
-
-        let output_node = graph.lookup(&output_id).expect("output concept must exist");
-        let input_a_node = graph
-            .lookup(&input_a_id)
-            .expect("input A concept must exist");
-        let input_b_node = graph
-            .lookup(&input_b_id)
-            .expect("input B concept must exist");
-
-        // Output → DerivedFrom → each input
-        let rels = graph.relationships(output_node);
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == input_a_node && e.relationship == RelationshipType::DerivedFrom),
-            "output must have DerivedFrom edge to input A"
-        );
-        assert!(
-            rels.iter()
-                .any(|(n, e)| *n == input_b_node && e.relationship == RelationshipType::DerivedFrom),
-            "output must have DerivedFrom edge to input B"
-        );
-    }
-
-    #[test]
-    fn fabrication_observation_creates_combined_with_edges_between_inputs() {
-        let mut app = build_test_app();
-
-        let obs = RecordObservation {
-            key: JournalKey::Fabrication { output_seed: 200 },
-            name: "Output-200".to_string(),
-            observation: Observation {
-                category: ObservationCategory::FabricationResult,
-                confidence: Confidence(1.0),
-                description: "fabricated".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![30, 40],
-            context_location: None,
-        };
-
-        inject_observation(&mut app, obs);
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let input_a_id = ConceptId::new(JournalKey::Material {
-            seed: 30,
-            planet_seed: None,
-        });
-        let input_b_id = ConceptId::new(JournalKey::Material {
-            seed: 40,
-            planet_seed: None,
-        });
-
-        let input_a_node = graph
-            .lookup(&input_a_id)
-            .expect("input A concept must exist");
-        let input_b_node = graph
-            .lookup(&input_b_id)
-            .expect("input B concept must exist");
-
-        // Input A → CombinedWith → Input B (and reverse via bidirectionality)
-        let rels_a = graph.relationships(input_a_node);
-        assert!(
-            rels_a.iter().any(|(n, e)| {
-                *n == input_b_node && e.relationship == RelationshipType::CombinedWith
-            }),
-            "input A must have CombinedWith edge to input B"
-        );
-
-        let rels_b = graph.relationships(input_b_node);
-        assert!(
-            rels_b.iter().any(|(n, e)| {
-                *n == input_a_node && e.relationship == RelationshipType::CombinedWith
-            }),
-            "input B must have reverse CombinedWith edge to input A"
-        );
-    }
-
-    #[test]
-    fn repeated_observation_strengthens_edge_not_duplicates() {
-        let mut app = build_test_app();
-
-        let location_key = JournalKey::Material {
-            seed: 777,
-            planet_seed: Some(777),
-        };
-
-        // Send the same material+location observation twice.
-        for _ in 0..2 {
-            let obs = RecordObservation {
-                key: JournalKey::Material {
-                    seed: 5,
-                    planet_seed: None,
-                },
-                name: "Mat-5".to_string(),
-                observation: Observation {
-                    category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.3),
-                    description: "test".to_string(),
-                    recorded_at: 0,
-                },
-                input_seeds: vec![],
-                context_location: Some(location_key.clone()),
-            };
-            inject_observation(&mut app, obs);
-            app.update();
-        }
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let mat_id = ConceptId::new(JournalKey::Material {
-            seed: 5,
-            planet_seed: None,
-        });
-        let loc_id = ConceptId::new(location_key);
-
-        let mat_node = graph.lookup(&mat_id).expect("material concept must exist");
-        let loc_node = graph.lookup(&loc_id).expect("location concept must exist");
-
-        // There must be exactly one FoundOn edge from material to location
-        // (strengthened, not duplicated).
-        let rels = graph.relationships(mat_node);
-        let found_on_edges: Vec<_> = rels
-            .iter()
-            .filter(|(n, e)| *n == loc_node && e.relationship == RelationshipType::FoundOn)
-            .collect();
-        assert_eq!(
-            found_on_edges.len(),
-            1,
-            "repeated observation must strengthen the edge, not create a duplicate"
-        );
-        // Confidence must be higher than a single observation (0.3 + 0.3 = 0.6).
-        assert!(
-            found_on_edges[0].1.confidence.0 > 0.3,
-            "confidence must accumulate across repeated observations"
-        );
-    }
-
-    #[test]
-    fn observation_without_context_creates_no_location_edge() {
-        let mut app = build_test_app();
-        inject_observation(&mut app, material_obs(99));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id = ConceptId::new(JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        });
-        let node = graph.lookup(&id).expect("concept must exist");
-
-        // No edges should exist — no context_location was provided.
-        assert!(
-            graph.relationships(node).is_empty(),
-            "observation without context_location must not create any edges"
-        );
-    }
-
-    // ── Similarity detection tests ────────────────────────────────────────
-
-    /// Seeds 0 and 4 have cosine similarity ≈ 0.9255, which exceeds the 0.85
-    /// threshold. Both are registered in the catalog before observations are
-    /// sent so the system can compare them.
-    const SIMILAR_SEED_A: u64 = 0;
-    const SIMILAR_SEED_B: u64 = 4;
-
-    /// Build a test app with both similar materials pre-registered in the catalog.
-    fn build_test_app_with_similar_materials() -> App {
-        let mut app = build_test_app();
-        {
-            let mut catalog = app.world_mut().resource_mut::<MaterialCatalog>();
-            catalog.derive_and_register(SIMILAR_SEED_A);
-            catalog.derive_and_register(SIMILAR_SEED_B);
-        }
-        app
-    }
-
-    /// Construct a material observation with the given seed and confidence.
-    fn material_obs_with_confidence(seed: u64, confidence: f32) -> RecordObservation {
-        RecordObservation {
-            key: JournalKey::Material {
-                seed,
-                planet_seed: None,
-            },
-            name: format!("Mat-{seed}"),
-            observation: Observation {
-                category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(confidence),
-                description: "test".to_string(),
-                recorded_at: 0,
-            },
-            input_seeds: vec![],
-            context_location: None,
-        }
-    }
-
-    #[test]
-    fn similar_materials_both_observed_creates_similar_to_edge() {
-        // Both materials must be at Observed tier (≥ 0.3) for the edge to appear.
-        let mut app = build_test_app_with_similar_materials();
-
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "material A must have SimilarTo edge to material B"
-        );
-
-        // Bidirectionality: B must also link back to A.
-        let rels_b = graph.relationships(node_b);
-        assert!(
-            rels_b
-                .iter()
-                .any(|(n, e)| *n == node_a && e.relationship == RelationshipType::SimilarTo),
-            "material B must have reverse SimilarTo edge to material A"
-        );
-    }
-
-    #[test]
-    fn similar_to_edge_not_created_when_other_material_below_observed_tier() {
-        // Material B is only at Tentative tier (< 0.3) — no SimilarTo edge should appear.
-        let mut app = build_test_app_with_similar_materials();
-
-        // Observe A at Observed tier.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-        // Observe B at Tentative tier only.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.1));
-        app.update();
-        // Re-observe A — at this point B is still Tentative, so no edge.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            !rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo edge must not be created when other material is below Observed tier"
-        );
-    }
-
-    #[test]
-    fn similar_to_edge_not_created_when_subject_material_is_tentative() {
-        // Material A is only at Tentative tier (< 0.3) — no SimilarTo edge should appear
-        // even when the other material (B) is at Observed tier.
-        // This covers the symmetric case: the *triggering* material being Tentative.
-        let mut app = build_test_app_with_similar_materials();
-
-        // Observe B at Observed tier first.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_B, 0.5));
-        app.update();
-        // Observe A at Tentative tier only — similarity check runs but A is below threshold.
-        inject_observation(&mut app, material_obs_with_confidence(SIMILAR_SEED_A, 0.1));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_a = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_A,
-            planet_seed: None,
-        });
-        let id_b = ConceptId::new(JournalKey::Material {
-            seed: SIMILAR_SEED_B,
-            planet_seed: None,
-        });
-        let node_a = graph.lookup(&id_a).expect("material A concept must exist");
-        let node_b = graph.lookup(&id_b).expect("material B concept must exist");
-
-        // A is Tentative — no SimilarTo edge from A to B.
-        let rels_a = graph.relationships(node_a);
-        assert!(
-            !rels_a
-                .iter()
-                .any(|(n, e)| *n == node_b && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo edge must not be created when subject material is below Observed tier"
-        );
-
-        // B is Observed but A is Tentative — no reverse edge from B to A either.
-        let rels_b = graph.relationships(node_b);
-        assert!(
-            !rels_b
-                .iter()
-                .any(|(n, e)| *n == node_a && e.relationship == RelationshipType::SimilarTo),
-            "SimilarTo reverse edge must not be created when subject material is below Observed tier"
-        );
-    }
-
-    #[test]
-    fn similar_to_not_created_for_dissimilar_materials() {
-        // Seeds 1 and 2 are unlikely to be similar — verify no SimilarTo edge.
-        // We use seeds that are known to be dissimilar (< 0.85 threshold).
-        // Seeds 1 and 2 have low similarity by inspection of the property space.
-        let mut app = build_test_app();
-        {
-            let mut catalog = app.world_mut().resource_mut::<MaterialCatalog>();
-            catalog.derive_and_register(1);
-            catalog.derive_and_register(2);
-        }
-
-        inject_observation(&mut app, material_obs_with_confidence(1, 0.5));
-        app.update();
-        inject_observation(&mut app, material_obs_with_confidence(2, 0.5));
-        app.update();
-
-        let graph = app.world().resource::<KnowledgeGraph>();
-        let id_1 = ConceptId::new(JournalKey::Material {
-            seed: 1,
-            planet_seed: None,
-        });
-        let id_2 = ConceptId::new(JournalKey::Material {
-            seed: 2,
-            planet_seed: None,
-        });
-
-        // Verify these seeds are actually dissimilar before asserting.
-        {
-            use crate::materials::{cosine_similarity, derive_material_from_seed};
-            let m1 = derive_material_from_seed(1);
-            let m2 = derive_material_from_seed(2);
-            let sim = cosine_similarity(&m1.property_vector(), &m2.property_vector());
-            if sim >= DEFAULT_SIMILARITY_SCORE_THRESHOLD {
-                // Seeds turned out to be similar — skip the assertion.
-                return;
-            }
-        }
-
-        let node_1 = graph.lookup(&id_1).expect("material 1 concept must exist");
-        let node_2 = graph.lookup(&id_2).expect("material 2 concept must exist");
-
-        let rels_1 = graph.relationships(node_1);
-        assert!(
-            !rels_1
-                .iter()
-                .any(|(n, e)| *n == node_2 && e.relationship == RelationshipType::SimilarTo),
-            "dissimilar materials must not have SimilarTo edge"
-        );
-    }
-
-    #[test]
-    fn detect_similarity_returns_seeds_above_threshold() {
-        use crate::materials::derive_material_from_seed;
-
-        let mut catalog = MaterialCatalog::default();
-        catalog.derive_and_register(SIMILAR_SEED_A);
-        catalog.derive_and_register(SIMILAR_SEED_B);
-
-        let subject = derive_material_from_seed(SIMILAR_SEED_A);
-        let results = detect_similarity(
-            SIMILAR_SEED_A,
-            &subject,
-            &catalog,
-            DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-        );
-
-        // SIMILAR_SEED_B must appear in results.
-        assert!(
-            results.iter().any(|(seed, _)| *seed == SIMILAR_SEED_B),
-            "detect_similarity must return SIMILAR_SEED_B for SIMILAR_SEED_A"
-        );
-
-        // Self must not appear.
-        assert!(
-            !results.iter().any(|(seed, _)| *seed == SIMILAR_SEED_A),
-            "detect_similarity must not return the subject seed itself"
-        );
-
-        // All returned scores must be at or above the threshold.
-        for (_, score) in &results {
-            assert!(
-                *score >= DEFAULT_SIMILARITY_SCORE_THRESHOLD,
-                "all returned scores must be >= DEFAULT_SIMILARITY_SCORE_THRESHOLD, got {score}"
-            );
-        }
+    fn round_trip_preserves_all_indexes() {
+        let mut graph = KnowledgeGraph::default();
+        // Add several concepts across categories.
+        graph.ensure_concept(mat_id(1), ConceptCategory::Material, 5);
+        graph.ensure_concept(mat_id(2), ConceptCategory::Material, 10);
+        graph.ensure_concept(loc_id(1), ConceptCategory::Location, 15);
+
+        let json = serde_json::to_string(&graph).expect("serialize");
+        let restored: KnowledgeGraph = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored.by_category(&ConceptCategory::Material).len(), 2);
+        assert_eq!(restored.by_category(&ConceptCategory::Location).len(), 1);
+        assert_eq!(restored.timeline().len(), 3);
+        // Timeline must be sorted by tick after deserialization.
+        let ticks: Vec<u64> = restored.timeline().iter().map(|(t, _)| *t).collect();
+        assert_eq!(ticks, vec![5, 10, 15]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,11 @@ use bevy::prelude::*;
 
 pub mod carry;
 pub mod carry_feedback;
+pub mod classification;
 pub mod combination;
 pub mod debug_overlay;
 pub mod descriptions;
+pub mod diegetic_ui;
 pub mod fabricator;
 pub mod heat;
 pub mod input;
@@ -53,6 +55,8 @@ pub fn add_game_plugins(app: &mut App) {
         .add_plugins(input::InputPlugin)
         // Materials: data-driven material definitions with observable/hidden properties.
         .add_plugins(materials::MaterialPlugin)
+        // Material classifications: asset-defined property ranges for query-time type grouping.
+        .add_plugins(classification::MaterialClassificationsPlugin)
         // Exterior generation: deterministic baseline surface mineral deposits per active chunk.
         .add_plugins(world_generation::exterior::ExteriorGenerationPlugin)
         // Interaction: raycast, pickup/place, crosshair UI.
@@ -67,12 +71,14 @@ pub fn add_game_plugins(app: &mut App) {
         .add_plugins(observation::ObservationPlugin)
         // Journal: player-owned record of observations and fabrication history.
         .add_plugins(journal::JournalPlugin)
-        // Knowledge graph: cross-reference system linking journal entries.
+        // Knowledge graph: typed cross-reference edges between journal concepts (Story 10.5).
         .add_plugins(knowledge_graph::KnowledgeGraphPlugin)
         // Solar system: deterministic star/orbital/planet derivation from system seed.
         .add_plugins(solar_system::SolarSystemPlugin)
         // World generation: deterministic planet/chunk identity foundation for exterior systems.
         .add_plugins(world_generation::WorldGenerationPlugin)
+        // Diegetic UI: in-world information surface framework (Story 10.6).
+        .add_plugins(diegetic_ui::DiegeticUiPlugin)
         // Debug: terrain diagnostic overlay (temporary — remove before shipping).
         .add_plugins(debug_overlay::DebugOverlayPlugin);
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -14,15 +14,15 @@
 //! Legacy TOML files under `assets/materials/` are retained as reference
 //! documentation but are no longer loaded at startup.
 //!
-//! The `spawn_material_objects` system creates 3D entities from the catalog and
-//! distributes them across [`Surface`](crate::scene::Surface) shelves.
+//! Materials are spawned in the world exclusively through exterior chunk
+//! generation — deposits place entities with `origin_planet_seed` stamped at
+//! spawn time. There is no longer a room-based starter set.
 
 use std::collections::HashMap;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::scene::Shelf;
 use crate::seed_util::{
     MAT_COLOR_B_CHANNEL, MAT_COLOR_G_CHANNEL, MAT_COLOR_R_CHANNEL, MAT_CONDUCTIVITY_CHANNEL,
     MAT_DENSITY_CHANNEL, MAT_REACTIVITY_CHANNEL, MAT_THERMAL_RESISTANCE_CHANNEL,
@@ -33,6 +33,13 @@ pub struct MaterialPlugin;
 
 /// Small vertical gap between a material object and the surface it rests on.
 pub const MATERIAL_SURFACE_GAP: f32 = 0.01;
+
+/// Number of properties in a [`GameMaterial`] property vector.
+///
+/// Used as the compile-time array size for [`GameMaterial::property_vector`]
+/// so callers never need a magic number and adding a new property automatically
+/// updates the type.
+pub const PROPERTY_DIM: usize = 5;
 
 // ── Well-known material seeds ────────────────────────────────────────────
 //
@@ -59,8 +66,7 @@ pub const WELL_KNOWN_MATERIAL_SEEDS: &[(&str, u64)] = &[
 
 impl Plugin for MaterialPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreStartup, load_material_catalog)
-            .add_systems(PostStartup, spawn_material_objects);
+        app.add_systems(PreStartup, load_material_catalog);
 
         // In debug builds, run a per-frame assertion that no GameMaterial entity
         // has more than one of the three mutually-exclusive location markers:
@@ -167,6 +173,16 @@ pub struct GameMaterial {
     pub seed: u64,
     /// Display colour as \[R, G, B\] in sRGB 0.0–1.0.
     pub color: [f32; 3],
+    /// The planet seed this material instance was generated on.
+    ///
+    /// Set at spawn time from `WorldProfile::planet_seed` and immutable
+    /// thereafter — this piece came from this planet, forever. Used by
+    /// observation systems to wire `FoundOn` edges in the KnowledgeGraph
+    /// and by the `CurrentPlanet` journal filter.
+    ///
+    /// `None` in contexts where no planetary world profile exists (early
+    /// bring-up, fabricated materials, integration tests).
+    pub origin_planet_seed: Option<u64>,
     /// How heavy the material feels — affects mesh shape selection.
     pub density: MaterialProperty,
     /// Resistance to heat transfer.
@@ -215,25 +231,6 @@ impl GameMaterial {
         surface_y + self.support_height() + MATERIAL_SURFACE_GAP
     }
 
-    /// Returns a normalised property vector for similarity comparison.
-    ///
-    /// The vector encodes the five core material properties in a fixed order:
-    /// `[density, thermal_resistance, reactivity, conductivity, toxicity]`.
-    /// All values are already normalised to \[0.0, 1.0\] by [`MaterialProperty`],
-    /// so cosine similarity can be applied directly without further scaling.
-    ///
-    /// Used by the cross-reference system (Story 10.5) to detect `SimilarTo`
-    /// relationships between materials whose property profiles are close.
-    pub fn property_vector(&self) -> [f32; 5] {
-        [
-            self.density.value(),
-            self.thermal_resistance.value(),
-            self.reactivity.value(),
-            self.conductivity.value(),
-            self.toxicity.value(),
-        ]
-    }
-
     /// Returns the horizontal collision radius of the mesh for this material's density.
     pub fn footprint_radius(&self) -> f32 {
         let density = self.density.value();
@@ -245,6 +242,29 @@ impl GameMaterial {
             0.13
         }
     }
+
+    /// Returns the material's measured properties as a normalised 5-dimensional
+    /// vector for cosine-similarity comparison (Story 10.5 — `SimilarTo` edges).
+    ///
+    /// Component order: `[density, thermal_resistance, reactivity, conductivity, toxicity]`.
+    ///
+    /// All values are in \[0.0, 1.0\] by construction (clamped at creation time
+    /// in [`MaterialProperty::new`]), so the cosine similarity between any two
+    /// vectors is always non-negative — no centring or normalisation required.
+    ///
+    /// The vector includes ALL five properties regardless of their visibility
+    /// state. This is intentional: the knowledge graph is the simulation layer
+    /// and operates on ground-truth data; the player only sees the similarity
+    /// when they have sufficient observation confidence (checked at call site).
+    pub fn property_vector(&self) -> [f32; PROPERTY_DIM] {
+        [
+            self.density.value(),
+            self.thermal_resistance.value(),
+            self.reactivity.value(),
+            self.conductivity.value(),
+            self.toxicity.value(),
+        ]
+    }
 }
 
 // ── Seed-derived helpers ─────────────────────────────────────────────────
@@ -252,35 +272,6 @@ impl GameMaterial {
 /// Map a `u64` into the closed unit interval \[0.0, 1.0\].
 fn unit_interval_01(value: u64) -> f32 {
     (value as f64 / u64::MAX as f64) as f32
-}
-
-/// Compute the cosine similarity between two fixed-length property vectors.
-///
-/// Returns a value in `[0.0, 1.0]` where `1.0` means identical direction
-/// (maximally similar) and `0.0` means orthogonal (no shared profile).
-/// Negative cosine similarity cannot occur here because all property values
-/// are non-negative (normalised to `[0.0, 1.0]`).
-///
-/// If either vector is the zero vector (all properties are exactly 0.0),
-/// the function returns `0.0` — a zero-vector material has no meaningful
-/// similarity to anything.
-///
-/// Used by the cross-reference system (Story 10.5) to detect `SimilarTo`
-/// relationships between materials whose property profiles are close.
-pub fn cosine_similarity(a: &[f32; 5], b: &[f32; 5]) -> f32 {
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-
-    let denom = mag_a * mag_b;
-    if denom == 0.0 {
-        // At least one vector is the zero vector — no meaningful similarity.
-        return 0.0;
-    }
-
-    // Clamp to [0.0, 1.0] to guard against floating-point rounding that could
-    // push an identical-vector comparison slightly above 1.0.
-    (dot / denom).clamp(0.0, 1.0)
 }
 
 /// Derive a complete [`GameMaterial`] deterministically from a seed.
@@ -307,6 +298,7 @@ pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
         name,
         seed,
         color,
+        origin_planet_seed: None, // set at spawn time by world generation
         density: MaterialProperty::new(
             unit_interval_01(mix_seed(seed, MAT_DENSITY_CHANNEL)),
             PropertyVisibility::Hidden,
@@ -462,73 +454,6 @@ impl MaterialCatalog {
 #[derive(Component, Debug)]
 pub struct MaterialObject;
 
-// ── Spawning ─────────────────────────────────────────────────────────────
-
-const OBJECT_SCALE: f32 = 1.0;
-
-/// Places a 3D entity for each material in the catalog onto the `Surface`
-/// entities created by the scene plugin. Materials are distributed across
-/// surfaces round-robin and offset so they don't overlap.
-fn spawn_material_objects(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut std_materials: ResMut<Assets<StandardMaterial>>,
-    catalog: Res<MaterialCatalog>,
-    shelves: Query<&Transform, With<Shelf>>,
-) {
-    let shelf_transforms: Vec<&Transform> = shelves.iter().collect();
-    if shelf_transforms.is_empty() {
-        warn!("No Shelf entities found — materials will not be spawned in the world");
-        return;
-    }
-
-    let mut sorted_names: Vec<&String> = catalog.names().collect();
-    sorted_names.sort();
-
-    for (i, name) in sorted_names.iter().enumerate() {
-        let mat = catalog
-            .get_by_name(name)
-            .expect("name index references a valid material");
-        let surface_tf = shelf_transforms[i % shelf_transforms.len()];
-
-        let items_on_this_surface = sorted_names
-            .iter()
-            .enumerate()
-            .filter(|(j, _)| j % shelf_transforms.len() == i % shelf_transforms.len())
-            .position(|(j, _)| j == i)
-            .unwrap_or(0);
-
-        let x_offset = (items_on_this_surface as f32) * 0.3 - 0.3;
-
-        let mesh = mat.mesh_for_density(&mut meshes);
-        let render_mat = std_materials.add(StandardMaterial {
-            base_color: mat.bevy_color(),
-            perceptual_roughness: 0.5,
-            metallic: if mat.conductivity.value() > 0.6 {
-                0.6
-            } else {
-                0.1
-            },
-            ..default()
-        });
-
-        commands.spawn((
-            MaterialObject,
-            mat.clone(),
-            Mesh3d(mesh),
-            MeshMaterial3d(render_mat),
-            Transform::from_xyz(
-                surface_tf.translation.x + x_offset,
-                mat.resting_center_y(surface_tf.translation.y),
-                surface_tf.translation.z,
-            )
-            .with_scale(Vec3::splat(OBJECT_SCALE)),
-        ));
-
-        info!("Spawned material object '{}' on surface", mat.name);
-    }
-}
-
 // ── Loading ──────────────────────────────────────────────────────────────
 
 /// Initializes an empty [`MaterialCatalog`].
@@ -569,6 +494,7 @@ mod tests {
             name: "Ferrite".into(),
             seed: 1001,
             color: [0.58, 0.55, 0.52],
+            origin_planet_seed: None,
             density: prop(0.78, PropertyVisibility::Observable),
             thermal_resistance: prop(0.65, PropertyVisibility::Hidden),
             reactivity: prop(0.35, PropertyVisibility::Hidden),
@@ -860,46 +786,6 @@ visibility = "Hidden"
     }
 
     #[test]
-    fn property_vector_contains_all_five_properties() {
-        let mat = sample_material();
-        let vec = mat.property_vector();
-        assert_eq!(vec.len(), 5);
-        assert!(
-            (vec[0] - mat.density.value()).abs() < f32::EPSILON,
-            "index 0 must be density"
-        );
-        assert!(
-            (vec[1] - mat.thermal_resistance.value()).abs() < f32::EPSILON,
-            "index 1 must be thermal_resistance"
-        );
-        assert!(
-            (vec[2] - mat.reactivity.value()).abs() < f32::EPSILON,
-            "index 2 must be reactivity"
-        );
-        assert!(
-            (vec[3] - mat.conductivity.value()).abs() < f32::EPSILON,
-            "index 3 must be conductivity"
-        );
-        assert!(
-            (vec[4] - mat.toxicity.value()).abs() < f32::EPSILON,
-            "index 4 must be toxicity"
-        );
-    }
-
-    #[test]
-    fn property_vector_values_in_unit_range() {
-        for seed in [0u64, 1, 42, u64::MAX, 0xDEAD_BEEF] {
-            let mat = derive_material_from_seed(seed);
-            for (i, &v) in mat.property_vector().iter().enumerate() {
-                assert!(
-                    (0.0..=1.0).contains(&v),
-                    "seed {seed:#X}: property_vector[{i}] = {v} out of [0,1]"
-                );
-            }
-        }
-    }
-
-    #[test]
     fn mix_seed_deterministic() {
         let a = mix_seed(100, 200);
         let b = mix_seed(100, 200);
@@ -919,80 +805,6 @@ visibility = "Hidden"
         assert!((unit_interval_01(u64::MAX) - 1.0).abs() < f32::EPSILON);
         let mid = unit_interval_01(u64::MAX / 2);
         assert!((0.0..=1.0).contains(&mid));
-    }
-
-    #[test]
-    fn cosine_similarity_identical_vectors_returns_one() {
-        let v = [0.5_f32, 0.3, 0.8, 0.1, 0.6];
-        let result = cosine_similarity(&v, &v);
-        assert!(
-            (result - 1.0).abs() < 1e-6,
-            "identical vectors must have similarity 1.0, got {result}"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_orthogonal_vectors_returns_zero() {
-        // Two vectors with no overlapping non-zero components are orthogonal.
-        let a = [1.0_f32, 0.0, 0.0, 0.0, 0.0];
-        let b = [0.0_f32, 1.0, 0.0, 0.0, 0.0];
-        let result = cosine_similarity(&a, &b);
-        assert!(
-            result.abs() < 1e-6,
-            "orthogonal vectors must have similarity 0.0, got {result}"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_zero_vector_returns_zero() {
-        let zero = [0.0_f32; 5];
-        let v = [0.5_f32, 0.3, 0.8, 0.1, 0.6];
-        assert_eq!(
-            cosine_similarity(&zero, &v),
-            0.0,
-            "zero vector vs any vector must return 0.0"
-        );
-        assert_eq!(
-            cosine_similarity(&v, &zero),
-            0.0,
-            "any vector vs zero vector must return 0.0"
-        );
-        assert_eq!(
-            cosine_similarity(&zero, &zero),
-            0.0,
-            "zero vector vs zero vector must return 0.0"
-        );
-    }
-
-    #[test]
-    fn cosine_similarity_result_in_unit_range() {
-        // Spot-check a handful of seed-derived materials to confirm the result
-        // is always in [0.0, 1.0].
-        let seeds: &[u64] = &[0x1, 0xDEAD_BEEF, 0xCAFE_BABE, 0xFFFF_FFFF_FFFF_FFFF];
-        for &s1 in seeds {
-            for &s2 in seeds {
-                let m1 = derive_material_from_seed(s1);
-                let m2 = derive_material_from_seed(s2);
-                let sim = cosine_similarity(&m1.property_vector(), &m2.property_vector());
-                assert!(
-                    (0.0..=1.0).contains(&sim),
-                    "cosine_similarity({s1:#X}, {s2:#X}) = {sim} out of [0,1]"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn cosine_similarity_partial_overlap_between_zero_and_one() {
-        // Vectors that share some but not all components should yield a value
-        // strictly between 0 and 1.
-        let a = [1.0_f32, 1.0, 0.0, 0.0, 0.0];
-        let b = [1.0_f32, 0.0, 1.0, 0.0, 0.0];
-        let result = cosine_similarity(&a, &b);
-        assert!(
-            result > 0.0 && result < 1.0,
-            "partial overlap must yield similarity in (0, 1), got {result}"
-        );
     }
 
     // ── Collision-avoidance tests ────────────────────────────────────────

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -34,6 +34,7 @@ impl Plugin for ObservationPlugin {
             // ConfidenceTracker removed - confidence is now tracked per-observation
             // in the journal system via Confidence(f32) and accumulate() method
             .init_resource::<DescriptorVocabulary>()
+            .add_message::<RecordObservation>()
             .add_message::<OnPlayerDeathEvent>()
             .add_systems(PreStartup, load_confidence_config)
             .add_systems(Update, handle_player_death);
@@ -202,6 +203,18 @@ pub struct ConfidenceConfig {
     /// Lower values require more repeated testing. Typical range: 0.1-0.3
     #[serde(default = "default_base_observation_weight")]
     pub base_observation_weight: f32,
+
+    /// Cosine similarity threshold above which two materials are considered
+    /// "similar" for the purposes of wiring `SimilarTo` edges in the knowledge
+    /// graph (Story 10.5).
+    ///
+    /// A value of 1.0 means "identical property vectors only"; lower values
+    /// surface more pairs as similar. Values below 0.5 are not recommended —
+    /// they tend to produce spurious connections that erode trust in the journal.
+    ///
+    /// Typical range: 0.80-0.95
+    #[serde(default = "default_similarity_threshold")]
+    pub similarity_threshold: f32,
 }
 
 /// Default value for death_degradation_factor field.
@@ -229,6 +242,11 @@ fn default_base_observation_weight() -> f32 {
     0.2
 }
 
+/// Default cosine similarity threshold for `SimilarTo` edge creation.
+fn default_similarity_threshold() -> f32 {
+    0.85
+}
+
 impl Default for ConfidenceConfig {
     /// Default confidence configuration values.
     ///
@@ -242,6 +260,7 @@ impl Default for ConfidenceConfig {
             domain_recovery_multiplier: 2.0,  // 2x recovery in death domain
             passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
             base_observation_weight: 0.2,     // Standard observation strength
+            similarity_threshold: 0.85,       // 85% cosine similarity = "similar materials"
         }
     }
 }
@@ -1203,38 +1222,23 @@ pub struct OnPlayerDeathEvent {
 /// before any UI systems that might display confidence-dependent language.
 fn handle_player_death(
     mut reader: MessageReader<OnPlayerDeathEvent>,
-    mut player_query: Query<&mut crate::journal::Journal, With<crate::player::Player>>,
+    graph: Option<ResMut<crate::knowledge_graph::KnowledgeGraph>>,
     mut commands: Commands,
     config: Res<ConfidenceConfig>,
     time: Res<Time>,
 ) {
-    // Process all death events (should typically be just one per frame)
     let death_events: Vec<_> = reader.read().collect();
     if death_events.is_empty() {
         return;
     }
 
-    let Ok(mut journal) = player_query.single_mut() else {
-        warn!("OnPlayerDeathEvent received but no player with journal found");
-        return;
-    };
-
-    // Use the most recent death event if multiple occurred
     let death_event = death_events.last().unwrap();
     let current_time = time.elapsed().as_millis() as u64;
 
-    // Apply death degradation to all observations in all journal entries
-    for entry in journal.entries.values_mut() {
-        for observation_group in entry.observations.values_mut() {
-            for observation in observation_group.iter_mut() {
-                observation
-                    .confidence
-                    .degrade(config.death_degradation_factor, config.death_floor);
-            }
-        }
+    if let Some(mut graph) = graph {
+        graph.degrade_all(config.death_degradation_factor, config.death_floor);
     }
 
-    // Create death context for domain-weighted recovery
     let death_context = DeathContext::new(death_event.cause, current_time);
     commands.insert_resource(death_context);
 
@@ -1242,6 +1246,68 @@ fn handle_player_death(
         "Applied death confidence degradation (factor: {}, floor: {}) and established death context for {:?}",
         config.death_degradation_factor, config.death_floor, death_event.cause
     );
+}
+
+// ── RecordObservation message ─────────────────────────────────────────────
+
+/// Message sent by any game system to record a player observation.
+///
+/// This is the single observation ingestion point for the entire game —
+/// heat, carry, fabricator, interaction, and any future system all send
+/// this message rather than writing to the KnowledgeGraph directly.
+///
+/// The knowledge graph system (`update_knowledge_graph`) is the sole
+/// consumer: it routes by `observation.category`, wires graph edges from
+/// `planet_seed` / `context_location`, and stores revealed property values
+/// from `material_seed` via catalog lookup.
+///
+/// **Material instance observations** should set `material_seed` to the
+/// seed of the [`crate::materials::GameMaterial`] being observed.
+/// `update_knowledge_graph` resolves the full material (name, property
+/// values) from the catalog so callers never need to decompose it.
+///
+/// **Fabrication observations** leave `material_seed` as `None` and set
+/// `key` to [`crate::journal::JournalKey::Fabrication`] directly — there
+/// is no single "material instance" being observed.
+#[derive(Message, Clone)]
+pub struct RecordObservation {
+    /// Which journal subject this observation belongs to.
+    ///
+    /// For material instance observations, prefer setting `material_seed`
+    /// and leaving this as `JournalKey::MaterialInstance { seed }` — the
+    /// two must be consistent when both are provided.
+    pub key: crate::journal::JournalKey,
+    /// Player-facing display name for the subject (used to initialise the
+    /// KnowledgeGraph node on first encounter; ignored for subsequent
+    /// observations of the same key).
+    pub name: String,
+    /// The observation payload: category, confidence, description, tick.
+    pub observation: crate::journal::Observation,
+    /// Seed of the [`crate::materials::GameMaterial`] being observed, when
+    /// this observation is about a material instance.
+    ///
+    /// `update_knowledge_graph` uses this to look up the material's property
+    /// values from the [`crate::materials::MaterialCatalog`] and store them
+    /// as revealed values on the KnowledgeGraph node, enabling query-time
+    /// classification without reaching back into world entities.
+    ///
+    /// `None` for fabrication results, location notes, and any observation
+    /// that is not about a specific material instance.
+    pub material_seed: Option<u64>,
+    /// Planet on which this observation was made.
+    ///
+    /// When `Some`, the knowledge graph system wires a `FoundOn` edge from
+    /// the observed subject to the corresponding location concept.
+    pub planet_seed: Option<u64>,
+    /// For fabrication observations: seeds of the input materials combined
+    /// to produce the output. Used to wire `DerivedFrom` edges.
+    ///
+    /// Empty for non-fabrication observations.
+    pub input_seeds: Vec<u64>,
+    /// Optional location context where this observation was made.
+    ///
+    /// When `Some`, wires an `ObservedAt` edge to this location concept.
+    pub context_location: Option<crate::journal::JournalKey>,
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -1567,6 +1633,7 @@ mod tests {
             domain_recovery_multiplier: 2.5,
             passive_recovery_multiplier: 0.8,
             base_observation_weight: 0.25,
+            similarity_threshold: 0.85,
         };
 
         let toml = toml::to_string(&config).expect("ConfidenceConfig should serialize to TOML");
@@ -2640,11 +2707,10 @@ mod tests {
 
     #[test]
     fn death_event_degrades_all_journal_observations() {
-        use crate::journal::{Journal, JournalKey, Observation, ObservationCategory};
-        use crate::player::Player;
+        use crate::journal::{JournalKey, Observation, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
 
         let mut app = App::new();
-        // Don't use the plugin to avoid TOML config loading
         app.add_message::<OnPlayerDeathEvent>()
             .add_systems(Update, handle_player_death)
             .insert_resource(ConfidenceConfig {
@@ -2653,80 +2719,46 @@ mod tests {
                 domain_recovery_multiplier: 2.0,
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
+                similarity_threshold: 0.85,
             })
             .insert_resource(Time::<()>::default());
 
-        // Create a player with a journal containing observations at different confidence levels
-        let mut journal = Journal::default();
+        // Populate the KnowledgeGraph with concept nodes carrying observations.
+        let mut graph = KnowledgeGraph::default();
 
-        // Add observations with high confidence
-        journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
-            "Test Material",
-            Observation {
+        let key42 = JournalKey::MaterialInstance { seed: 42 };
+        let node42 = graph.ensure_concept(ConceptId(key42.clone()), ConceptCategory::Material, 0);
+        if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
+            n.name = "Test Material".to_string();
+            n.confidence = Confidence(0.8);
+            n.add_observation(Observation {
                 category: ObservationCategory::ThermalBehavior,
-                confidence: Confidence(0.8), // High confidence
+                confidence: Confidence(0.8),
                 description: "Reliably withstands heat".to_string(),
                 recorded_at: 100,
-            },
-        );
-
-        journal.record(
-            JournalKey::Material {
-                seed: 99,
-                planet_seed: None,
-            },
-            "Another Material",
-            Observation {
-                category: ObservationCategory::Weight,
-                confidence: Confidence(0.9), // Very high confidence
-                description: "Notably heavy".to_string(),
-                recorded_at: 200,
-            },
-        );
-
-        // Add observation with medium confidence
-        journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
-            "Test Material",
-            Observation {
+            });
+            n.add_observation(Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5), // Medium confidence
+                confidence: Confidence(0.5),
                 description: "Smooth metallic surface".to_string(),
                 recorded_at: 150,
-            },
-        );
+            });
+        }
 
-        // Spawn player with the journal
-        let player_entity = app.world_mut().spawn((Player, journal)).id();
+        let key99 = JournalKey::MaterialInstance { seed: 99 };
+        let node99 = graph.ensure_concept(ConceptId(key99.clone()), ConceptCategory::Material, 0);
+        if let Some(n) = graph.graph_mut().node_weight_mut(node99) {
+            n.name = "Another Material".to_string();
+            n.confidence = Confidence(0.9);
+            n.add_observation(Observation {
+                category: ObservationCategory::Weight,
+                confidence: Confidence(0.9),
+                description: "Notably heavy".to_string(),
+                recorded_at: 200,
+            });
+        }
 
-        // Verify initial confidence levels
-        let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-        let weight_obs = &journal.entries[&JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::Weight][0];
-        let surface_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::SurfaceAppearance][0];
-
-        assert_eq!(thermal_obs.confidence.0, 0.8);
-        assert_eq!(weight_obs.confidence.0, 0.9);
-        assert_eq!(surface_obs.confidence.0, 0.5);
+        app.insert_resource(graph);
 
         // Emit death event
         app.world_mut()
@@ -2734,100 +2766,79 @@ mod tests {
             .write(OnPlayerDeathEvent {
                 cause: DeathCause::HeatSystem,
             });
-
-        // Run the death handler system
         app.update();
 
-        // Verify confidence has been degraded
-        let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-        let weight_obs = &journal.entries[&JournalKey::Material {
-            seed: 99,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::Weight][0];
-        let surface_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::SurfaceAppearance][0];
+        // Verify confidence was degraded in the KnowledgeGraph.
+        let graph = app.world().resource::<KnowledgeGraph>();
+        let n42 = graph.node(node42).unwrap();
+        let thermal = &n42.observations_by_category(&ObservationCategory::ThermalBehavior)[0];
+        let surface = &n42.observations_by_category(&ObservationCategory::SurfaceAppearance)[0];
+        let n99 = graph.node(node99).unwrap();
+        let weight = &n99.observations_by_category(&ObservationCategory::Weight)[0];
 
-        // Expected values: original * 0.6, but not below 0.2 floor
-        assert_eq!(thermal_obs.confidence.0, 0.8 * 0.6); // 0.48
-        assert_eq!(weight_obs.confidence.0, 0.9 * 0.6); // 0.54
-        assert_eq!(surface_obs.confidence.0, 0.5 * 0.6); // 0.30
+        // Expected: original * 0.6, not below 0.2 floor
+        assert!(
+            (thermal.confidence.0 - 0.8 * 0.6).abs() < 1e-5,
+            "thermal: {}",
+            thermal.confidence.0
+        );
+        assert!(
+            (weight.confidence.0 - 0.9 * 0.6).abs() < 1e-5,
+            "weight: {}",
+            weight.confidence.0
+        );
+        assert!(
+            (surface.confidence.0 - 0.5 * 0.6).abs() < 1e-5,
+            "surface: {}",
+            surface.confidence.0
+        );
     }
 
     #[test]
     fn death_event_respects_confidence_floor() {
-        use crate::journal::{Journal, JournalKey, Observation, ObservationCategory};
-        use crate::player::Player;
+        use crate::journal::{JournalKey, Observation, ObservationCategory};
+        use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
 
         let mut app = App::new();
-        // Don't use the plugin to avoid TOML config loading
         app.add_message::<OnPlayerDeathEvent>()
             .add_systems(Update, handle_player_death)
             .insert_resource(ConfidenceConfig {
-                death_degradation_factor: 0.5, // Aggressive degradation
-                death_floor: 0.3,              // High floor
+                death_degradation_factor: 0.5,
+                death_floor: 0.3,
                 domain_recovery_multiplier: 2.0,
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
+                similarity_threshold: 0.85,
             })
             .insert_resource(Time::<()>::default());
 
-        // Create a player with a journal containing low confidence observation
-        let mut journal = Journal::default();
-
-        journal.record(
-            JournalKey::Material {
-                seed: 42,
-                planet_seed: None,
-            },
-            "Test Material",
-            Observation {
+        let mut graph = KnowledgeGraph::default();
+        let key42 = JournalKey::MaterialInstance { seed: 42 };
+        let node42 = graph.ensure_concept(ConceptId(key42.clone()), ConceptCategory::Material, 0);
+        if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
+            n.add_observation(Observation {
                 category: ObservationCategory::ThermalBehavior,
-                confidence: Confidence(0.4), // Low confidence that would degrade below floor
+                confidence: Confidence(0.4),
                 description: "Seemed to react to heat".to_string(),
                 recorded_at: 100,
-            },
-        );
+            });
+        }
+        app.insert_resource(graph);
 
-        let player_entity = app.world_mut().spawn((Player, journal)).id();
-
-        // Verify initial confidence
-        let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-        assert_eq!(thermal_obs.confidence.0, 0.4);
-
-        // Emit death event
         app.world_mut()
             .resource_mut::<Messages<OnPlayerDeathEvent>>()
             .write(OnPlayerDeathEvent {
                 cause: DeathCause::Fabrication,
             });
-
-        // Run the death handler system
         app.update();
 
-        // Verify confidence was clamped to floor
-        // Expected: 0.4 * 0.5 = 0.2, but floor is 0.3, so should be 0.3
-        let journal = app.world().entity(player_entity).get::<Journal>().unwrap();
-        let thermal_obs = &journal.entries[&JournalKey::Material {
-            seed: 42,
-            planet_seed: None,
-        }]
-            .observations[&ObservationCategory::ThermalBehavior][0];
-
-        assert_eq!(thermal_obs.confidence.0, 0.3); // Clamped to floor
+        // Expected: 0.4 * 0.5 = 0.2, clamped to floor 0.3
+        let graph = app.world().resource::<KnowledgeGraph>();
+        let thermal = &graph
+            .node(node42)
+            .unwrap()
+            .observations_by_category(&ObservationCategory::ThermalBehavior)[0];
+        assert_eq!(thermal.confidence.0, 0.3);
     }
 
     #[test]
@@ -2910,6 +2921,7 @@ mod tests {
             domain_recovery_multiplier: 2.0,
             passive_recovery_multiplier: 0.7,
             base_observation_weight: 0.2,
+            similarity_threshold: 0.85,
         };
 
         let context = DeathContext::new(DeathCause::HeatSystem, 1000);
@@ -2986,6 +2998,7 @@ mod tests {
             domain_recovery_multiplier: 2.0, // 2x recovery in death domain
             passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
             base_observation_weight: 0.2,
+            similarity_threshold: 0.85,
         };
 
         // Create death context for heat system death

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -631,9 +631,12 @@ fn sync_active_exterior_chunks(
                 continue;
             }
 
-            let deposit_material = material_catalog
+            let mut deposit_material = material_catalog
                 .derive_and_register(placement.material_seed)
                 .clone();
+            // Tag the spawn origin so observation systems can wire the FoundOn
+            // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
+            deposit_material.origin_planet_seed = Some(world_profile.planet_seed.0);
             let mesh = deposit_material.mesh_for_density(&mut meshes);
             let render_material = render_materials.add(StandardMaterial {
                 base_color: deposit_material.bevy_color(),

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -802,6 +802,7 @@ fn sample_game_material(name: &str) -> GameMaterial {
         name: name.to_string(),
         seed: 42,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: MaterialProperty::new(0.5, PropertyVisibility::Observable),
         thermal_resistance: MaterialProperty::new(0.5, PropertyVisibility::Observable),
         reactivity: MaterialProperty::new(0.5, PropertyVisibility::Observable),

--- a/tests/carry_processing.rs
+++ b/tests/carry_processing.rs
@@ -26,6 +26,7 @@ fn test_material(name: &str, density: f32, seed: u64) -> GameMaterial {
         name: name.into(),
         seed,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: prop(density),
         thermal_resistance: prop(0.5),
         reactivity: prop(0.5),

--- a/tests/scenarios/helpers.rs
+++ b/tests/scenarios/helpers.rs
@@ -18,6 +18,7 @@ pub fn test_material(name: &str, density: f32, seed: u64) -> GameMaterial {
         name: name.into(),
         seed,
         color: [0.5, 0.5, 0.5],
+        origin_planet_seed: None,
         density: prop(density),
         thermal_resistance: prop(0.5),
         reactivity: prop(0.5),


### PR DESCRIPTION
Closes #390

- `CombinationRules.pair_rules` key changed from `(String, String)` to `(u64, u64)`
- `rules_for()` now takes seeds instead of names
- `combinations.toml` updated to use `material_seed_a` / `material_seed_b`
- `fabricator.rs` passes `a.seed, b.seed` instead of names
- No classification logic runs during world generation
- Material names in journal/inspect derived from classification at query time (N.3)

698 tests pass, make check clean.