### PR TITLE
fix(world-gen): remove material type name strings from deposit_weight_modifiers

### DIFF
--- a/assets/config/biomes.toml
+++ b/assets/config/biomes.toml
@@ -40,12 +40,8 @@ ground_color = [0.55, 0.38, 0.22]
 # Slightly more deposits than baseline (hot erosion exposes veins).
 density_modifier = 1.15
 
-[biomes.deposit_weight_modifiers]
-ferrite  = 3.0
-silite   = 0.8
-prismate = 0.2
 
-# Material palette — hot, metallic, and reactive materials dominate.
+
 [[biomes.material_palette]]
 material_seed = 1001  # Ferrite — iron-rich, at home in baked desert
 selection_weight = 3.0
@@ -128,10 +124,6 @@ ground_color = [0.42, 0.48, 0.56]
 # Fewer deposits — ice cover reduces surface exposure.
 density_modifier = 0.7
 
-[biomes.deposit_weight_modifiers]
-ferrite  = 0.2
-silite   = 1.0
-prismate = 3.0
 
 # Material palette — crystalline, cold-affinity materials dominate.
 [[biomes.material_palette]]

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -1898,11 +1898,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             moisture_max: 0.4,
             ground_color: [0.55, 0.38, 0.22],
             density_modifier: 1.15,
-            deposit_weight_modifiers: HashMap::from([
-                ("ferrite".to_string(), 3.0),
-                ("silite".to_string(), 0.8),
-                ("prismate".to_string(), 0.2),
-            ]),
+            deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
                     material_seed: 1001,
@@ -1953,11 +1949,7 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             moisture_max: 1.0,
             ground_color: [0.42, 0.48, 0.56],
             density_modifier: 0.7,
-            deposit_weight_modifiers: HashMap::from([
-                ("ferrite".to_string(), 0.2),
-                ("silite".to_string(), 1.0),
-                ("prismate".to_string(), 3.0),
-            ]),
+            deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
                     material_seed: 1004,


### PR DESCRIPTION
## Summary

Removes all material classification type name strings (`"ferrite"`, `"silite"`, `"prismate"`) from world-gen code, satisfying the AC:

> World-gen code contains zero material type name strings; all type names in UI come from classification ranges; changing asset ranges changes displayed types without code changes.

## What changed

The `deposit_weight_modifiers` HashMaps in `default_biome_definitions()` (ScorchedFlats and FrostShelf biomes) previously contained entries keyed by material **classification names** — but `choose_deposit_definition` in `exterior.rs` matches modifier keys against `SurfaceMineralDepositDefinition::key` values, which are **deposit shape keys** (`"dense_cluster_deposit"` etc.). The classification names never matched any deposit key, making the entries dead code that also violated the AC.

**`src/world_generation.rs`**: Both `deposit_weight_modifiers: HashMap::from([...]))` entries replaced with `HashMap::new()`, matching the MineralSteppe default.

**`assets/config/biomes.toml`**: Removed the two `[biomes.deposit_weight_modifiers]` sections containing the same incorrect keys.

## Functional impact

None. Material selection in each biome is governed by `material_palette` (seed-based u64 values, not type-name strings). The removed modifiers never matched any deposit definition key at runtime, so removing them has zero effect on world generation behavior.

## Tests

701 lib tests · 9 integration tests · 5 doc-tests — all pass.