### PR TITLE
fix: 342.5 - make combination pair keys order-independent

### DIFF
--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -379,7 +379,23 @@ fn blend_color(a: &[f32; 3], b: &[f32; 3], reactive: bool) -> [f32; 3] {
     }
 }
 
+/// Derives the canonical fabricated output seed for an unordered pair of input seeds.
+///
+/// Fabricator slots are physical placement affordances, not recipe semantics: combining
+/// A+B must be the same experiment as combining B+A. Sorting the seeds before applying
+/// the stable arithmetic formula makes the fabricated material identity independent of
+/// which input slot happened to hold each constituent.
+fn combined_material_seed(seed_a: u64, seed_b: u64) -> u64 {
+    let seed_min = seed_a.min(seed_b);
+    let seed_max = seed_a.max(seed_b);
+    seed_min.wrapping_mul(31).wrapping_add(seed_max)
+}
+
 /// Combine two materials using pure property math — no external rule tables.
+///
+/// Input order does not affect the output: the two input seeds are sorted before
+/// the fabricated seed is derived, so placing A in slot 0 and B in slot 1 yields
+/// the same material as placing B in slot 0 and A in slot 1.
 ///
 /// # Property formulas
 ///
@@ -394,7 +410,7 @@ fn blend_color(a: &[f32; 3], b: &[f32; 3], reactive: bool) -> [f32; 3] {
 /// All outputs receive a small deterministic perturbation from the combined
 /// seed so results are reproducible but not perfectly clean averages.
 pub fn property_combine(a: &GameMaterial, b: &GameMaterial) -> GameMaterial {
-    let combined_seed = a.seed.wrapping_mul(31).wrapping_add(b.seed);
+    let combined_seed = combined_material_seed(a.seed, b.seed);
     let name = crate::naming::compositional_name(&a.name, &b.name);
 
     // ── Density: weighted by each input's density (denser dominates) ──
@@ -485,19 +501,67 @@ mod tests {
 
     #[test]
     fn property_combine_order_independent() {
-        // Combined seed is asymmetric by design (a*31+b ≠ b*31+a) but properties
-        // should still be symmetric since the formulas don't distinguish a from b.
-        // Actually combined_seed IS asymmetric — outputs intentionally differ.
-        // What we verify: neither direction panics and both are valid.
+        // Fabricator input slots are not semantic recipe operands. The output must
+        // be identical no matter which slot receives which constituent material.
         let a = test_material("Alpha", 1, 0.8);
         let b = test_material("Beta", 2, 0.3);
-        let r1 = property_combine(&a, &b);
-        let r2 = property_combine(&b, &a);
-        // Seeds differ (asymmetric by design)
-        assert_ne!(r1.seed, r2.seed);
-        // But both are valid materials
-        assert!(!r1.name.is_empty());
-        assert!(!r2.name.is_empty());
+
+        let ab = property_combine(&a, &b);
+        let ba = property_combine(&b, &a);
+
+        assert_eq!(ab.seed, ba.seed, "combined seed should ignore slot order");
+        assert_eq!(ab.name, ba.name, "display name should ignore slot order");
+        assert_eq!(ab.color, ba.color, "color should ignore slot order");
+        assert_eq!(
+            ab.origin_planet_seed, ba.origin_planet_seed,
+            "origin metadata should ignore slot order"
+        );
+
+        assert_eq!(
+            ab.density.value(),
+            ba.density.value(),
+            "density should ignore slot order"
+        );
+        assert_eq!(
+            ab.density.visibility, ba.density.visibility,
+            "density visibility should ignore slot order"
+        );
+        assert_eq!(
+            ab.thermal_resistance.value(),
+            ba.thermal_resistance.value(),
+            "thermal resistance should ignore slot order"
+        );
+        assert_eq!(
+            ab.thermal_resistance.visibility, ba.thermal_resistance.visibility,
+            "thermal resistance visibility should ignore slot order"
+        );
+        assert_eq!(
+            ab.reactivity.value(),
+            ba.reactivity.value(),
+            "reactivity should ignore slot order"
+        );
+        assert_eq!(
+            ab.reactivity.visibility, ba.reactivity.visibility,
+            "reactivity visibility should ignore slot order"
+        );
+        assert_eq!(
+            ab.conductivity.value(),
+            ba.conductivity.value(),
+            "conductivity should ignore slot order"
+        );
+        assert_eq!(
+            ab.conductivity.visibility, ba.conductivity.visibility,
+            "conductivity visibility should ignore slot order"
+        );
+        assert_eq!(
+            ab.toxicity.value(),
+            ba.toxicity.value(),
+            "toxicity should ignore slot order"
+        );
+        assert_eq!(
+            ab.toxicity.visibility, ba.toxicity.visibility,
+            "toxicity visibility should ignore slot order"
+        );
     }
 
     #[test]
@@ -627,7 +691,7 @@ mod tests {
 
         for &a in &palette_seeds {
             for &b in &palette_seeds {
-                let combined = a.wrapping_mul(31).wrapping_add(b);
+                let combined = combined_material_seed(a, b);
                 assert!(
                     !palette_set.contains(&combined),
                     "fabrication of ({a}, {b}) → {combined} collides with a palette seed"

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -49,8 +49,6 @@ pub const PROPERTY_DIM: usize = 5;
 // appear naturally through exploration. The seed values must never change —
 // doing so would break saved worlds and biome palette references.
 
-/// Well-known material seeds: `(name, seed)` pairs for the 10 original
-/// materials that shipped in the static TOML catalog.
 /// The 10 base materials whose seeds, display names, and classification
 /// identities are part of the game's authoritative data model.
 ///
@@ -58,6 +56,11 @@ pub const PROPERTY_DIM: usize = 5;
 /// material across every generated world. Display names are cosmetic and may
 /// be updated freely. Classification ranges in `classifications.toml` must
 /// stay in sync with the seed values here.
+///
+/// Every variant's [`Self::seed`] value must be unique. A const assertion below
+/// validates the full variant list at compile time so a duplicate seed fails
+/// the build before it can silently collapse two deterministic material
+/// identities into the same generated material.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum WellKnownMaterial {
     /// Iron-rich metal. Dense, thermally resilient, conductive.
@@ -81,6 +84,19 @@ pub enum WellKnownMaterial {
     /// Phosphorescent mineral. Very low density, very high thermal.
     Phosphite,
 }
+
+const ALL_WELL_KNOWN_MATERIALS: [WellKnownMaterial; 10] = [
+    WellKnownMaterial::Ferrite,
+    WellKnownMaterial::Calcium,
+    WellKnownMaterial::Sulfurite,
+    WellKnownMaterial::Prismate,
+    WellKnownMaterial::Verdant,
+    WellKnownMaterial::Osmium,
+    WellKnownMaterial::Volatite,
+    WellKnownMaterial::Cobaltine,
+    WellKnownMaterial::Silite,
+    WellKnownMaterial::Phosphite,
+];
 
 impl WellKnownMaterial {
     /// The generation seed that deterministically defines this material's
@@ -120,20 +136,47 @@ impl WellKnownMaterial {
     ///
     /// Use this wherever the old `WELL_KNOWN_MATERIAL_SEEDS` array was iterated.
     pub fn all() -> &'static [WellKnownMaterial] {
-        &[
-            Self::Ferrite,
-            Self::Calcium,
-            Self::Sulfurite,
-            Self::Prismate,
-            Self::Verdant,
-            Self::Osmium,
-            Self::Volatite,
-            Self::Cobaltine,
-            Self::Silite,
-            Self::Phosphite,
-        ]
+        &ALL_WELL_KNOWN_MATERIALS
     }
 }
+
+const WELL_KNOWN_MATERIAL_SEEDS_FOR_VALIDATION: [u64; ALL_WELL_KNOWN_MATERIALS.len()] =
+    well_known_material_seed_values();
+
+const fn well_known_material_seed_values() -> [u64; ALL_WELL_KNOWN_MATERIALS.len()] {
+    let mut seeds = [0_u64; ALL_WELL_KNOWN_MATERIALS.len()];
+    let mut i = 0;
+
+    while i < ALL_WELL_KNOWN_MATERIALS.len() {
+        seeds[i] = ALL_WELL_KNOWN_MATERIALS[i].seed();
+        i += 1;
+    }
+
+    seeds
+}
+
+const fn validate_well_known_material_seed_uniqueness(seeds: &[u64]) {
+    let mut i = 0;
+
+    while i < seeds.len() {
+        let mut j = i + 1;
+
+        while j < seeds.len() {
+            if seeds[i] == seeds[j] {
+                panic!(
+                    "duplicate WellKnownMaterial seed detected; every \
+                     WellKnownMaterial::seed() value must be unique",
+                );
+            }
+            j += 1;
+        }
+
+        i += 1;
+    }
+}
+
+const _: () =
+    validate_well_known_material_seed_uniqueness(&WELL_KNOWN_MATERIAL_SEEDS_FOR_VALIDATION);
 
 /// Backward-compatible flat array for code that still iterates `(label, seed)` pairs.
 /// New code should use [`WellKnownMaterial::all()`] instead.
@@ -992,6 +1035,47 @@ visibility = "Hidden"
         let a = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
         let b = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
         assert_eq!(a, b);
+    }
+
+    /// Defense-in-depth check for the compile-time uniqueness assertion above.
+    ///
+    /// The const assertion fails the build before tests can run when two variants
+    /// share a seed. This test keeps a human-readable regression check in the test
+    /// suite and verifies that the canonical 10 starter seeds are still represented
+    /// exactly once.
+    #[test]
+    fn well_known_seeds_are_unique() {
+        let mut seen: std::collections::HashMap<u64, &'static str> =
+            std::collections::HashMap::new();
+
+        for &wk in WellKnownMaterial::all() {
+            let seed = wk.seed();
+            if let Some(previous_label) = seen.insert(seed, wk.display_name()) {
+                panic!(
+                    "duplicate WellKnownMaterial seed {seed} produced by both \
+                     {previous_label} and {}",
+                    wk.display_name(),
+                );
+            }
+        }
+
+        assert_eq!(
+            WellKnownMaterial::all().len(),
+            10,
+            "WellKnownMaterial must continue to expose exactly 10 starter variants",
+        );
+        assert_eq!(
+            seen.len(),
+            10,
+            "all 10 WellKnownMaterial seeds must appear exactly once",
+        );
+
+        for expected_seed in 1001_u64..=1010_u64 {
+            assert!(
+                seen.contains_key(&expected_seed),
+                "canonical WellKnownMaterial seed {expected_seed} is missing",
+            );
+        }
     }
 
     /// Verifies that the 10 well-known material seeds each produce a material


### PR DESCRIPTION
## Summary
- Normalize fabricated material seed generation by sorting input seeds before deriving the combined seed.
- Preserve slot-order independence so A+B and B+A produce the same fabricated material identity.
- Strengthen `property_combine_order_independent` to assert full output equality across seed, name, color, origin metadata, properties, and visibility.

## Verification
- Pending GitHub Actions.

## Notes
- This branch is stacked after #409 / Story 342.4. Because the requested base is `main`, the PR diff will include Story 342.4 changes until #409 is merged.

Closes #408
