### PR TITLE
docs: add comment explaining #[allow(dead_code)] for deprecated count() method

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1016,6 +1016,8 @@ impl ConfidenceTracker {
         since = "0.1.0",
         note = "Use RecordObservation messages with journal system instead"
     )]
+    // Retained for backward compatibility while call-sites migrate to journal-based
+    // RecordObservation messages. Remove once all consumers are migrated.
     #[allow(dead_code)]
     pub fn record(&mut self, seed: u64, property: PropertyName) -> u32 {
         let key = (seed, property);

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1034,6 +1034,7 @@ impl ConfidenceTracker {
         since = "0.1.0",
         note = "Query journal observations directly for confidence information"
     )]
+    /// Kept for API compatibility during transition to journal-based confidence tracking.
     #[allow(dead_code)]
     pub fn count(&self, seed: u64, property: PropertyName) -> u32 {
         self.counts.get(&(seed, property)).copied().unwrap_or(0)


### PR DESCRIPTION
Adds an explanatory comment above the `#[allow(dead_code)]` attribute on the deprecated `ConfidenceTracker::count()` method in `src/observation.rs`, clarifying that the suppression exists for API compatibility during the transition to journal-based confidence tracking.

Closes #eef042a8 (kanban)