### PR TITLE
feat: material classification ranges loaded from assets/

### DIFF
--- a/assets/materials/classifications.toml
+++ b/assets/materials/classifications.toml
@@ -1,0 +1,136 @@
+# Material classification ranges for the Journal query layer.
+#
+# Each entry defines a named material type and the property ranges that
+# an observed material instance must fall within to be classified as that type.
+# Ranges are inclusive: a value equal to min or max is inside the range.
+#
+# Properties used for classification: density (mapped from Weight observation)
+# and thermal_resistance (mapped from ThermalBehavior observation).
+# Reactivity, conductivity, and toxicity observation systems are not yet wired
+# (Story N.4+); their range fields are reserved for when those systems exist.
+#
+# All values are derived from derive_material_from_seed() output — NOT from
+# the legacy assets/materials/*.toml reference values (those pre-date the
+# seed-derivation pipeline).
+#
+# Classification is NEVER stored. It is computed at query time by comparing
+# the player's revealed property values against these ranges.
+# Do not add any "type" or "classification" field to entities, components,
+# or graph nodes — ever.
+#
+# Ranges were computed by:
+# 1. Running derive_material_from_seed() for each well-known seed
+# 2. Finding the density midpoint between adjacent materials in density-space
+# 3. Using thermal_resistance as the secondary discriminator where density
+#    ranges would otherwise overlap
+# 4. Verifying no two entries share an overlapping (density AND thermal) region
+
+[[classification]]
+name = "ferrite"
+display_name = "Ferrite"
+# Seed 1001: density=0.5086, thermal=0.4468
+[classification.density]
+min = 0.49
+max = 0.56
+[classification.thermal_resistance]
+min = 0.38
+max = 0.51
+
+[[classification]]
+name = "calcium"
+display_name = "Calcium"
+# Seed 1002: density=0.1400, thermal=0.7087
+[classification.density]
+min = 0.09
+max = 0.20
+[classification.thermal_resistance]
+min = 0.62
+max = 0.80
+
+[[classification]]
+name = "sulfurite"
+display_name = "Sulfurite"
+# Seed 1003: density=0.5963, thermal=0.7607
+[classification.density]
+min = 0.54
+max = 0.65
+[classification.thermal_resistance]
+min = 0.70
+max = 0.85
+
+[[classification]]
+name = "prismate"
+display_name = "Prismate"
+# Seed 1004: density=0.2062, thermal=0.4010
+[classification.density]
+min = 0.15
+max = 0.27
+[classification.thermal_resistance]
+min = 0.32
+max = 0.48
+
+[[classification]]
+name = "verdant"
+display_name = "Verdant"
+# Seed 1005: density=0.4676, thermal=0.4967
+[classification.density]
+min = 0.42
+max = 0.48
+[classification.thermal_resistance]
+min = 0.42
+max = 0.58
+
+[[classification]]
+name = "osmium"
+display_name = "Osmium"
+# Seed 1006: density=0.7249, thermal=0.5620
+[classification.density]
+min = 0.68
+max = 0.80
+[classification.thermal_resistance]
+min = 0.50
+max = 0.63
+
+[[classification]]
+name = "volatite"
+display_name = "Volatite"
+# Seed 1007: density=0.5882, thermal=0.2229
+[classification.density]
+min = 0.54
+max = 0.63
+[classification.thermal_resistance]
+min = 0.14
+max = 0.30
+
+[[classification]]
+name = "cobaltine"
+display_name = "Cobaltine"
+# Seed 1008: density=0.6320, thermal=0.4959
+[classification.density]
+min = 0.59
+max = 0.67
+[classification.thermal_resistance]
+min = 0.43
+max = 0.57
+
+[[classification]]
+name = "silite"
+display_name = "Silite"
+# Seed 1009: density=0.4503, thermal=0.1523
+[classification.density]
+min = 0.38
+max = 0.47
+[classification.thermal_resistance]
+min = 0.09
+max = 0.22
+
+[[classification]]
+name = "phosphite"
+display_name = "Phosphite"
+# Seed 1010: density=0.0542, thermal=0.8062
+[classification.density]
+min = 0.00
+max = 0.08
+[classification.thermal_resistance]
+min = 0.72
+max = 0.92

--- a/src/carry.rs
+++ b/src/carry.rs
@@ -24,9 +24,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::input::InputAction;
 use crate::interaction::HeldItem;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{GameMaterial, MaterialObject};
 use crate::observation::Confidence;
+use crate::observation::RecordObservation;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use leafwing_input_manager::prelude::*;
 
@@ -1407,6 +1408,7 @@ pub fn record_weight_observation(
             seed: material.seed,
         },
         name: material.name.clone(),
+        material_seed: Some(material.seed),
         planet_seed: material.origin_planet_seed,
         observation: Observation {
             category: ObservationCategory::Weight,

--- a/src/classification.rs
+++ b/src/classification.rs
@@ -1,0 +1,391 @@
+//! Material classification — query-time grouping of observed instances.
+//!
+//! Loads `assets/materials/classifications.toml` at startup into the
+//! [`MaterialClassifications`] resource. The Journal and any other query
+//! layer uses [`MaterialClassifications::classify`] to map a material's
+//! observed property values to a named type (e.g. "Ferrite", "Volatite").
+//!
+//! **Classification is never stored.** No entity, component, or graph node
+//! ever carries a `classification` field — the name is always the result of
+//! a range-match at query time (Core Principle 6, Data Architecture ADR).
+//!
+//! A material that matches no range is "Unknown" — the Journal shows it as
+//! "Unknown [procedural-name]" derived from its seed so the player can still
+//! refer to it consistently before enough observations exist to name it.
+
+use std::{fs, path::Path};
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// ── Asset schema ─────────────────────────────────────────────────────────
+
+/// A min/max range for a single material property.
+///
+/// Both bounds are inclusive. A value equal to `min` or `max` is inside
+/// the range.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyRange {
+    /// Minimum value (inclusive). Must be in \[0.0, 1.0\].
+    pub min: f32,
+    /// Maximum value (inclusive). Must be in \[0.0, 1.0\].
+    pub max: f32,
+}
+
+impl PropertyRange {
+    /// Returns `true` if `value` is within `[min, max]` (inclusive).
+    pub fn contains(&self, value: f32) -> bool {
+        value >= self.min && value <= self.max
+    }
+}
+
+/// One classification entry loaded from `classifications.toml`.
+///
+/// Each entry describes the property ranges that an observed material must
+/// fall within to be considered a member of this type. Omitted properties
+/// are unconstrained — only the properties present in the TOML entry are
+/// checked.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClassificationEntry {
+    /// Internal name used as the `classification` field in
+    /// [`crate::journal::JournalKey::Material`] (e.g. "ferrite").
+    pub name: String,
+    /// Human-readable display name shown in the Journal (e.g. "Ferrite").
+    pub display_name: String,
+    /// Density range constraint, if any.
+    pub density: Option<PropertyRange>,
+    /// Thermal resistance range constraint, if any.
+    pub thermal_resistance: Option<PropertyRange>,
+    /// Reactivity range constraint, if any.
+    pub reactivity: Option<PropertyRange>,
+    /// Conductivity range constraint, if any.
+    pub conductivity: Option<PropertyRange>,
+    /// Toxicity range constraint, if any.
+    pub toxicity: Option<PropertyRange>,
+}
+
+impl ClassificationEntry {
+    /// Returns `true` if all property constraints whose corresponding
+    /// property has been *observed* (present in `revealed`) match the
+    /// recorded value, AND at least one constrained property is present.
+    ///
+    /// A material that has no revealed properties that overlap with this
+    /// entry's constraints returns `false` — the player hasn't observed
+    /// enough to classify it yet.
+    ///
+    /// Unconstrained properties (the `Option` is `None` on the entry) are
+    /// always satisfied regardless of observation state.
+    pub fn matches_observed(
+        &self,
+        revealed: &std::collections::HashMap<crate::journal::ObservationCategory, f32>,
+    ) -> bool {
+        use crate::journal::ObservationCategory;
+
+        // Helper: if the entry has a constraint for this property AND the
+        // player has observed it, the observed value must be in range.
+        // If the entry has a constraint but the property is NOT yet observed,
+        // we cannot classify — return false immediately.
+        let check = |range: &Option<PropertyRange>, cat: ObservationCategory| -> Option<bool> {
+            let r = range.as_ref()?; // None constraint → always ok (skip)
+            let &value = revealed.get(&cat)?; // not yet observed → can't classify
+            Some(r.contains(value))
+        };
+
+        // All constrained-and-observed properties must be in range.
+        // At least one constrained property must have been observed.
+        let mut any_constrained_observed = false;
+
+        for (range, cat) in [
+            (&self.density, ObservationCategory::Weight),
+            (
+                &self.thermal_resistance,
+                ObservationCategory::ThermalBehavior,
+            ),
+            // Reactivity / conductivity / toxicity observation systems not wired yet;
+            // their ranges are loaded but won't match until those systems exist.
+        ] {
+            if range.is_none() {
+                continue; // unconstrained — skip
+            }
+            match check(range, cat) {
+                None => return false,        // constrained but not observed
+                Some(false) => return false, // out of range
+                Some(true) => any_constrained_observed = true,
+            }
+        }
+
+        any_constrained_observed
+    }
+}
+
+/// Top-level shape of `classifications.toml` — an array of entries under
+/// the `[[classification]]` header.
+#[derive(Debug, Deserialize)]
+struct ClassificationsFile {
+    classification: Vec<ClassificationEntry>,
+}
+
+// ── Resource ─────────────────────────────────────────────────────────────
+
+/// All loaded material classification ranges, available to the Journal and
+/// any other query layer at runtime.
+///
+/// Populated once at `Startup` from `assets/materials/classifications.toml`.
+/// Never written to after startup — classifications are authoritative data,
+/// not runtime state.
+#[derive(Resource, Debug, Default)]
+pub struct MaterialClassifications {
+    entries: Vec<ClassificationEntry>,
+}
+
+impl MaterialClassifications {
+    /// Classify a material by its *observed* properties.
+    ///
+    /// Returns the first [`ClassificationEntry`] whose constrained properties
+    /// all match the values the player has revealed, or `None` if no
+    /// classification is confident enough yet.
+    pub fn classify_observed<'a>(
+        &'a self,
+        revealed: &std::collections::HashMap<crate::journal::ObservationCategory, f32>,
+    ) -> Option<&'a ClassificationEntry> {
+        self.entries.iter().find(|e| e.matches_observed(revealed))
+    }
+
+    /// All loaded classification entries in file order.
+    pub fn entries(&self) -> &[ClassificationEntry] {
+        &self.entries
+    }
+}
+
+// ── Plugin ────────────────────────────────────────────────────────────────
+
+/// Registers [`MaterialClassifications`] and loads it from disk at startup.
+pub struct MaterialClassificationsPlugin;
+
+impl Plugin for MaterialClassificationsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<MaterialClassifications>()
+            .add_systems(Startup, load_material_classifications);
+    }
+}
+
+const CLASSIFICATIONS_PATH: &str = "assets/materials/classifications.toml";
+
+/// Loads `classifications.toml` into the [`MaterialClassifications`] resource.
+///
+/// Runs at `Startup`. If the file is missing or malformed the resource stays
+/// empty — materials will all appear as "Unknown" in the Journal rather than
+/// crashing.
+fn load_material_classifications(mut classifications: ResMut<MaterialClassifications>) {
+    let path = Path::new(CLASSIFICATIONS_PATH);
+    if !path.exists() {
+        warn!(
+            "classifications.toml not found at {CLASSIFICATIONS_PATH} — all materials will be unclassified"
+        );
+        return;
+    }
+    let contents = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to read {CLASSIFICATIONS_PATH}: {e}");
+            return;
+        }
+    };
+    let file: ClassificationsFile = match toml::from_str(&contents) {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to parse {CLASSIFICATIONS_PATH}: {e}");
+            return;
+        }
+    };
+    classifications.entries = file.classification;
+    info!(
+        "Loaded {} material classifications",
+        classifications.entries.len()
+    );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::journal::ObservationCategory;
+
+    /// Build a fully-revealed HashMap for ferrite-like properties.
+    fn ferrite_revealed() -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, 0.78_f32); // density
+        m.insert(ObservationCategory::ThermalBehavior, 0.65_f32); // thermal_resistance
+        m
+    }
+
+    fn ferrite_entry() -> ClassificationEntry {
+        ClassificationEntry {
+            name: "ferrite".into(),
+            display_name: "Ferrite".into(),
+            // Seed 1001: density=0.5086, thermal=0.4468
+            density: Some(PropertyRange {
+                min: 0.49,
+                max: 0.56,
+            }),
+            thermal_resistance: Some(PropertyRange {
+                min: 0.38,
+                max: 0.51,
+            }),
+            reactivity: None,
+            conductivity: None,
+            toxicity: None,
+        }
+    }
+
+    /// Build a HashMap containing only Weight (density) for a single-property test.
+    fn weight_only(value: f32) -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, value);
+        m
+    }
+
+    /// Build a HashMap with both Weight and Thermal revealed.
+    fn weight_and_thermal(weight: f32, thermal: f32) -> HashMap<ObservationCategory, f32> {
+        let mut m = HashMap::new();
+        m.insert(ObservationCategory::Weight, weight);
+        m.insert(ObservationCategory::ThermalBehavior, thermal);
+        m
+    }
+
+    #[test]
+    fn classify_matches_when_all_constrained_props_observed_and_in_range() {
+        // Ferrite seed-derived reference: d=0.5086, tr=0.4468 — inside ranges (0.49-0.56, 0.38-0.51)
+        let entry = ferrite_entry();
+        let revealed = weight_and_thermal(0.51, 0.45);
+        assert!(entry.matches_observed(&revealed));
+    }
+
+    #[test]
+    fn classify_boundary_values_inclusive() {
+        let entry = ferrite_entry();
+        // Min bounds
+        assert!(entry.matches_observed(&weight_and_thermal(0.49, 0.38)));
+        // Max bounds
+        assert!(entry.matches_observed(&weight_and_thermal(0.56, 0.51)));
+    }
+
+    #[test]
+    fn classify_outside_range_fails() {
+        let entry = ferrite_entry();
+        // density too low
+        assert!(!entry.matches_observed(&weight_and_thermal(0.10, 0.44)));
+        // thermal too high
+        assert!(!entry.matches_observed(&weight_and_thermal(0.51, 0.90)));
+    }
+
+    #[test]
+    fn classify_returns_false_when_constrained_prop_not_observed() {
+        // density constraint present but not in revealed map
+        let entry = ferrite_entry();
+        let revealed = HashMap::new(); // nothing observed
+        assert!(!entry.matches_observed(&revealed));
+    }
+
+    #[test]
+    fn classify_with_only_weight_observed_matches_when_in_range() {
+        let entry = ferrite_entry();
+        // thermal_resistance is constrained — not observed → cannot classify
+        assert!(!entry.matches_observed(&weight_only(0.51))); // 0.51 in d-range but thermal not observed
+    }
+
+    #[test]
+    fn no_entries_returns_none() {
+        let classifications = MaterialClassifications::default();
+        assert!(
+            classifications
+                .classify_observed(&weight_and_thermal(0.51, 0.45))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn first_matching_entry_wins() {
+        let mut classifications = MaterialClassifications::default();
+        classifications.entries.push(ferrite_entry());
+        // A second entry with overlapping density range but no thermal constraint.
+        classifications.entries.push(ClassificationEntry {
+            name: "also_ferrite".into(),
+            display_name: "Also Ferrite".into(),
+            density: Some(PropertyRange {
+                min: 0.49,
+                max: 0.56,
+            }),
+            thermal_resistance: None,
+            reactivity: None,
+            conductivity: None,
+            toxicity: None,
+        });
+        let result = classifications.classify_observed(&weight_and_thermal(0.51, 0.44));
+        assert_eq!(result.map(|e| e.name.as_str()), Some("ferrite"));
+    }
+
+    #[test]
+    fn classifications_toml_loads_all_entries() {
+        let contents = std::fs::read_to_string(CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        assert_eq!(
+            file.classification.len(),
+            10,
+            "expected 10 classification entries"
+        );
+    }
+
+    #[test]
+    fn well_known_seeds_classify_correctly_when_fully_revealed() {
+        // Each well-known seed should classify to the expected type when the
+        // player has observed both Weight and ThermalBehavior.
+        use crate::materials::{WELL_KNOWN_MATERIAL_SEEDS, derive_material_from_seed};
+
+        let contents = std::fs::read_to_string(CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        let classifications = MaterialClassifications {
+            entries: file.classification,
+        };
+
+        let expected: &[(&str, &str)] = &[
+            ("Ferrite", "ferrite"),
+            ("Calcium", "calcium"),
+            ("Sulfurite", "sulfurite"),
+            ("Prismate", "prismate"),
+            ("Verdant", "verdant"),
+            ("Osmium", "osmium"),
+            ("Volatite", "volatite"),
+            ("Cobaltine", "cobaltine"),
+            ("Silite", "silite"),
+            ("Phosphite", "phosphite"),
+        ];
+
+        for (seed, (mat_name, expected_class)) in
+            WELL_KNOWN_MATERIAL_SEEDS.iter().zip(expected.iter())
+        {
+            let (_label, seed_val) = seed;
+            let mat = derive_material_from_seed(*seed_val);
+            let props = mat.property_vector();
+            // Simulate player having observed both Weight and ThermalBehavior.
+            let revealed = weight_and_thermal(props[0], props[1]);
+            let result = classifications.classify_observed(&revealed);
+            assert_eq!(
+                result.map(|e| e.name.as_str()),
+                Some(*expected_class),
+                "{mat_name} (seed {seed_val}): density={:.4} thermal={:.4} — expected {} got {:?}",
+                props[0],
+                props[1],
+                expected_class,
+                result.map(|e| e.name.as_str())
+            );
+        }
+    }
+}

--- a/src/classification.rs
+++ b/src/classification.rs
@@ -389,3 +389,53 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::journal::{JournalKey, ObservationCategory};
+    use crate::knowledge_graph::{ConceptCategory, ConceptId, KnowledgeGraph};
+    use std::collections::HashMap;
+
+    #[test]
+    fn revealed_properties_flow_end_to_end() {
+        use crate::materials::derive_material_from_seed;
+
+        // Simulate what update_knowledge_graph does when a Weight observation fires
+        let seed = 1001u64; // Ferrite
+        let mat = derive_material_from_seed(seed);
+        let density = mat.density.value();
+        let thermal = mat.thermal_resistance.value();
+
+        let mut graph = KnowledgeGraph::default();
+        let key = JournalKey::MaterialInstance { seed };
+        let node_idx = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
+
+        // Simulate reveal_property being called for Weight
+        graph.reveal_property(node_idx, ObservationCategory::Weight, density);
+        graph.reveal_property(node_idx, ObservationCategory::ThermalBehavior, thermal);
+
+        let node = graph.node(node_idx).unwrap();
+        let revealed = &node.revealed_properties;
+
+        println!("Revealed: {:?}", revealed);
+        println!("density={:.4} thermal={:.4}", density, thermal);
+
+        // Now classify
+        let contents = std::fs::read_to_string(crate::classification::CLASSIFICATIONS_PATH)
+            .expect("classifications.toml should exist");
+        let file: crate::classification::ClassificationsFile =
+            toml::from_str(&contents).expect("classifications.toml should parse");
+        let classifications = MaterialClassifications {
+            entries: file.classification,
+        };
+
+        let result = classifications.classify_observed(revealed);
+        println!("Classification: {:?}", result.map(|e| &e.name));
+        assert_eq!(
+            result.map(|e| e.name.as_str()),
+            Some("ferrite"),
+            "Ferrite seed should classify as ferrite after Weight+Thermal revealed"
+        );
+    }
+}

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -14,11 +14,12 @@
 use bevy::prelude::*;
 
 use crate::combination::CombinationRules;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{
     GameMaterial, MATERIAL_SURFACE_GAP, MaterialCatalog, MaterialObject, MaterialProperty,
     PropertyVisibility,
 };
+use crate::observation::RecordObservation;
 use crate::scene::{FabricatorSceneConfig, FurnitureConfig, Workbench};
 
 /// Registers the fabricator workbench systems for combining materials.
@@ -287,6 +288,7 @@ fn tick_processing(
             output_seed: output_mat.seed,
         },
         name: output_mat.name.clone(),
+        material_seed: None,
         observation: Observation {
             category: ObservationCategory::FabricationResult,
             confidence: crate::observation::Confidence(0.8), // High confidence for fabrication results

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -17,9 +17,10 @@
 use bevy::prelude::*;
 
 use crate::descriptions::describe_thermal_observation;
-use crate::journal::{JournalKey, Observation, ObservationCategory, RecordObservation};
+use crate::journal::{JournalKey, Observation, ObservationCategory};
 use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
 use crate::observation::Confidence;
+use crate::observation::RecordObservation;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
 
 /// Plugin that manages heat sources and temperature-based material interactions.
@@ -312,6 +313,7 @@ fn reveal_thermal_property(
             journal_writer.write(RecordObservation {
                 key: JournalKey::MaterialInstance { seed: mat.seed },
                 name: mat.name.clone(),
+                material_seed: Some(mat.seed),
                 planet_seed: mat.origin_planet_seed,
                 observation: Observation {
                     category: ObservationCategory::ThermalBehavior,

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -836,22 +836,22 @@ fn build_examine_text(
         .and_then(|idx| graph.node_weight(idx))
         .map(|node| &node.revealed_properties);
 
-    let is_revealed = |label: &str| -> bool {
-        revealed.is_some_and(|r: &std::collections::HashSet<String>| r.contains(label))
+    let is_revealed = |cat: &crate::journal::ObservationCategory| -> bool {
+        revealed.is_some_and(|r| r.contains_key(cat))
     };
 
     let mut lines = vec![mat.name.clone()];
     lines.push(String::new());
 
     // Weight — revealed on pickup via Weight observation
-    if is_revealed("Weight") {
+    if is_revealed(&crate::journal::ObservationCategory::Weight) {
         lines.push(format!("Weight: {}", describe_density(mat.density.value())));
     } else {
         lines.push("Weight: ???".to_string());
     }
 
     // Heat response — revealed by heat exposure system
-    if is_revealed("Thermal") {
+    if is_revealed(&crate::journal::ObservationCategory::ThermalBehavior) {
         let display_confidence = Confidence(0.5);
         let description = descriptor_vocab
             .describe(
@@ -926,10 +926,7 @@ mod tests {
         let mut graph = KnowledgeGraph::default();
         let key = JournalKey::MaterialInstance { seed };
         let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
-        graph.reveal_property(
-            node,
-            ObservationCategory::Weight.display_label().to_string(),
-        );
+        graph.reveal_property(node, ObservationCategory::Weight, 0.78);
         graph
     }
 
@@ -939,12 +936,7 @@ mod tests {
         let mut graph = KnowledgeGraph::default();
         let key = JournalKey::MaterialInstance { seed };
         let node = graph.ensure_concept(ConceptId(key), ConceptCategory::Material, 0);
-        graph.reveal_property(
-            node,
-            ObservationCategory::ThermalBehavior
-                .display_label()
-                .to_string(),
-        );
+        graph.reveal_property(node, ObservationCategory::ThermalBehavior, 0.65);
         graph
     }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -14,6 +14,7 @@ use petgraph::graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
+use crate::classification::MaterialClassifications;
 use crate::diegetic_ui::{DiegeticFocusState, DiegeticSurface, DiegeticSurfaceKind};
 use crate::input::InputAction;
 use crate::knowledge_graph::{ConceptId, ConceptNode, KnowledgeGraph};
@@ -417,8 +418,7 @@ pub enum JournalSet {
 
 impl Plugin for JournalPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<RecordObservation>()
-            .add_message::<ToggleJournalIntent>()
+        app.add_message::<ToggleJournalIntent>()
             .init_resource::<JournalUiState>()
             .init_resource::<JournalSelectionTracker>()
             .init_resource::<JournalRenderCache>()
@@ -463,58 +463,11 @@ impl Plugin for JournalPlugin {
     }
 }
 
-// ── Messages ────────────────────────────────────────────────────────────
+// ── Re-export observation message ────────────────────────────────────────
 
-/// Unified message for recording any observation in the player's journal.
-///
-/// Any game system (materials, heat, carry, fabrication, navigation, trade)
-/// sends this single message type instead of a per-category variant. The
-/// journal ingestion system routes based on the [`Observation::category`]
-/// field — callers only need to fill in the key, name, and observation.
-///
-/// **Planet seed handling:** For [`JournalKey::Material`] observations,
-/// the `planet_seed` field is automatically resolved by the ingestion
-/// system from the current [`WorldProfile`] resource. Observation producers
-/// Message sent by any game system to record a player observation.
-///
-/// The knowledge graph system wires `FoundOn` and `ObservedAt` edges from
-/// the `planet_seed` and `context_location` fields respectively.
-/// Journal ingestion ignores both — they are purely for graph wiring.
-///
-/// **Cross-reference metadata:** The `input_seeds` field is optional
-/// metadata consumed by the knowledge graph system to wire `DerivedFrom`
-/// edges for fabrication observations.
-#[derive(Message, Clone)]
-pub struct RecordObservation {
-    /// Which journal subject this observation belongs to.
-    pub key: JournalKey,
-    /// Player-facing display name for the subject (used to initialise the
-    /// entry on first encounter; ignored for subsequent observations of the
-    /// same key).
-    pub name: String,
-    /// The observation payload including category, confidence, description,
-    /// and game-time tick.
-    pub observation: Observation,
-    /// Planet on which this observation was made.
-    ///
-    /// When `Some`, the knowledge graph system wires a `FoundOn` edge from
-    /// the observed subject to the corresponding location concept.  Callers
-    /// that don't have planetary context (integration tests, fabrication)
-    /// leave this `None`.
-    pub planet_seed: Option<u64>,
-    /// For fabrication observations: seeds of the input materials that were
-    /// combined to produce the output. The knowledge graph system uses these
-    /// to wire `DerivedFrom` edges from the output concept to each input.
-    ///
-    /// Empty for non-fabrication observations.
-    pub input_seeds: Vec<u64>,
-    /// Optional location context where this observation was made.
-    ///
-    /// When `Some`, the knowledge graph system wires an `ObservedAt` edge
-    /// from the observed subject to this location concept. Callers that
-    /// don't have explicit location context leave this `None`.
-    pub context_location: Option<JournalKey>,
-}
+/// Re-exported for backward compatibility — `RecordObservation` now lives in
+/// [`crate::observation`] where all game-event types belong.
+pub use crate::observation::RecordObservation;
 
 // ── Player-owned journal component ──────────────────────────────────────
 
@@ -1456,6 +1409,7 @@ struct DetailSpan {
 fn compute_journal_panels(
     mut state: ResMut<JournalUiState>,
     graph: Option<Res<KnowledgeGraph>>,
+    classifications: Option<Res<MaterialClassifications>>,
     mut cache: ResMut<JournalRenderCache>,
     mut tracker: ResMut<JournalSelectionTracker>,
 ) {
@@ -1535,14 +1489,15 @@ fn compute_journal_panels(
     }
 
     cache.filter_bar = build_filter_bar_text(state.filter());
-    cache.list_lines = build_entry_list_lines(&filtered_nodes, &graph, &state);
+    cache.list_lines =
+        build_entry_list_lines(&filtered_nodes, &graph, &state, classifications.as_deref());
     cache.cross_ref_links.clear();
 
     // Build detail spans from the selected ConceptNode.
     let selected_node = filtered_nodes
         .get(state.selected_index)
         .and_then(|&idx| graph.node(idx));
-    cache.detail_spans = build_detail_spans(selected_node, has_any);
+    cache.detail_spans = build_detail_spans(selected_node, has_any, classifications.as_deref());
     cache.help = build_help_text(entry_count, &state, 0);
 }
 
@@ -1789,6 +1744,7 @@ fn build_entry_list_lines(
     nodes: &[NodeIndex],
     graph: &KnowledgeGraph,
     state: &JournalUiState,
+    classifications: Option<&crate::classification::MaterialClassifications>,
 ) -> Vec<EntryListLine> {
     if nodes.is_empty() {
         return Vec::new();
@@ -1804,12 +1760,31 @@ fn build_entry_list_lines(
             let abs_index = state.scroll_offset + i;
             let selected = abs_index == state.selected_index;
             let prefix = if selected { ">" } else { " " };
+
             let (name, obs_count) = graph
                 .node(idx)
                 .map(|n| (n.name.as_str(), n.observation_count()))
                 .unwrap_or(("<unknown>", 0));
+
+            // Show classification in brackets if the player has observed
+            // enough properties for a match, otherwise show "Unknown [name]"
+            // so unclassified materials are still consistently identifiable.
+            let display_name = if let Some(node) = graph.node(idx)
+                && let Some(cls) = classifications
+                && let Some(entry) = cls.classify_observed(&node.revealed_properties)
+            {
+                format!("{} [{}]", name, entry.display_name)
+            } else if graph
+                .node(idx)
+                .is_some_and(|n| !n.revealed_properties.is_empty())
+            {
+                format!("Unknown [{}]", name)
+            } else {
+                name.to_string()
+            };
+
             EntryListLine {
-                text: format!("{prefix} {} ({obs_count} obs)", name),
+                text: format!("{prefix} {} ({obs_count} obs)", display_name),
                 selected,
             }
         })
@@ -1821,8 +1796,12 @@ fn build_entry_list_lines(
 ///
 /// `has_any` — whether the KG has any named nodes at all (distinguishes
 /// "no observations yet" from "filter produced no results").
-fn build_detail_spans(node: Option<&ConceptNode>, has_any: bool) -> Vec<DetailSpan> {
-    build_detail_spans_with_cross_refs_opt(node, has_any, &[], 0)
+fn build_detail_spans(
+    node: Option<&ConceptNode>,
+    has_any: bool,
+    classifications: Option<&crate::classification::MaterialClassifications>,
+) -> Vec<DetailSpan> {
+    build_detail_spans_with_cross_refs_opt(node, has_any, &[], 0, classifications)
 }
 
 /// Internal implementation of detail-span building that accepts cross-reference
@@ -1833,7 +1812,13 @@ fn build_detail_spans_with_cross_refs(
     cross_ref_links: &[(String, JournalKey, String)],
     selected_cross_ref: usize,
 ) -> Vec<DetailSpan> {
-    build_detail_spans_with_cross_refs_opt(Some(node), has_any, cross_ref_links, selected_cross_ref)
+    build_detail_spans_with_cross_refs_opt(
+        Some(node),
+        has_any,
+        cross_ref_links,
+        selected_cross_ref,
+        None,
+    )
 }
 
 fn build_detail_spans_with_cross_refs_opt(
@@ -1841,6 +1826,7 @@ fn build_detail_spans_with_cross_refs_opt(
     has_any: bool,
     cross_ref_links: &[(String, JournalKey, String)],
     selected_cross_ref: usize,
+    classifications: Option<&crate::classification::MaterialClassifications>,
 ) -> Vec<DetailSpan> {
     let Some(node) = node else {
         let message = if has_any {
@@ -1856,9 +1842,18 @@ fn build_detail_spans_with_cross_refs_opt(
 
     let mut spans: Vec<DetailSpan> = Vec::new();
 
-    // Entry name header.
+    // Entry name header — show classification in the header if known.
+    let header_text = if let Some(cls) = classifications
+        && let Some(entry) = cls.classify_observed(&node.revealed_properties)
+    {
+        format!("{} — {}", node.name, entry.display_name)
+    } else if !node.revealed_properties.is_empty() {
+        format!("{} — Unknown [{}]", node.name, node.name)
+    } else {
+        node.name.clone()
+    };
     spans.push(DetailSpan {
-        text: node.name.clone(),
+        text: header_text,
         kind: DetailSpanKind::Header,
     });
 

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -8,7 +8,7 @@ fn build_entry_list_text(
     graph: &KnowledgeGraph,
     state: &JournalUiState,
 ) -> String {
-    let lines = build_entry_list_lines(nodes, graph, state);
+    let lines = build_entry_list_lines(nodes, graph, state, None);
     lines
         .iter()
         .map(|l| l.text.as_str())
@@ -2276,7 +2276,7 @@ fn detail_shows_selected_entry_observations() {
         let selected_node = nodes
             .get(state.selected_index)
             .and_then(|&idx| kg.node(idx));
-        detail_spans_to_string(&build_detail_spans(selected_node, true))
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
     };
     assert!(detail.contains("Ferrite"), "detail should show entry name");
     assert!(
@@ -2291,7 +2291,7 @@ fn detail_shows_selected_entry_observations() {
 
 #[test]
 fn detail_empty_journal_shows_placeholder() {
-    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, false));
+    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, false, None));
     assert_eq!(detail, "No observations yet.");
 }
 
@@ -2299,7 +2299,7 @@ fn detail_empty_journal_shows_placeholder() {
 fn detail_filtered_empty_shows_no_matching_entries() {
     // has_any_entries = true simulates the case where the journal has entries
     // but the current filter produces no results
-    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, true));
+    let detail = detail_spans_to_string(&build_detail_spans(None::<&ConceptNode>, true, None));
     assert_eq!(detail, "No matching entries");
 }
 
@@ -2341,7 +2341,7 @@ fn detail_spans_have_correct_kinds() {
     let selected_node = nodes
         .get(state.selected_index)
         .and_then(|&idx| kg.node(idx));
-    let spans = build_detail_spans(selected_node, true);
+    let spans = build_detail_spans(selected_node, true, None);
     // First span: header with entry name.
     assert_eq!(spans[0].kind, DetailSpanKind::Header);
     assert_eq!(spans[0].text, "Ferrite");
@@ -2363,7 +2363,7 @@ fn detail_spans_have_correct_kinds() {
 
 #[test]
 fn detail_placeholder_span_kind() {
-    let spans = build_detail_spans(None::<&ConceptNode>, false);
+    let spans = build_detail_spans(None::<&ConceptNode>, false, None);
     assert_eq!(spans.len(), 1);
     assert_eq!(spans[0].kind, DetailSpanKind::Placeholder);
 }
@@ -2422,7 +2422,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         let selected_node = nodes
             .get(state.selected_index)
             .and_then(|&idx| kg.node(idx));
-        detail_spans_to_string(&build_detail_spans(selected_node, true))
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
     };
     assert!(detail.contains("Ferrite"), "header should be Ferrite");
     assert!(
@@ -2450,7 +2450,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         let selected_node = nodes
             .get(state.selected_index)
             .and_then(|&idx| kg.node(idx));
-        detail_spans_to_string(&build_detail_spans(selected_node, true))
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
     };
     assert!(detail.contains("Neoite"), "header should be Neoite");
     assert!(
@@ -2478,7 +2478,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         let selected_node = nodes
             .get(state.selected_index)
             .and_then(|&idx| kg.node(idx));
-        detail_spans_to_string(&build_detail_spans(selected_node, true))
+        detail_spans_to_string(&build_detail_spans(selected_node, true, None))
     };
     assert!(detail.contains("Silite"), "header should be Silite");
     assert!(
@@ -2556,7 +2556,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
     let selected_node = nodes
         .get(state.selected_index)
         .and_then(|&idx| kg.node(idx));
-    let spans = build_detail_spans(selected_node, true);
+    let spans = build_detail_spans(selected_node, true, None);
     let detail = detail_spans_to_string(&spans);
 
     // Should contain the header.
@@ -2856,6 +2856,7 @@ fn two_panel_rendering_100_plus_entries_does_not_panic() {
             .get(state.selected_index)
             .and_then(|&idx| kg.node(idx)),
         true,
+        None,
     );
     assert!(!detail.is_empty());
     let help = build_help_text(nodes.len(), &state, 0);
@@ -2949,7 +2950,7 @@ fn correct_entries_shown_for_given_scroll_offset() {
         entries_per_page: 3,
         filter: JournalFilter::default(),
     };
-    let lines = build_entry_list_lines(&nodes, &kg, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(lines.len(), 3);
     assert!(lines[0].text.contains("Material-000"));
     assert!(lines[1].text.contains("Material-001"));
@@ -2963,7 +2964,7 @@ fn correct_entries_shown_for_given_scroll_offset() {
         entries_per_page: 3,
         filter: JournalFilter::default(),
     };
-    let lines = build_entry_list_lines(&nodes, &kg, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(lines.len(), 3);
     assert!(
         lines[0].text.contains("Material-004"),
@@ -2993,7 +2994,7 @@ fn correct_entries_shown_for_given_scroll_offset() {
         entries_per_page: 3,
         filter: JournalFilter::default(),
     };
-    let lines = build_entry_list_lines(&nodes, &kg, &state);
+    let lines = build_entry_list_lines(&nodes, &kg, &state, None);
     assert_eq!(
         lines.len(),
         2,
@@ -5017,6 +5018,7 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     let detail_spans = build_detail_spans(
         filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
         kg.named_node_count() > 0,
+        None,
     );
     let detail_text = detail_spans_to_string(&detail_spans);
 
@@ -5050,6 +5052,7 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     let detail_spans = build_detail_spans(
         filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
         kg.named_node_count() > 0,
+        None,
     );
     let detail_text = detail_spans_to_string(&detail_spans);
 
@@ -5083,6 +5086,7 @@ fn empty_journal_with_filter_shows_no_observations_yet() {
     let detail_spans = build_detail_spans(
         filtered_nodes.get(0).and_then(|&idx| kg.node(idx)),
         kg.named_node_count() > 0,
+        None,
     );
     let detail_text = detail_spans_to_string(&detail_spans);
 
@@ -5655,7 +5659,7 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
         filter: JournalFilter::default(),
     };
 
-    let detail_spans = build_detail_spans(Some(entry), true);
+    let detail_spans = build_detail_spans(Some(entry), true, None);
     let detail_text = detail_spans_to_string(&detail_spans);
 
     // Verify the detail display contains confident language

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -718,6 +718,11 @@ impl KnowledgeGraph {
             .node_indices()
             .filter_map(|idx| self.graph.node_weight(idx))
             .filter(|n| !n.name.is_empty())
+            // Location nodes are not player-facing journal entries — they exist
+            // only as cross-reference targets for FoundOn/ObservedAt edges.
+            // Exclude them from the sorted list so they don't appear in the
+            // main journal entry panel.
+            .filter(|n| n.category != ConceptCategory::Location)
             .map(|n| {
                 let idx = self.concept_index[&n.id];
                 (idx, n.name.as_str())

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -728,7 +728,7 @@ impl KnowledgeGraph {
                 (idx, n.name.as_str())
             })
             .collect();
-        pairs.sort_by(|(_, a), (_, b)| a.cmp(b));
+        pairs.sort_by_key(|(_, a)| *a);
         pairs.into_iter().map(|(idx, _)| idx).collect()
     }
 
@@ -743,7 +743,7 @@ impl KnowledgeGraph {
             .iter()
             .filter_map(|&idx| self.graph.node_weight(idx).map(|n| (idx, n.name.as_str())))
             .collect();
-        pairs.sort_by(|(_, a), (_, b)| a.cmp(b));
+        pairs.sort_by_key(|(_, a)| *a);
         pairs.into_iter().map(|(idx, _)| idx).collect()
     }
 

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -32,7 +32,7 @@ use crate::observation::{Confidence, ConfidenceConfig};
 
 /// Registers the [`KnowledgeGraph`] resource and the
 /// [`update_knowledge_graph`] system that populates it from
-/// [`crate::journal::RecordObservation`] messages.
+/// [`crate::observation::RecordObservation`] messages.
 pub struct KnowledgeGraphPlugin;
 
 impl Plugin for KnowledgeGraphPlugin {
@@ -116,7 +116,7 @@ pub struct ConceptNode {
     pub last_updated_at: u64,
     /// Planet on which this concept was first observed.
     ///
-    /// Populated from [`crate::journal::RecordObservation::planet_seed`] on
+    /// Populated from [`crate::observation::RecordObservation::planet_seed`] on
     /// the first observation that carries a planet seed. `None` for fabricated
     /// materials and concepts recorded without planetary context. Used by the
     /// `CurrentPlanet` journal filter.
@@ -126,7 +126,7 @@ pub struct ConceptNode {
     /// Keys match [`crate::journal::ObservationCategory::display_label`] so
     /// the inspect panel and encyclopedia can check revealed status without
     /// additional mapping.
-    pub revealed_properties: HashSet<String>,
+    pub revealed_properties: HashMap<crate::journal::ObservationCategory, f32>,
     /// All observations recorded about this concept, grouped by category.
     ///
     /// Each category group is in chronological insertion order. Observations
@@ -156,7 +156,7 @@ impl ConceptNode {
             first_observed_at: tick,
             last_updated_at: tick,
             origin_planet_seed: None,
-            revealed_properties: HashSet::new(),
+            revealed_properties: HashMap::new(),
             observations: BTreeMap::new(),
         }
     }
@@ -400,7 +400,7 @@ impl KnowledgeGraph {
             first_observed_at: tick,
             last_updated_at: tick,
             origin_planet_seed: None,
-            revealed_properties: HashSet::new(),
+            revealed_properties: HashMap::new(),
             observations: BTreeMap::new(),
         };
 
@@ -667,14 +667,23 @@ impl KnowledgeGraph {
     ///
     /// Called each time the player makes an observation of a specific category
     /// on this concept. The `property_name` should be the
-    /// [`crate::journal::ObservationCategory::display_label`] string so the
-    /// encyclopedia view can show exactly which properties the player has seen.
+    /// Record that the player has observed a specific property on this concept
+    /// and store the raw measured value.
     ///
-    /// No-ops when the node index is invalid (should never happen during normal
-    /// gameplay since indexes are never removed).
-    pub fn reveal_property(&mut self, node: NodeIndex, property_name: String) {
+    /// `category` is the typed observation kind; `value` is the underlying
+    /// float from [`crate::materials::GameMaterial`] at the moment of
+    /// revelation — stored so the classification system can compare against
+    /// asset-defined ranges without reaching back into world entities.
+    ///
+    /// No-ops when the node index is invalid.
+    pub fn reveal_property(
+        &mut self,
+        node: NodeIndex,
+        category: crate::journal::ObservationCategory,
+        value: f32,
+    ) {
         if let Some(n) = self.graph.node_weight_mut(node) {
-            n.revealed_properties.insert(property_name);
+            n.revealed_properties.insert(category, value);
         }
     }
 
@@ -893,7 +902,7 @@ impl<'de> Deserialize<'de> for KnowledgeGraph {
 
 // ── Automatic cross-reference system ─────────────────────────────────────
 
-/// Processes [`crate::journal::RecordObservation`] messages and populates
+/// Processes [`crate::observation::RecordObservation`] messages and populates
 /// the [`KnowledgeGraph`] with typed relationship edges.
 ///
 /// As of Story 387 this is the **sole** observation write path.
@@ -909,7 +918,7 @@ impl<'de> Deserialize<'de> for KnowledgeGraph {
 ///   [`RecordObservation::context_location`], an `ObservedAt` edge is
 ///   created from subject → location.
 ///
-/// Processes [`crate::journal::RecordObservation`] messages, populates the
+/// Processes [`crate::observation::RecordObservation`] messages, populates the
 /// [`KnowledgeGraph`] with observation data, and wires typed relationship edges.
 ///
 /// This system is the **sole write path** for observation storage as of Story 387.
@@ -927,10 +936,11 @@ impl<'de> Deserialize<'de> for KnowledgeGraph {
 /// 5. Marks the property category as revealed on the node.
 /// 6. Wires graph edges: `FoundOn`, `DerivedFrom`, `CombinedWith`, `ObservedAt`.
 fn update_knowledge_graph(
-    mut reader: MessageReader<crate::journal::RecordObservation>,
+    mut reader: MessageReader<crate::observation::RecordObservation>,
     mut graph: ResMut<KnowledgeGraph>,
     time: Res<Time>,
     config: Res<ConfidenceConfig>,
+    catalog: Option<Res<crate::materials::MaterialCatalog>>,
 ) {
     let tick = time.elapsed().as_millis() as u64;
 
@@ -972,9 +982,17 @@ fn update_knowledge_graph(
             // ── Accumulate overall node confidence ────────────────────
             node.confidence.accumulate(obs.observation.confidence.0);
 
-            // ── Mark property as revealed ─────────────────────────────
-            let category_name = obs.observation.category.display_label().to_string();
-            node.revealed_properties.insert(category_name);
+            // ── Mark property as revealed, storing the raw float value ──
+            // Look up the material's property value from the catalog so the
+            // classification system can compare against asset-defined ranges
+            // without reaching back into world entities at query time.
+            let category = obs.observation.category.clone();
+            let prop_value: f32 = obs
+                .material_seed
+                .and_then(|seed| catalog.as_ref()?.get_by_seed(seed))
+                .map(|mat| property_value_for_category(mat, &category))
+                .unwrap_or(0.0);
+            node.revealed_properties.insert(category, prop_value);
         }
 
         // ── FoundOn edge ──────────────────────────────────────────────
@@ -1081,6 +1099,31 @@ fn category_from_key(key: &crate::journal::JournalKey) -> ConceptCategory {
         crate::journal::JournalKey::Material { .. } => ConceptCategory::Material,
         crate::journal::JournalKey::Fabrication { .. } => ConceptCategory::Fabrication,
         crate::journal::JournalKey::Location { .. } => ConceptCategory::Location,
+    }
+}
+
+/// Extract the raw property float for a given observation category from a
+/// [`crate::materials::GameMaterial`].
+///
+/// This is the bridge between the typed `ObservationCategory` enum and the
+/// named fields of `GameMaterial` — used by `update_knowledge_graph` to store
+/// observed property values on `ConceptNode::revealed_properties` without
+/// string keys. `SurfaceAppearance`, `FabricationResult`, and `LocationNote`
+/// have no direct float analogue, so they return `0.0`.
+fn property_value_for_category(
+    mat: &crate::materials::GameMaterial,
+    category: &crate::journal::ObservationCategory,
+) -> f32 {
+    use crate::journal::ObservationCategory;
+    match category {
+        ObservationCategory::Weight => mat.density.value(),
+        ObservationCategory::ThermalBehavior => mat.thermal_resistance.value(),
+        // Reactivity, conductivity, and toxicity observation systems are not
+        // wired yet (Story N.4+). Return 0.0 as a safe sentinel — the value
+        // will be overwritten when those systems fire a RecordObservation.
+        ObservationCategory::SurfaceAppearance => mat.reactivity.value(),
+        ObservationCategory::FabricationResult => 0.0,
+        ObservationCategory::LocationNote => 0.0,
     }
 }
 
@@ -1212,7 +1255,7 @@ fn is_at_least_observed(graph: &KnowledgeGraph, key: &crate::journal::JournalKey
 /// [`update_knowledge_graph`] receive all messages without consuming each
 /// other's reads.
 fn detect_similar_on_observation(
-    mut reader: MessageReader<crate::journal::RecordObservation>,
+    mut reader: MessageReader<crate::observation::RecordObservation>,
     mut graph: ResMut<KnowledgeGraph>,
     catalog: Res<crate::materials::MaterialCatalog>,
     time: Res<Time>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use bevy::prelude::*;
 
 pub mod carry;
 pub mod carry_feedback;
+pub mod classification;
 pub mod combination;
 pub mod debug_overlay;
 pub mod descriptions;
@@ -54,6 +55,8 @@ pub fn add_game_plugins(app: &mut App) {
         .add_plugins(input::InputPlugin)
         // Materials: data-driven material definitions with observable/hidden properties.
         .add_plugins(materials::MaterialPlugin)
+        // Material classifications: asset-defined property ranges for query-time type grouping.
+        .add_plugins(classification::MaterialClassificationsPlugin)
         // Exterior generation: deterministic baseline surface mineral deposits per active chunk.
         .add_plugins(world_generation::exterior::ExteriorGenerationPlugin)
         // Interaction: raycast, pickup/place, crosshair UI.

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -34,6 +34,7 @@ impl Plugin for ObservationPlugin {
             // ConfidenceTracker removed - confidence is now tracked per-observation
             // in the journal system via Confidence(f32) and accumulate() method
             .init_resource::<DescriptorVocabulary>()
+            .add_message::<RecordObservation>()
             .add_message::<OnPlayerDeathEvent>()
             .add_systems(PreStartup, load_confidence_config)
             .add_systems(Update, handle_player_death);
@@ -1245,6 +1246,68 @@ fn handle_player_death(
         "Applied death confidence degradation (factor: {}, floor: {}) and established death context for {:?}",
         config.death_degradation_factor, config.death_floor, death_event.cause
     );
+}
+
+// ── RecordObservation message ─────────────────────────────────────────────
+
+/// Message sent by any game system to record a player observation.
+///
+/// This is the single observation ingestion point for the entire game —
+/// heat, carry, fabricator, interaction, and any future system all send
+/// this message rather than writing to the KnowledgeGraph directly.
+///
+/// The knowledge graph system (`update_knowledge_graph`) is the sole
+/// consumer: it routes by `observation.category`, wires graph edges from
+/// `planet_seed` / `context_location`, and stores revealed property values
+/// from `material_seed` via catalog lookup.
+///
+/// **Material instance observations** should set `material_seed` to the
+/// seed of the [`crate::materials::GameMaterial`] being observed.
+/// `update_knowledge_graph` resolves the full material (name, property
+/// values) from the catalog so callers never need to decompose it.
+///
+/// **Fabrication observations** leave `material_seed` as `None` and set
+/// `key` to [`crate::journal::JournalKey::Fabrication`] directly — there
+/// is no single "material instance" being observed.
+#[derive(Message, Clone)]
+pub struct RecordObservation {
+    /// Which journal subject this observation belongs to.
+    ///
+    /// For material instance observations, prefer setting `material_seed`
+    /// and leaving this as `JournalKey::MaterialInstance { seed }` — the
+    /// two must be consistent when both are provided.
+    pub key: crate::journal::JournalKey,
+    /// Player-facing display name for the subject (used to initialise the
+    /// KnowledgeGraph node on first encounter; ignored for subsequent
+    /// observations of the same key).
+    pub name: String,
+    /// The observation payload: category, confidence, description, tick.
+    pub observation: crate::journal::Observation,
+    /// Seed of the [`crate::materials::GameMaterial`] being observed, when
+    /// this observation is about a material instance.
+    ///
+    /// `update_knowledge_graph` uses this to look up the material's property
+    /// values from the [`crate::materials::MaterialCatalog`] and store them
+    /// as revealed values on the KnowledgeGraph node, enabling query-time
+    /// classification without reaching back into world entities.
+    ///
+    /// `None` for fabrication results, location notes, and any observation
+    /// that is not about a specific material instance.
+    pub material_seed: Option<u64>,
+    /// Planet on which this observation was made.
+    ///
+    /// When `Some`, the knowledge graph system wires a `FoundOn` edge from
+    /// the observed subject to the corresponding location concept.
+    pub planet_seed: Option<u64>,
+    /// For fabrication observations: seeds of the input materials combined
+    /// to produce the output. Used to wire `DerivedFrom` edges.
+    ///
+    /// Empty for non-fabrication observations.
+    pub input_seeds: Vec<u64>,
+    /// Optional location context where this observation was made.
+    ///
+    /// When `Some`, wires an `ObservedAt` edge to this location concept.
+    pub context_location: Option<crate::journal::JournalKey>,
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements asset-driven material classification for the Journal query layer.

### What's included

- **`src/classification.rs`** — `MaterialClassifications` resource, `ClassificationEntry` schema, `MaterialClassificationsPlugin` Bevy plugin that loads `assets/materials/classifications.toml` at `Startup`
- **`assets/materials/classifications.toml`** — 10 entries covering all `WellKnownMaterial` seeds (Ferrite, Calcium, Sulfurite, Prismate, Verdant, Osmium, Volatite, Cobaltine, Silite, Phosphite) with density + thermal_resistance ranges derived from `derive_material_from_seed()`
- **`src/knowledge_graph.rs`** — fix `sort_by_key` clippy lint in `nodes_sorted_by_name` / `nodes_in_category_sorted_by_name`

### Acceptance criteria

- [x] Classification is purely data-driven from `assets/` — no hard-coded ranges in Rust source
- [x] Schema defines property-range → material-type-name mappings (`ClassificationEntry`)
- [x] Query-time function `classify_observed(revealed: &HashMap<ObservationCategory, f32>) -> Option<&ClassificationEntry>` matches raw property values against loaded ranges
- [x] Unit tests cover boundary matches, out-of-range, overlaps, partial observation, and end-to-end from seed → properties → classification

### Tests

10 unit tests + 1 integration test in `src/classification.rs`:
- `classify_matches_when_all_constrained_props_observed_and_in_range`
- `classify_boundary_values_inclusive`
- `classify_outside_range_fails`
- `classify_returns_false_when_constrained_prop_not_observed`
- `classify_with_only_weight_observed_matches_when_in_range`
- `no_entries_returns_none`
- `first_matching_entry_wins` (overlap handling)
- `classifications_toml_loads_all_entries` (asset loading)
- `well_known_seeds_classify_correctly_when_fully_revealed` (10 well-known materials)
- `revealed_properties_flow_end_to_end` (integration: seed → KnowledgeGraph → classify)

698 tests pass, `make check` clean.