### PR TITLE
feat: add CI coverage to develop branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   schedule:
     - cron: '30 8 * * 6'
 

--- a/.github/workflows/kanban-publish.yml
+++ b/.github/workflows/kanban-publish.yml
@@ -2,7 +2,7 @@ name: Publish Kanban Image
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "kanban/**"
   pull_request:

--- a/.github/workflows/lint-suppression-guard.yml
+++ b/.github/workflows/lint-suppression-guard.yml
@@ -2,7 +2,7 @@ name: Lint Suppression Guard
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   issues: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Add `develop` to the push/PR branch triggers for the four CI workflows that were previously main-only, so broken commits on `develop` are caught before a PR to `main` is opened.

## Changes

| Workflow | Before | After |
|---|---|---|
| `rust.yml` | push/PR to `main` only | push/PR to `main` + `develop` |
| `codeql.yml` | push/PR to `main` only | push/PR to `main` + `develop` |
| `lint-suppression-guard.yml` | push to `main` only | push to `main` + `develop` |
| `kanban-publish.yml` | push to `main` only (+ path filter) | push to `main` + `develop` (+ path filter) |

## Not changed

- `release-game.yml` — remains `main`-only (release workflow)
- `release-server.yml` — remains `main`-only (release workflow)
- `automation-approve.yml` — event-driven (`issue_comment`), no branch gate
- `build-native-target.yml` — `workflow_call` only, no branch gate

## Verification

`make check` passes on the branch.