### PR TITLE
docs: add comment for #[allow(deprecated)] at observation.rs:1004

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1001,6 +1001,11 @@ pub struct ConfidenceTracker {
     counts: HashMap<ObsKey, u32>,
 }
 
+// Implementing methods on a deprecated type requires suppressing the deprecation warning on
+// the impl block itself. ConfidenceTracker is deprecated in favour of journal-based
+// RecordObservation messages but the impl must remain compilable during the migration
+// window so existing call-sites can be updated incrementally. Remove this allow once all
+// call-sites have been migrated and ConfidenceTracker is deleted.
 #[allow(deprecated)]
 impl ConfidenceTracker {
     /// Record one observation. Returns the new count.


### PR DESCRIPTION
## Summary

Adds an explanatory comment above the `#[allow(deprecated)]` attribute at observation.rs:1004 describing why the deprecation suppression is needed.

The comment explains:
- `ConfidenceTracker` is deprecated in favour of journal-based `RecordObservation` messages
- The `impl` block still needs to compile during the migration window
- Once migration is complete, this impl block and the allow attribute can be removed

## Changes
- `src/observation.rs`: Added explanatory comment above `#[allow(deprecated)]`

## Verification
- `cargo clippy` passes (exit 0)

Closes related lint improvement task.