### PR TITLE
docs: add comment explaining #[allow(dead_code)] for ConfidenceTracker::record

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1016,6 +1016,8 @@ impl ConfidenceTracker {
         since = "0.1.0",
         note = "Use RecordObservation messages with journal system instead"
     )]
+    // Retained for backward compatibility while call-sites migrate to journal-based
+    // RecordObservation messages. Remove once all consumers are migrated.
     #[allow(dead_code)]
     pub fn record(&mut self, seed: u64, property: PropertyName) -> u32 {
         let key = (seed, property);


### PR DESCRIPTION
## Summary

Adds a `//` comment above `#[allow(dead_code)]` at `src/observation.rs` (line 1019 post-patch) explaining why the dead code suppression is necessary.

The `ConfidenceTracker::record()` method is marked `#[deprecated]` and `#[allow(dead_code)]` because it is retained for backward compatibility while call-sites migrate to journal-based `RecordObservation` messages.

## Changes
- `src/observation.rs`: added two-line comment above `#[allow(dead_code)]` on the `record()` method

## Tests
- All 701 unit tests pass
- All integration tests pass
- `make check` green (fmt, clippy, test, build)