### PR TITLE
refactor: encapsulate Confidence tuple struct field

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -1383,7 +1383,7 @@ pub fn record_weight_observation(
 ) {
     // Use initial confidence for new observations - the journal system
     // will handle accumulation automatically for repeated observations
-    let initial_confidence = Confidence(0.2);
+    let initial_confidence = Confidence::new(0.2);
 
     // Generate description using the DescriptorVocabulary system
     let description = descriptor_vocab
@@ -2204,7 +2204,7 @@ exponent = 1.0
         let text = describe_weight_observation(
             0.8,
             1.0,
-            Confidence(0.2), // Tentative
+            Confidence::new(0.2), // Tentative
             &default_weight_descriptions(),
         );
 
@@ -2216,7 +2216,7 @@ exponent = 1.0
         let text = describe_weight_observation(
             0.8,
             1.0,
-            Confidence(0.5), // Observed
+            Confidence::new(0.5), // Observed
             &default_weight_descriptions(),
         );
 

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -289,7 +289,7 @@ fn tick_processing(
         material_seed: None,
         observation: Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: crate::observation::Confidence(0.8), // High confidence for fabrication results
+            confidence: crate::observation::Confidence::new(0.8), // High confidence for fabrication results
             description,
             recorded_at: 0,
         },

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -308,7 +308,7 @@ fn reveal_thermal_property(
 
             // Use initial confidence for new observations - the journal system
             // will handle accumulation automatically for repeated observations
-            let initial_confidence = Confidence(0.2);
+            let initial_confidence = Confidence::new(0.2);
 
             journal_writer.write(RecordObservation {
                 key: JournalKey::MaterialInstance { seed: mat.seed },

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -852,7 +852,7 @@ fn build_examine_text(
 
     // Heat response — revealed by heat exposure system
     if is_revealed(&crate::journal::ObservationCategory::ThermalBehavior) {
-        let display_confidence = Confidence(0.5);
+        let display_confidence = Confidence::new(0.5);
         let description = descriptor_vocab
             .describe(
                 &crate::journal::ObservationCategory::ThermalBehavior,

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -93,7 +93,7 @@ fn journal_omits_unknown_properties() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Weight: Heavy".into(),
             recorded_at: 1,
         },
@@ -112,7 +112,7 @@ fn journal_includes_fabrication_history() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Ferrite + Silite -> Neoite".into(),
             recorded_at: 1,
         },
@@ -131,7 +131,7 @@ fn journal_shows_thermal_observation_when_present() {
         "TestMat",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Reliably hold together under heat".into(),
             recorded_at: 1,
         },
@@ -305,7 +305,7 @@ fn node_with_observation_on_planet(
     entry.origin_planet_seed = planet_seed;
     entry.add_observation(Observation {
         category,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "obs".to_string(),
         recorded_at: 0,
     });
@@ -598,7 +598,7 @@ fn journal_shows_weight_observation_only_when_present() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Color: Cool blue tone".into(),
             recorded_at: 1,
         },
@@ -612,7 +612,7 @@ fn journal_shows_weight_observation_only_when_present() {
         "Ferrite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Heavy but manageable".into(),
             recorded_at: 2,
         },
@@ -642,7 +642,7 @@ fn journal_entry_add_observation_updates_timestamp() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 20,
     });
@@ -659,19 +659,19 @@ fn journal_entry_accumulates_multiple_observations() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.5),
+        confidence: Confidence::new(0.5),
         description: "Holds together under heat".into(),
         recorded_at: 50,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Heavy".into(),
         recorded_at: 55,
     });
@@ -687,19 +687,19 @@ fn journal_entry_observations_by_category() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.5),
+        confidence: Confidence::new(0.5),
         description: "Holds together under heat".into(),
         recorded_at: 20,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.5),
+        confidence: Confidence::new(0.5),
         description: "Slightly rough texture".into(),
         recorded_at: 30,
     });
@@ -728,7 +728,7 @@ fn new_journal_ensure_entry_creates_and_retrieves() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "obs".to_string(),
             recorded_at: 100,
         },
@@ -739,7 +739,7 @@ fn new_journal_ensure_entry_creates_and_retrieves() {
         "Ignored Name",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "obs2".to_string(),
             recorded_at: 200,
         },
@@ -768,7 +768,7 @@ fn new_journal_record_accumulates_observations() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 10,
         },
@@ -778,7 +778,7 @@ fn new_journal_record_accumulates_observations() {
         "Ferrite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Holds together under heat".into(),
             recorded_at: 50,
         },
@@ -806,7 +806,7 @@ fn new_journal_different_keys_coexist() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 10,
         },
@@ -816,7 +816,7 @@ fn new_journal_different_keys_coexist() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Ferrite + Silite -> Neoite".into(),
             recorded_at: 20,
         },
@@ -835,7 +835,7 @@ fn new_journal_serde_round_trip() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 10,
         },
@@ -845,7 +845,7 @@ fn new_journal_serde_round_trip() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Ferrite + Silite -> Neoite".into(),
             recorded_at: 50,
         },
@@ -891,7 +891,7 @@ fn single_observation_recorded_correctly() {
         "Quarite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Cracks under rapid heating".into(),
             recorded_at: 42,
         },
@@ -916,7 +916,7 @@ fn single_observation_recorded_correctly() {
     assert_eq!(entry.observation_count(), 1);
     let obs = &entry.observations_by_category(&ObservationCategory::ThermalBehavior)[0];
     assert_eq!(obs.category, ObservationCategory::ThermalBehavior);
-    assert_eq!(obs.confidence, Confidence(0.5));
+    assert_eq!(obs.confidence, Confidence::new(0.5));
     assert_eq!(obs.description, "Cracks under rapid heating");
     assert_eq!(obs.recorded_at, 42);
 }
@@ -928,14 +928,14 @@ fn duplicate_observation_same_category_and_description_is_skipped() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     });
     // Same category + same description at a later tick — should NOT add a second entry.
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 20,
     });
@@ -952,14 +952,14 @@ fn duplicate_observation_upgrades_confidence() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Holds together under heat".into(),
         recorded_at: 10,
     });
     // Same category + description but higher confidence — should upgrade.
     entry.add_observation(Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.8),
+        confidence: Confidence::new(0.8),
         description: "Holds together under heat".into(),
         recorded_at: 30,
     });
@@ -967,7 +967,7 @@ fn duplicate_observation_upgrades_confidence() {
     assert_eq!(entry.observation_count(), 1, "duplicate should be skipped");
     assert_eq!(
         entry.observations_by_category(&ObservationCategory::ThermalBehavior)[0].confidence,
-        Confidence(0.8),
+        Confidence::new(0.8),
         "confidence should be upgraded"
     );
     assert_eq!(entry.last_updated_at, 30);
@@ -980,14 +980,14 @@ fn duplicate_does_not_downgrade_confidence() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.8),
+        confidence: Confidence::new(0.8),
         description: "Heavy".into(),
         recorded_at: 10,
     });
     // Same category + description but lower confidence — confidence should stay.
     entry.add_observation(Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Heavy".into(),
         recorded_at: 20,
     });
@@ -995,7 +995,7 @@ fn duplicate_does_not_downgrade_confidence() {
     assert_eq!(entry.observation_count(), 1);
     assert_eq!(
         entry.observations_by_category(&ObservationCategory::Weight)[0].confidence,
-        Confidence(0.8),
+        Confidence::new(0.8),
         "confidence should not downgrade"
     );
 }
@@ -1011,7 +1011,7 @@ fn examine_same_material_twice_does_not_duplicate() {
 
     let observation = Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     };
@@ -1025,7 +1025,7 @@ fn examine_same_material_twice_does_not_duplicate() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 50,
         },
@@ -1058,7 +1058,7 @@ fn examine_same_material_twice_upgrades_confidence() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 10,
         },
@@ -1070,7 +1070,7 @@ fn examine_same_material_twice_upgrades_confidence() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Warm rust tone".into(),
             recorded_at: 50,
         },
@@ -1086,7 +1086,7 @@ fn examine_same_material_twice_upgrades_confidence() {
     assert_eq!(entry.observation_count(), 1);
     assert_eq!(
         entry.observations_by_category(&ObservationCategory::SurfaceAppearance)[0].confidence,
-        Confidence(0.5),
+        Confidence::new(0.5),
         "confidence should upgrade on re-examination"
     );
 }
@@ -1098,13 +1098,13 @@ fn same_category_different_description_is_not_duplicate() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Slightly rough texture".into(),
         recorded_at: 20,
     });
@@ -1125,13 +1125,13 @@ fn same_description_different_category_is_not_duplicate() {
 
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Notable".into(),
         recorded_at: 10,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::LocationNote,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Notable".into(),
         recorded_at: 20,
     });
@@ -1159,7 +1159,7 @@ fn multiple_observations_for_same_key_accumulate() {
         "Volite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Dark mineral grey".into(),
             recorded_at: 10,
         },
@@ -1171,7 +1171,7 @@ fn multiple_observations_for_same_key_accumulate() {
         "Volite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Glows faintly when heated".into(),
             recorded_at: 25,
         },
@@ -1183,7 +1183,7 @@ fn multiple_observations_for_same_key_accumulate() {
         "Volite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Slightly crystalline texture".into(),
             recorded_at: 40,
         },
@@ -1195,7 +1195,7 @@ fn multiple_observations_for_same_key_accumulate() {
         "Volite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Very heavy".into(),
             recorded_at: 60,
         },
@@ -1207,7 +1207,7 @@ fn multiple_observations_for_same_key_accumulate() {
         "Volite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Volite + Silite -> Crystite".into(),
             recorded_at: 80,
         },
@@ -1236,28 +1236,28 @@ fn multiple_observations_for_same_key_accumulate() {
     let surface = entry.observations_by_category(&ObservationCategory::SurfaceAppearance);
     assert_eq!(surface.len(), 2);
     assert_eq!(surface[0].description, "Dark mineral grey");
-    assert_eq!(surface[0].confidence, Confidence(0.2));
+    assert_eq!(surface[0].confidence, Confidence::new(0.2));
     assert_eq!(surface[0].recorded_at, 10);
     assert_eq!(surface[1].description, "Slightly crystalline texture");
-    assert_eq!(surface[1].confidence, Confidence(0.5));
+    assert_eq!(surface[1].confidence, Confidence::new(0.5));
     assert_eq!(surface[1].recorded_at, 40);
 
     let thermal = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(thermal.len(), 1);
     assert_eq!(thermal[0].description, "Glows faintly when heated");
-    assert_eq!(thermal[0].confidence, Confidence(0.5));
+    assert_eq!(thermal[0].confidence, Confidence::new(0.5));
     assert_eq!(thermal[0].recorded_at, 25);
 
     let weight = entry.observations_by_category(&ObservationCategory::Weight);
     assert_eq!(weight.len(), 1);
     assert_eq!(weight[0].description, "Very heavy");
-    assert_eq!(weight[0].confidence, Confidence(0.8));
+    assert_eq!(weight[0].confidence, Confidence::new(0.8));
     assert_eq!(weight[0].recorded_at, 60);
 
     let fab = entry.observations_by_category(&ObservationCategory::FabricationResult);
     assert_eq!(fab.len(), 1);
     assert_eq!(fab[0].description, "Combined Volite + Silite -> Crystite");
-    assert_eq!(fab[0].confidence, Confidence(0.8));
+    assert_eq!(fab[0].confidence, Confidence::new(0.8));
     assert_eq!(fab[0].recorded_at, 80);
 
     let loc = entry.observations_by_category(&ObservationCategory::LocationNote);
@@ -1307,7 +1307,11 @@ fn all_types_serde_round_trip() {
     }
 
     // ── Confidence variants ────────────────────────────────
-    let levels = vec![Confidence(0.2), Confidence(0.5), Confidence(0.8)];
+    let levels = vec![
+        Confidence::new(0.2),
+        Confidence::new(0.5),
+        Confidence::new(0.8),
+    ];
     for level in &levels {
         let json = serde_json::to_string(level).expect("Confidence should serialize");
         let rt: Confidence = serde_json::from_str(&json).expect("Confidence should deserialize");
@@ -1317,7 +1321,7 @@ fn all_types_serde_round_trip() {
     // ── Observation struct ──────────────────────────────────────
     let observation = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.5),
+        confidence: Confidence::new(0.5),
         description: "Holds together under heat".into(),
         recorded_at: 999,
     };
@@ -1336,13 +1340,13 @@ fn all_types_serde_round_trip() {
     );
     entry.add_observation(Observation {
         category: ObservationCategory::SurfaceAppearance,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Warm rust tone".into(),
         recorded_at: 10,
     });
     entry.add_observation(Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.8),
+        confidence: Confidence::new(0.8),
         description: "Very heavy".into(),
         recorded_at: 20,
     });
@@ -1375,7 +1379,7 @@ fn all_types_serde_round_trip() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Cool blue tone".into(),
             recorded_at: 1,
         },
@@ -1385,7 +1389,7 @@ fn all_types_serde_round_trip() {
         "Silite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Softens quickly under heat".into(),
             recorded_at: 5,
         },
@@ -1395,7 +1399,7 @@ fn all_types_serde_round_trip() {
         "Silite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Light".into(),
             recorded_at: 8,
         },
@@ -1408,7 +1412,7 @@ fn all_types_serde_round_trip() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Silite + Ferrite -> Neoite".into(),
             recorded_at: 10,
         },
@@ -1418,7 +1422,7 @@ fn all_types_serde_round_trip() {
         "Neoite",
         Observation {
             category: ObservationCategory::LocationNote,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Found near volcanic ridge".into(),
             recorded_at: 15,
         },
@@ -1448,7 +1452,7 @@ fn all_types_serde_round_trip() {
     );
     assert_eq!(
         silite.observations_by_category(&ObservationCategory::SurfaceAppearance)[0].confidence,
-        Confidence(0.2)
+        Confidence::new(0.2)
     );
     assert_eq!(
         silite
@@ -1481,7 +1485,7 @@ fn all_types_serde_round_trip() {
     );
     assert_eq!(
         neoite.observations_by_category(&ObservationCategory::FabricationResult)[0].confidence,
-        Confidence(0.8)
+        Confidence::new(0.8)
     );
     assert_eq!(
         neoite
@@ -1516,7 +1520,7 @@ fn different_keys_stored_independently() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -1528,7 +1532,7 @@ fn different_keys_stored_independently() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Cool blue tone".into(),
             recorded_at: 2,
         },
@@ -1540,7 +1544,7 @@ fn different_keys_stored_independently() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Ferrite + Silite -> Neoite".into(),
             recorded_at: 3,
         },
@@ -1553,7 +1557,7 @@ fn different_keys_stored_independently() {
         "Ferrite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Holds together under heat".into(),
             recorded_at: 4,
         },
@@ -1671,7 +1675,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -1681,7 +1685,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Slightly rough texture".into(),
             recorded_at: 2,
         },
@@ -1691,7 +1695,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Ferrite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Holds together under heat".into(),
             recorded_at: 3,
         },
@@ -1701,7 +1705,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Ferrite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Heavy but manageable".into(),
             recorded_at: 4,
         },
@@ -1716,7 +1720,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Cool blue tone".into(),
             recorded_at: 5,
         },
@@ -1729,7 +1733,7 @@ fn rendered_text_contains_same_information_as_legacy_journal() {
         "Neoite",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Combined Ferrite + Silite -> Neoite".into(),
             recorded_at: 6,
         },
@@ -1840,7 +1844,11 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
         ObservationCategory::LocationNote,
     ];
 
-    let confidences = [Confidence(0.2), Confidence(0.5), Confidence(0.8)];
+    let confidences = [
+        Confidence::new(0.2),
+        Confidence::new(0.5),
+        Confidence::new(0.8),
+    ];
 
     let mut kg = KnowledgeGraph::default();
 
@@ -1878,7 +1886,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
                 &name,
                 Observation {
                     category: secondary_cat.clone(),
-                    confidence: Confidence(0.2),
+                    confidence: Confidence::new(0.2),
                     description: format!("Secondary observation for {name}"),
                     recorded_at: tick_base + 1,
                 },
@@ -1893,7 +1901,7 @@ fn journal_with_100_plus_mixed_entries_does_not_panic() {
                 &name,
                 Observation {
                     category: primary_cat.clone(),
-                    confidence: Confidence(0.8),
+                    confidence: Confidence::new(0.8),
                     description: format!("Follow-up observation for {name}"),
                     recorded_at: tick_base + 2,
                 },
@@ -1974,7 +1982,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -1984,7 +1992,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Ferrite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Holds together under heat".into(),
             recorded_at: 2,
         },
@@ -1997,7 +2005,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Cool blue tone".into(),
             recorded_at: 3,
         },
@@ -2007,7 +2015,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Silite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Feather-light".into(),
             recorded_at: 4,
         },
@@ -2020,7 +2028,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Volite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Dark mineral grey".into(),
             recorded_at: 5,
         },
@@ -2030,7 +2038,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Volite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Glows faintly when heated".into(),
             recorded_at: 6,
         },
@@ -2040,7 +2048,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Volite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Very heavy".into(),
             recorded_at: 7,
         },
@@ -2053,7 +2061,7 @@ fn multiple_materials_have_separate_entries_and_rendering() {
         "Crystite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Translucent with prismatic flecks".into(),
             recorded_at: 8,
         },
@@ -2177,7 +2185,7 @@ fn make_kg_with_n_entries(n: usize) -> KnowledgeGraph {
             &name,
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Appearance of {name}"),
                 recorded_at: i as u64,
             },
@@ -2222,7 +2230,7 @@ fn entry_list_shows_observation_count() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust".into(),
             recorded_at: 1,
         },
@@ -2232,7 +2240,7 @@ fn entry_list_shows_observation_count() {
         "Ferrite",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Heat resistant".into(),
             recorded_at: 2,
         },
@@ -2256,7 +2264,7 @@ fn detail_shows_selected_entry_observations() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -2312,7 +2320,7 @@ fn detail_spans_have_correct_kinds() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -2322,7 +2330,7 @@ fn detail_spans_have_correct_kinds() {
         "Ferrite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Heavy but manageable".into(),
             recorded_at: 2,
         },
@@ -2378,7 +2386,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -2388,7 +2396,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Glassy smooth surface".into(),
             recorded_at: 2,
         },
@@ -2398,7 +2406,7 @@ fn detail_panel_shows_correct_observations_for_selected_entry() {
         "Neoite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Surprisingly light".into(),
             recorded_at: 3,
         },
@@ -2505,7 +2513,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Warm rust tone".into(),
             recorded_at: 1,
         },
@@ -2515,7 +2523,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         "Ferrite",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Heavy but manageable".into(),
             recorded_at: 2,
         },
@@ -2525,7 +2533,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         "Ferrite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Rough, pitted texture".into(),
             recorded_at: 3,
         },
@@ -2537,7 +2545,7 @@ fn detail_panel_shows_all_observations_for_multi_category_entry() {
         "Silite",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Glassy smooth surface".into(),
             recorded_at: 4,
         },
@@ -2909,7 +2917,7 @@ fn panels_render_without_panic() {
                 &format!("Mat-{i}"),
                 Observation {
                     category: ObservationCategory::SurfaceAppearance,
-                    confidence: Confidence(0.2),
+                    confidence: Confidence::new(0.2),
                     description: format!("Appearance of Mat-{i}"),
                     recorded_at: i,
                 },
@@ -3126,7 +3134,7 @@ fn navigation_ignored_when_journal_is_hidden() {
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Obs {i}"),
                 recorded_at: 0,
             },
@@ -3176,7 +3184,7 @@ fn navigation_active_when_journal_is_visible() {
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Obs {i}"),
                 recorded_at: 0,
             },
@@ -3228,7 +3236,7 @@ fn navigation_first_to_last_entry() {
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Obs {i}"),
                 recorded_at: 0,
             },
@@ -3345,7 +3353,7 @@ fn navigation_bounds_single_entry_journal() {
         "Sole-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Only entry".to_string(),
             recorded_at: 0,
         },
@@ -3411,7 +3419,7 @@ fn navigation_bounds_page_keys_at_extremes() {
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Obs {i}"),
                 recorded_at: 0,
             },
@@ -3534,7 +3542,7 @@ fn navigation_never_exceeds_bounds_under_key_sequence() {
             &format!("Mat-{i:03}"),
             Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.2),
+                confidence: Confidence::new(0.2),
                 description: format!("Obs {i}"),
                 recorded_at: 0,
             },
@@ -3659,7 +3667,7 @@ fn record(app: &mut App, key: JournalKey, name: &str, recorded_at: u64) {
         name,
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: format!("Appearance of {name}"),
             recorded_at,
         },
@@ -4570,7 +4578,7 @@ fn shift_tab_cycles_context_filter() {
         "Planet0-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "From planet 0".to_string(),
             recorded_at: 1,
         },
@@ -4582,7 +4590,7 @@ fn shift_tab_cycles_context_filter() {
         "Planet1-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "From planet 1".to_string(),
             recorded_at: 2,
         },
@@ -4594,7 +4602,7 @@ fn shift_tab_cycles_context_filter() {
         "Unknown-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Unknown origin".to_string(),
             recorded_at: 3,
         },
@@ -4684,7 +4692,7 @@ fn tab_cycles_category_filter() {
         "Surface-Material",
         Observation {
             category: ObservationCategory::SurfaceAppearance,
-            confidence: Confidence(0.2),
+            confidence: Confidence::new(0.2),
             description: "Smooth metallic surface".to_string(),
             recorded_at: 1,
         },
@@ -4696,7 +4704,7 @@ fn tab_cycles_category_filter() {
         "Thermal-Material",
         Observation {
             category: ObservationCategory::ThermalBehavior,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             description: "Warm to the touch".to_string(),
             recorded_at: 2,
         },
@@ -4708,7 +4716,7 @@ fn tab_cycles_category_filter() {
         "Heavy-Material",
         Observation {
             category: ObservationCategory::Weight,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Heavy material".to_string(),
             recorded_at: 3,
         },
@@ -4720,7 +4728,7 @@ fn tab_cycles_category_filter() {
         "Alloy-Fabrication",
         Observation {
             category: ObservationCategory::FabricationResult,
-            confidence: Confidence(0.8),
+            confidence: Confidence::new(0.8),
             description: "Successfully fabricated alloy".to_string(),
             recorded_at: 4,
         },
@@ -5282,7 +5290,7 @@ fn test_confidence_accumulation_in_journal_entry() {
     // Create an initial observation
     let obs1 = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2), // Initial confidence
+        confidence: Confidence::new(0.2), // Initial confidence
         description: "Softens under heat".to_string(),
         recorded_at: 1000,
     };
@@ -5294,14 +5302,15 @@ fn test_confidence_accumulation_in_journal_entry() {
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(observations.len(), 1, "Should have exactly one observation");
     assert_eq!(
-        observations[0].confidence.0, 0.2,
+        observations[0].confidence.value(),
+        0.2,
         "First observation should have initial confidence"
     );
 
     // Add the same observation again (should accumulate)
     let obs2 = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2), // Same initial confidence
+        confidence: Confidence::new(0.2), // Same initial confidence
         description: "Softens under heat".to_string(), // Same description
         recorded_at: 2000,
     };
@@ -5321,16 +5330,16 @@ fn test_confidence_accumulation_in_journal_entry() {
     // Expected: 0.2 + (1.0 - 0.2) * 0.2 = 0.2 + 0.8 * 0.2 = 0.2 + 0.16 = 0.36
     let expected_confidence = 0.36;
     assert!(
-        (observations[0].confidence.0 - expected_confidence).abs() < f32::EPSILON,
+        (observations[0].confidence.value() - expected_confidence).abs() < f32::EPSILON,
         "Confidence should accumulate with diminishing returns. Expected: {}, Got: {}",
         expected_confidence,
-        observations[0].confidence.0
+        observations[0].confidence.value()
     );
 
     // Add a third observation to see further accumulation
     let obs3 = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Softens under heat".to_string(),
         recorded_at: 3000,
     };
@@ -5349,10 +5358,10 @@ fn test_confidence_accumulation_in_journal_entry() {
     // Expected: 0.36 + (1.0 - 0.36) * 0.2 = 0.36 + 0.64 * 0.2 = 0.36 + 0.128 = 0.488
     let expected_confidence_2 = 0.488;
     assert!(
-        (observations[0].confidence.0 - expected_confidence_2).abs() < 0.001,
+        (observations[0].confidence.value() - expected_confidence_2).abs() < 0.001,
         "Confidence should continue to accumulate with diminishing returns. Expected: {}, Got: {}",
         expected_confidence_2,
-        observations[0].confidence.0
+        observations[0].confidence.value()
     );
 
     // Verify confidence tier mapping
@@ -5380,14 +5389,14 @@ fn test_confidence_accumulation_different_descriptions() {
     // Add two observations with different descriptions
     let obs1 = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "Softens under heat".to_string(),
         recorded_at: 1000,
     };
 
     let obs2 = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.3),
+        confidence: Confidence::new(0.3),
         description: "Changes color when heated".to_string(), // Different description
         recorded_at: 2000,
     };
@@ -5405,11 +5414,13 @@ fn test_confidence_accumulation_different_descriptions() {
 
     // Both should retain their original confidence since no accumulation occurred
     assert_eq!(
-        observations[0].confidence.0, 0.2,
+        observations[0].confidence.value(),
+        0.2,
         "First observation should retain original confidence"
     );
     assert_eq!(
-        observations[1].confidence.0, 0.3,
+        observations[1].confidence.value(),
+        0.3,
         "Second observation should retain original confidence"
     );
 }
@@ -5436,7 +5447,7 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Create initial observation with low confidence (Tentative tier: < 0.3)
     let initial_observation = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2), // Tentative tier
+        confidence: Confidence::new(0.2), // Tentative tier
         description: "softens quickly under heat".to_string(),
         recorded_at: 1000,
     };
@@ -5454,7 +5465,8 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     let observations = entry.observations_by_category(&ObservationCategory::ThermalBehavior);
     assert_eq!(observations.len(), 1, "Should have exactly one observation");
     assert_eq!(
-        observations[0].confidence.0, 0.2,
+        observations[0].confidence.value(),
+        0.2,
         "Initial confidence should be 0.2"
     );
 
@@ -5469,7 +5481,7 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Record the same observation again (same category and description)
     let repeat_observation = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2), // Same initial confidence
+        confidence: Confidence::new(0.2), // Same initial confidence
         description: "softens quickly under heat".to_string(), // Same description
         recorded_at: 2000,
     };
@@ -5495,10 +5507,10 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Expected: 0.2 + (1.0 - 0.2) * 0.3 = 0.2 + 0.8 * 0.3 = 0.2 + 0.24 = 0.44
     let expected_confidence = 0.44;
     assert!(
-        (observations[0].confidence.0 - expected_confidence).abs() < f32::EPSILON,
+        (observations[0].confidence.value() - expected_confidence).abs() < f32::EPSILON,
         "Confidence should have accumulated. Expected: {}, Got: {}",
         expected_confidence,
-        observations[0].confidence.0
+        observations[0].confidence.value()
     );
 
     // Verify confidence tier has changed from Tentative to Observed
@@ -5524,7 +5536,7 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Record the same observation a third time to push into Confident tier
     let third_observation = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "softens quickly under heat".to_string(),
         recorded_at: 3000,
     };
@@ -5545,16 +5557,16 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Expected: 0.44 + (1.0 - 0.44) * 0.3 = 0.44 + 0.56 * 0.3 = 0.44 + 0.168 = 0.608
     let expected_confidence_2 = 0.608;
     assert!(
-        (observations[0].confidence.0 - expected_confidence_2).abs() < 0.001,
+        (observations[0].confidence.value() - expected_confidence_2).abs() < 0.001,
         "Confidence should have accumulated further. Expected: {}, Got: {}",
         expected_confidence_2,
-        observations[0].confidence.0
+        observations[0].confidence.value()
     );
 
     // Record one more time to push into Confident tier (>= 0.7)
     let fourth_observation = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: "softens quickly under heat".to_string(),
         recorded_at: 4000,
     };
@@ -5575,10 +5587,10 @@ fn recording_same_observation_twice_increases_confidence_and_changes_language() 
     // Expected: 0.608 + (1.0 - 0.608) * 0.3 = 0.608 + 0.392 * 0.3 = 0.608 + 0.1176 = 0.7256
     let expected_confidence_3 = 0.7256;
     assert!(
-        (observations[0].confidence.0 - expected_confidence_3).abs() < 0.001,
+        (observations[0].confidence.value() - expected_confidence_3).abs() < 0.001,
         "Confidence should have accumulated to Confident tier. Expected: {}, Got: {}",
         expected_confidence_3,
-        observations[0].confidence.0
+        observations[0].confidence.value()
     );
 
     // Verify we've reached Confident tier
@@ -5613,7 +5625,7 @@ fn journal_entry_shows_confident_language_after_sufficient_observations() {
     let vocab = DescriptorVocabulary::default();
 
     // Create an observation with confident-level confidence (≥0.7)
-    let confident_confidence = Confidence(0.8);
+    let confident_confidence = Confidence::new(0.8);
     let thermal_value = 0.1; // Low thermal resistance value (0.0-0.25 range)
 
     // Generate description using the vocabulary system with confident confidence
@@ -5728,9 +5740,13 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     // Create observations with confident-level confidence (≥0.7)
     let confident_thermal = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.8), // Confident tier
+        confidence: Confidence::new(0.8), // Confident tier
         description: vocab
-            .describe(&ObservationCategory::ThermalBehavior, 0.1, Confidence(0.8))
+            .describe(
+                &ObservationCategory::ThermalBehavior,
+                0.1,
+                Confidence::new(0.8),
+            )
             .expect("Should find thermal description")
             .to_string(),
         recorded_at: 1000,
@@ -5738,9 +5754,9 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
 
     let confident_weight = Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.75), // Confident tier
+        confidence: Confidence::new(0.75), // Confident tier
         description: vocab
-            .describe(&ObservationCategory::Weight, 0.8, Confidence(0.75))
+            .describe(&ObservationCategory::Weight, 0.8, Confidence::new(0.75))
             .expect("Should find weight description")
             .to_string(),
         recorded_at: 1100,
@@ -5798,8 +5814,8 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     let expected_thermal_confidence = 0.8 * 0.5; // 0.4 (Observed tier: 0.3-0.7)
     let expected_weight_confidence = 0.75 * 0.5; // 0.375 (Observed tier)
 
-    assert!((thermal_obs.confidence.0 - expected_thermal_confidence).abs() < 0.001);
-    assert!((weight_obs.confidence.0 - expected_weight_confidence).abs() < 0.001);
+    assert!((thermal_obs.confidence.value() - expected_thermal_confidence).abs() < 0.001);
+    assert!((weight_obs.confidence.value() - expected_weight_confidence).abs() < 0.001);
     assert_eq!(thermal_obs.confidence.tier(), ConfidenceTier::Observed);
     assert_eq!(weight_obs.confidence.tier(), ConfidenceTier::Observed);
 
@@ -5836,7 +5852,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     // Record new thermal observation (death-relevant domain - should recover faster)
     let _recovery_thermal = Observation {
         category: ObservationCategory::ThermalBehavior,
-        confidence: Confidence(0.2), // New observation confidence
+        confidence: Confidence::new(0.2), // New observation confidence
         description: thermal_obs.description.clone(), // Same description to trigger accumulation
         recorded_at: 2000,
     };
@@ -5844,7 +5860,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     // Record new weight observation (unrelated domain - should recover slower)
     let _recovery_weight = Observation {
         category: ObservationCategory::Weight,
-        confidence: Confidence(0.2),
+        confidence: Confidence::new(0.2),
         description: weight_obs.description.clone(),
         recorded_at: 2100,
     };
@@ -5903,16 +5919,16 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     let expected_weight_recovery = 0.375 + (1.0 - 0.375) * (0.25 * 0.8);
 
     assert!(
-        (thermal_obs.confidence.0 - expected_thermal_recovery).abs() < 0.001,
+        (thermal_obs.confidence.value() - expected_thermal_recovery).abs() < 0.001,
         "Thermal confidence should recover faster. Expected: {}, Got: {}",
         expected_thermal_recovery,
-        thermal_obs.confidence.0
+        thermal_obs.confidence.value()
     );
     assert!(
-        (weight_obs.confidence.0 - expected_weight_recovery).abs() < 0.001,
+        (weight_obs.confidence.value() - expected_weight_recovery).abs() < 0.001,
         "Weight confidence should recover slower. Expected: {}, Got: {}",
         expected_weight_recovery,
-        weight_obs.confidence.0
+        weight_obs.confidence.value()
     );
 
     // Thermal should have recovered to Confident tier (≥0.7), weight should still be Observed
@@ -5992,7 +6008,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
     assert!(
         weight_obs.confidence.tier() == ConfidenceTier::Confident,
         "Weight should have recovered to Confident tier after multiple observations (confidence: {:.3})",
-        weight_obs.confidence.0
+        weight_obs.confidence.value()
     );
 
     let final_weight_desc = vocab

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -152,7 +152,7 @@ impl ConceptNode {
             id: ConceptId(key),
             category,
             name: name.to_string(),
-            confidence: Confidence(0.3),
+            confidence: Confidence::new(0.3),
             first_observed_at: tick,
             last_updated_at: tick,
             origin_planet_seed: None,
@@ -187,7 +187,7 @@ impl ConceptNode {
             .find(|o| o.description == observation.description)
         {
             // Upgrade confidence if the new evidence is stronger.
-            if observation.confidence.0 > existing.confidence.0 {
+            if observation.confidence.value() > existing.confidence.value() {
                 existing.confidence = observation.confidence;
             }
             return;
@@ -396,7 +396,7 @@ impl KnowledgeGraph {
             id: id.clone(),
             category: category.clone(),
             name: String::new(),
-            confidence: Confidence(0.3), // Start at Tentative/Observed boundary
+            confidence: Confidence::new(0.3), // Start at Tentative/Observed boundary
             first_observed_at: tick,
             last_updated_at: tick,
             origin_planet_seed: None,
@@ -985,7 +985,8 @@ fn update_knowledge_graph(
             node.add_observation_with_domain_weighted_accumulation(observation, &config, 1.0);
 
             // ── Accumulate overall node confidence ────────────────────
-            node.confidence.accumulate(obs.observation.confidence.0);
+            node.confidence
+                .accumulate(obs.observation.confidence.value());
 
             // ── Mark property as revealed, storing the raw float value ──
             // Look up the material's property value from the catalog so the
@@ -1036,7 +1037,7 @@ fn update_knowledge_graph(
                     ConceptEdge {
                         relationship: RelationshipType::DerivedFrom,
                         // Fabrication is directly observed — full confidence.
-                        confidence: Confidence(1.0),
+                        confidence: Confidence::new(1.0),
                         discovered_at: tick,
                     },
                 );
@@ -1065,7 +1066,7 @@ fn update_knowledge_graph(
 
             let edge = ConceptEdge {
                 relationship: RelationshipType::CombinedWith,
-                confidence: Confidence(1.0),
+                confidence: Confidence::new(1.0),
                 discovered_at: tick,
             };
             graph.relate(node_a, node_b, edge);
@@ -1194,7 +1195,7 @@ pub fn detect_and_wire_similar_materials(
 
         let edge = ConceptEdge {
             relationship: RelationshipType::SimilarTo,
-            confidence: Confidence(sim),
+            confidence: Confidence::new(sim),
             discovered_at: tick,
         };
         graph.relate(new_node, existing_node, edge);
@@ -1244,7 +1245,7 @@ fn is_at_least_observed(graph: &KnowledgeGraph, key: &crate::journal::JournalKey
     graph
         .lookup(&id)
         .and_then(|idx| graph.node(idx))
-        .is_some_and(|node| node.confidence.0 >= 0.3)
+        .is_some_and(|node| node.confidence.value() >= 0.3)
 }
 
 /// Detects and wires `SimilarTo` edges for newly observed materials.
@@ -1328,7 +1329,7 @@ mod tests {
             b,
             ConceptEdge {
                 relationship: RelationshipType::FoundOn,
-                confidence: Confidence(0.5),
+                confidence: Confidence::new(0.5),
                 discovered_at: 0,
             },
         );
@@ -1345,7 +1346,7 @@ mod tests {
 
         let initial_edge = ConceptEdge {
             relationship: RelationshipType::FoundOn,
-            confidence: Confidence(0.3),
+            confidence: Confidence::new(0.3),
             discovered_at: 0,
         };
         graph.relate(a, b, initial_edge.clone());
@@ -1355,7 +1356,7 @@ mod tests {
         let rels = graph.relationships(a);
         assert_eq!(rels.len(), 1, "no duplicate edge");
         assert!(
-            rels[0].1.confidence.0 > 0.3,
+            rels[0].1.confidence.value() > 0.3,
             "confidence must increase on repeated observation"
         );
     }
@@ -1403,7 +1404,7 @@ mod tests {
             neighbor,
             ConceptEdge {
                 relationship: RelationshipType::SimilarTo,
-                confidence: Confidence(0.9),
+                confidence: Confidence::new(0.9),
                 discovered_at: 0,
             },
         );
@@ -1412,7 +1413,7 @@ mod tests {
             far,
             ConceptEdge {
                 relationship: RelationshipType::SimilarTo,
-                confidence: Confidence(0.9),
+                confidence: Confidence::new(0.9),
                 discovered_at: 0,
             },
         );
@@ -1438,7 +1439,7 @@ mod tests {
 
         let edge = || ConceptEdge {
             relationship: RelationshipType::FoundOn,
-            confidence: Confidence(0.5),
+            confidence: Confidence::new(0.5),
             discovered_at: 0,
         };
         graph.relate(center, mat_neighbor, edge());
@@ -1466,7 +1467,7 @@ mod tests {
 
         let edge = || ConceptEdge {
             relationship: RelationshipType::SimilarTo,
-            confidence: Confidence(0.9),
+            confidence: Confidence::new(0.9),
             discovered_at: 0,
         };
         // Create a cycle: a → b → c → a
@@ -1525,7 +1526,7 @@ mod tests {
             b,
             ConceptEdge {
                 relationship: RelationshipType::FoundOn,
-                confidence: Confidence(0.6),
+                confidence: Confidence::new(0.6),
                 discovered_at: 10,
             },
         );

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -32,7 +32,7 @@ impl Plugin for ObservationPlugin {
     fn build(&self, app: &mut App) {
         app
             // ConfidenceTracker removed - confidence is now tracked per-observation
-            // in the journal system via Confidence(f32) and accumulate() method
+            // in the journal system via Confidence and accumulate() method
             .init_resource::<DescriptorVocabulary>()
             .add_message::<RecordObservation>()
             .add_message::<OnPlayerDeathEvent>()
@@ -54,9 +54,26 @@ impl Plugin for ObservationPlugin {
 /// death penalties, domain-weighted recovery) while the discrete tiers
 /// provide stable language selection for player-facing descriptions.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Confidence(pub f32);
+pub struct Confidence(f32);
 
 impl Confidence {
+    /// Construct a `Confidence` value, clamping to `[0.0, 1.0]`.
+    ///
+    /// NaN is treated as `0.0` (unknown). Any value outside the valid range is
+    /// clamped, so callers never need to guard before constructing.
+    pub fn new(value: f32) -> Self {
+        if value.is_nan() {
+            Self(0.0)
+        } else {
+            Self(value.clamp(0.0, 1.0))
+        }
+    }
+
+    /// Return the underlying confidence value in `[0.0, 1.0]`.
+    pub fn value(&self) -> f32 {
+        self.0
+    }
+
     /// Map continuous value to qualitative tier for language selection.
     ///
     /// The tier boundaries are:
@@ -509,7 +526,7 @@ impl DescriptorVocabulary {
     ///     ],
     /// );
     ///
-    /// let confidence = Confidence(0.2); // Maps to Tentative tier
+    /// let confidence = Confidence::new(0.2); // Maps to Tentative tier
     /// let description = vocab.describe(
     ///     &ObservationCategory::ThermalBehavior,
     ///     0.25,
@@ -915,7 +932,7 @@ impl Default for DescriptorVocabulary {
 /// Used by the examine panel and journal to select descriptor language.
 ///
 /// **DEPRECATED:** This enum is retained for backward compatibility with
-/// existing tests and POC code, but new code should use `Confidence(f32)`
+/// existing tests and POC code, but new code should use `Confidence`
 /// and `ConfidenceTier` instead. The discrete levels will be phased out
 /// as the continuous confidence system is fully integrated.
 #[allow(dead_code)]
@@ -984,7 +1001,7 @@ type ObsKey = (u64, PropertyName);
 #[allow(dead_code)]
 /// **DEPRECATED**: This resource has been replaced by per-observation confidence
 /// tracking in the journal system. Each `Observation` now carries its own
-/// `Confidence(f32)` value that accumulates evidence using the `accumulate()`
+/// `Confidence` value that accumulates evidence using the `accumulate()`
 /// method. The journal's `add_observation_with_accumulation()` handles
 /// confidence evolution automatically.
 ///
@@ -1042,11 +1059,11 @@ impl ConfidenceTracker {
 
     /// Confidence level for a specific (material, property) pair.
     ///
-    /// **DEPRECATED**: Use the `Confidence(f32)` system in journal observations.
+    /// **DEPRECATED**: Use the `Confidence` system in journal observations.
     /// Each observation carries its own confidence that evolves with evidence.
     #[deprecated(
         since = "0.1.0",
-        note = "Use Confidence(f32) in journal observations instead of ConfidenceLevel"
+        note = "Use Confidence in journal observations instead of ConfidenceLevel"
     )]
     #[allow(dead_code)]
     pub fn level(&self, seed: u64, property: PropertyName) -> ConfidenceLevel {
@@ -1402,20 +1419,20 @@ mod tests {
 
     #[test]
     fn confidence_tier_mapping() {
-        assert_eq!(Confidence(0.0).tier(), ConfidenceTier::Tentative);
-        assert_eq!(Confidence(0.1).tier(), ConfidenceTier::Tentative);
-        assert_eq!(Confidence(0.29).tier(), ConfidenceTier::Tentative);
-        assert_eq!(Confidence(0.3).tier(), ConfidenceTier::Observed);
-        assert_eq!(Confidence(0.5).tier(), ConfidenceTier::Observed);
-        assert_eq!(Confidence(0.69).tier(), ConfidenceTier::Observed);
-        assert_eq!(Confidence(0.7).tier(), ConfidenceTier::Confident);
-        assert_eq!(Confidence(0.9).tier(), ConfidenceTier::Confident);
-        assert_eq!(Confidence(1.0).tier(), ConfidenceTier::Confident);
+        assert_eq!(Confidence::new(0.0).tier(), ConfidenceTier::Tentative);
+        assert_eq!(Confidence::new(0.1).tier(), ConfidenceTier::Tentative);
+        assert_eq!(Confidence::new(0.29).tier(), ConfidenceTier::Tentative);
+        assert_eq!(Confidence::new(0.3).tier(), ConfidenceTier::Observed);
+        assert_eq!(Confidence::new(0.5).tier(), ConfidenceTier::Observed);
+        assert_eq!(Confidence::new(0.69).tier(), ConfidenceTier::Observed);
+        assert_eq!(Confidence::new(0.7).tier(), ConfidenceTier::Confident);
+        assert_eq!(Confidence::new(0.9).tier(), ConfidenceTier::Confident);
+        assert_eq!(Confidence::new(1.0).tier(), ConfidenceTier::Confident);
     }
 
     #[test]
     fn confidence_accumulate_basic() {
-        let mut conf = Confidence(0.0);
+        let mut conf = Confidence::new(0.0);
 
         // First observation has significant impact
         conf.accumulate(0.2);
@@ -1429,7 +1446,7 @@ mod tests {
 
     #[test]
     fn confidence_accumulate_asymptotic() {
-        let mut conf = Confidence(0.9);
+        let mut conf = Confidence::new(0.9);
 
         // High confidence accumulates slowly
         conf.accumulate(0.2);
@@ -1443,21 +1460,21 @@ mod tests {
 
     #[test]
     fn confidence_accumulate_clamping() {
-        let mut conf = Confidence(0.5);
+        let mut conf = Confidence::new(0.5);
 
         // Large weight is clamped to 1.0
         conf.accumulate(2.0);
         assert_eq!(conf.0, 1.0);
 
         // Negative weight is clamped to 0.0
-        let mut conf2 = Confidence(0.5);
+        let mut conf2 = Confidence::new(0.5);
         conf2.accumulate(-1.0);
         assert_eq!(conf2.0, 0.0);
     }
 
     #[test]
     fn confidence_accumulate_converges_toward_one_with_diminishing_returns() {
-        let mut conf = Confidence(0.0);
+        let mut conf = Confidence::new(0.0);
         let weight = 0.2;
 
         // Track confidence values to verify diminishing returns
@@ -1513,7 +1530,7 @@ mod tests {
 
     #[test]
     fn confidence_degrade_basic() {
-        let mut conf = Confidence(0.8);
+        let mut conf = Confidence::new(0.8);
 
         // 40% penalty (factor 0.6)
         conf.degrade(0.6, 0.1);
@@ -1522,7 +1539,7 @@ mod tests {
 
     #[test]
     fn confidence_degrade_floor() {
-        let mut conf = Confidence(0.3);
+        let mut conf = Confidence::new(0.3);
 
         // Large penalty would drop below floor
         conf.degrade(0.1, 0.2);
@@ -1531,7 +1548,7 @@ mod tests {
 
     #[test]
     fn confidence_degrade_no_floor_violation() {
-        let mut conf = Confidence(0.8);
+        let mut conf = Confidence::new(0.8);
 
         // Penalty doesn't hit floor
         conf.degrade(0.7, 0.2);
@@ -1547,7 +1564,7 @@ mod tests {
 
     #[test]
     fn confidence_serialization() {
-        let conf = Confidence(0.42);
+        let conf = Confidence::new(0.42);
         let json = serde_json::to_string(&conf).expect("Confidence should serialize");
         let deserialized: Confidence =
             serde_json::from_str(&json).expect("Confidence should deserialize");
@@ -1558,7 +1575,7 @@ mod tests {
 
     #[test]
     fn confidence_accumulate_at_max_stays_at_max() {
-        let mut conf = Confidence(1.0);
+        let mut conf = Confidence::new(1.0);
 
         // Accumulating at 1.0 should stay at 1.0
         conf.accumulate(0.2);
@@ -1587,7 +1604,7 @@ mod tests {
     #[test]
     fn confidence_degrade_at_floor_stays_at_floor() {
         let floor = 0.2;
-        let mut conf = Confidence(floor);
+        let mut conf = Confidence::new(floor);
 
         // Degrading at floor should stay at floor
         conf.degrade(0.5, floor);
@@ -1614,7 +1631,7 @@ mod tests {
 
         // Test with different floor values
         let higher_floor = 0.5;
-        let mut conf2 = Confidence(higher_floor);
+        let mut conf2 = Confidence::new(higher_floor);
         conf2.degrade(0.1, higher_floor);
         assert_eq!(
             conf2.0, higher_floor,
@@ -1789,7 +1806,7 @@ mod tests {
         );
 
         // Test tentative tier, low value
-        let confidence_tentative = Confidence(0.2);
+        let confidence_tentative = Confidence::new(0.2);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             0.1,
@@ -1806,7 +1823,7 @@ mod tests {
         assert_eq!(result, Some("seemed to change noticeably"));
 
         // Test observed tier, low value
-        let confidence_observed = Confidence(0.5);
+        let confidence_observed = Confidence::new(0.5);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             0.1,
@@ -1820,7 +1837,7 @@ mod tests {
         use crate::journal::ObservationCategory;
 
         let vocab = DescriptorVocabulary::new();
-        let confidence = Confidence(0.2);
+        let confidence = Confidence::new(0.2);
         let result = vocab.describe(&ObservationCategory::ThermalBehavior, 0.1, confidence);
         assert_eq!(result, None);
     }
@@ -1840,12 +1857,12 @@ mod tests {
         );
 
         // Value outside range
-        let confidence = Confidence(0.2);
+        let confidence = Confidence::new(0.2);
         let result = vocab.describe(&ObservationCategory::ThermalBehavior, 0.5, confidence);
         assert_eq!(result, None);
 
         // Wrong tier (confident tier not defined)
-        let confidence_confident = Confidence(0.8);
+        let confidence_confident = Confidence::new(0.8);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             0.1,
@@ -1864,7 +1881,7 @@ mod tests {
         let low_color_value = 0.1; // Should be in 0.0..0.125 range
 
         // Tentative tier
-        let confidence_tentative = Confidence(0.2);
+        let confidence_tentative = Confidence::new(0.2);
         let result = vocab.describe(
             &ObservationCategory::SurfaceAppearance,
             low_color_value,
@@ -1873,7 +1890,7 @@ mod tests {
         assert_eq!(result, Some("Appeared to have a dark, muted coloration"));
 
         // Observed tier
-        let confidence_observed = Confidence(0.5);
+        let confidence_observed = Confidence::new(0.5);
         let result = vocab.describe(
             &ObservationCategory::SurfaceAppearance,
             low_color_value,
@@ -1882,7 +1899,7 @@ mod tests {
         assert_eq!(result, Some("Dark, muted coloration"));
 
         // Confident tier
-        let confidence_confident = Confidence(0.8);
+        let confidence_confident = Confidence::new(0.8);
         let result = vocab.describe(
             &ObservationCategory::SurfaceAppearance,
             low_color_value,
@@ -1993,7 +2010,7 @@ mod tests {
         let low_value = 0.1; // Should be in 0.0..0.25 range
 
         // Tentative tier
-        let confidence_tentative = Confidence(0.2);
+        let confidence_tentative = Confidence::new(0.2);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             low_value,
@@ -2002,7 +2019,7 @@ mod tests {
         assert_eq!(result, Some("Seemed to soften quickly under heat"));
 
         // Observed tier
-        let confidence_observed = Confidence(0.5);
+        let confidence_observed = Confidence::new(0.5);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             low_value,
@@ -2011,7 +2028,7 @@ mod tests {
         assert_eq!(result, Some("Softens quickly under heat"));
 
         // Confident tier
-        let confidence_confident = Confidence(0.8);
+        let confidence_confident = Confidence::new(0.8);
         let result = vocab.describe(
             &ObservationCategory::ThermalBehavior,
             low_value,
@@ -2026,12 +2043,12 @@ mod tests {
     #[test]
     fn descriptor_vocabulary_confidence_tier_mapping() {
         // Test that confidence values map to the correct tiers
-        assert_eq!(Confidence(0.0).tier(), ConfidenceTier::Tentative);
-        assert_eq!(Confidence(0.29).tier(), ConfidenceTier::Tentative);
-        assert_eq!(Confidence(0.3).tier(), ConfidenceTier::Observed);
-        assert_eq!(Confidence(0.69).tier(), ConfidenceTier::Observed);
-        assert_eq!(Confidence(0.7).tier(), ConfidenceTier::Confident);
-        assert_eq!(Confidence(1.0).tier(), ConfidenceTier::Confident);
+        assert_eq!(Confidence::new(0.0).tier(), ConfidenceTier::Tentative);
+        assert_eq!(Confidence::new(0.29).tier(), ConfidenceTier::Tentative);
+        assert_eq!(Confidence::new(0.3).tier(), ConfidenceTier::Observed);
+        assert_eq!(Confidence::new(0.69).tier(), ConfidenceTier::Observed);
+        assert_eq!(Confidence::new(0.7).tier(), ConfidenceTier::Confident);
+        assert_eq!(Confidence::new(1.0).tier(), ConfidenceTier::Confident);
     }
 
     #[test]
@@ -2043,24 +2060,52 @@ mod tests {
         // Test cases covering all categories and confidence tiers
         let test_cases = [
             // ThermalBehavior tests
-            (ObservationCategory::ThermalBehavior, 0.1, Confidence(0.2)), // Tentative, low thermal resistance
-            (ObservationCategory::ThermalBehavior, 0.3, Confidence(0.5)), // Observed, medium thermal resistance
-            (ObservationCategory::ThermalBehavior, 0.8, Confidence(0.9)), // Confident, high thermal resistance
+            (
+                ObservationCategory::ThermalBehavior,
+                0.1,
+                Confidence::new(0.2),
+            ), // Tentative, low thermal resistance
+            (
+                ObservationCategory::ThermalBehavior,
+                0.3,
+                Confidence::new(0.5),
+            ), // Observed, medium thermal resistance
+            (
+                ObservationCategory::ThermalBehavior,
+                0.8,
+                Confidence::new(0.9),
+            ), // Confident, high thermal resistance
             // SurfaceAppearance tests
             (
                 ObservationCategory::SurfaceAppearance,
                 0.05,
-                Confidence(0.1),
+                Confidence::new(0.1),
             ), // Tentative, dark color
-            (ObservationCategory::SurfaceAppearance, 0.4, Confidence(0.4)), // Observed, medium color
-            (ObservationCategory::SurfaceAppearance, 0.9, Confidence(0.8)), // Confident, dense appearance
+            (
+                ObservationCategory::SurfaceAppearance,
+                0.4,
+                Confidence::new(0.4),
+            ), // Observed, medium color
+            (
+                ObservationCategory::SurfaceAppearance,
+                0.9,
+                Confidence::new(0.8),
+            ), // Confident, dense appearance
             // Weight tests
-            (ObservationCategory::Weight, 0.15, Confidence(0.25)), // Tentative, light
-            (ObservationCategory::Weight, 0.5, Confidence(0.6)),   // Observed, medium
-            (ObservationCategory::Weight, 0.85, Confidence(0.95)), // Confident, heavy
+            (ObservationCategory::Weight, 0.15, Confidence::new(0.25)), // Tentative, light
+            (ObservationCategory::Weight, 0.5, Confidence::new(0.6)),   // Observed, medium
+            (ObservationCategory::Weight, 0.85, Confidence::new(0.95)), // Confident, heavy
             // FabricationResult tests
-            (ObservationCategory::FabricationResult, 0.2, Confidence(0.3)), // Observed, low success
-            (ObservationCategory::FabricationResult, 0.7, Confidence(0.8)), // Confident, high success
+            (
+                ObservationCategory::FabricationResult,
+                0.2,
+                Confidence::new(0.3),
+            ), // Observed, low success
+            (
+                ObservationCategory::FabricationResult,
+                0.7,
+                Confidence::new(0.8),
+            ), // Confident, high success
         ];
 
         // For each test case, call describe() multiple times and verify identical results
@@ -2098,16 +2143,40 @@ mod tests {
         // Test edge cases that might be prone to non-deterministic behavior
         let edge_cases = [
             // Boundary values for confidence tiers
-            (ObservationCategory::ThermalBehavior, 0.5, Confidence(0.3)), // Exactly at Observed threshold
-            (ObservationCategory::ThermalBehavior, 0.5, Confidence(0.7)), // Exactly at Confident threshold
+            (
+                ObservationCategory::ThermalBehavior,
+                0.5,
+                Confidence::new(0.3),
+            ), // Exactly at Observed threshold
+            (
+                ObservationCategory::ThermalBehavior,
+                0.5,
+                Confidence::new(0.7),
+            ), // Exactly at Confident threshold
             // Boundary values for value ranges
-            (ObservationCategory::SurfaceAppearance, 0.0, Confidence(0.5)), // Minimum value
-            (ObservationCategory::SurfaceAppearance, 1.0, Confidence(0.5)), // Maximum value
-            (ObservationCategory::Weight, 0.25, Confidence(0.5)),           // Range boundary
-            (ObservationCategory::Weight, 0.75, Confidence(0.5)),           // Range boundary
+            (
+                ObservationCategory::SurfaceAppearance,
+                0.0,
+                Confidence::new(0.5),
+            ), // Minimum value
+            (
+                ObservationCategory::SurfaceAppearance,
+                1.0,
+                Confidence::new(0.5),
+            ), // Maximum value
+            (ObservationCategory::Weight, 0.25, Confidence::new(0.5)), // Range boundary
+            (ObservationCategory::Weight, 0.75, Confidence::new(0.5)), // Range boundary
             // Extreme confidence values
-            (ObservationCategory::FabricationResult, 0.5, Confidence(0.0)), // Minimum confidence
-            (ObservationCategory::FabricationResult, 0.5, Confidence(1.0)), // Maximum confidence
+            (
+                ObservationCategory::FabricationResult,
+                0.5,
+                Confidence::new(0.0),
+            ), // Minimum confidence
+            (
+                ObservationCategory::FabricationResult,
+                0.5,
+                Confidence::new(1.0),
+            ), // Maximum confidence
         ];
 
         for (category, value, confidence) in edge_cases {
@@ -2136,10 +2205,22 @@ mod tests {
         let vocab3 = DescriptorVocabulary::default();
 
         let test_cases = [
-            (ObservationCategory::ThermalBehavior, 0.1, Confidence(0.2)),
-            (ObservationCategory::SurfaceAppearance, 0.6, Confidence(0.5)),
-            (ObservationCategory::Weight, 0.8, Confidence(0.9)),
-            (ObservationCategory::FabricationResult, 0.3, Confidence(0.4)),
+            (
+                ObservationCategory::ThermalBehavior,
+                0.1,
+                Confidence::new(0.2),
+            ),
+            (
+                ObservationCategory::SurfaceAppearance,
+                0.6,
+                Confidence::new(0.5),
+            ),
+            (ObservationCategory::Weight, 0.8, Confidence::new(0.9)),
+            (
+                ObservationCategory::FabricationResult,
+                0.3,
+                Confidence::new(0.4),
+            ),
         ];
 
         for (category, value, confidence) in test_cases {
@@ -2240,9 +2321,9 @@ mod tests {
 
                         // Test the actual describe() method returns a non-empty result
                         let confidence = match tier {
-                            ConfidenceTier::Tentative => Confidence(0.2),
-                            ConfidenceTier::Observed => Confidence(0.5),
-                            ConfidenceTier::Confident => Confidence(0.8),
+                            ConfidenceTier::Tentative => Confidence::new(0.2),
+                            ConfidenceTier::Observed => Confidence::new(0.5),
+                            ConfidenceTier::Confident => Confidence::new(0.8),
                         };
 
                         let result = vocab.describe(&category, value, confidence);
@@ -2569,9 +2650,9 @@ mod tests {
         for (category, boundary_value, tier) in boundary_test_cases {
             // Convert tier to appropriate confidence value
             let confidence = match tier {
-                ConfidenceTier::Tentative => Confidence(0.2),
-                ConfidenceTier::Observed => Confidence(0.5),
-                ConfidenceTier::Confident => Confidence(0.8),
+                ConfidenceTier::Tentative => Confidence::new(0.2),
+                ConfidenceTier::Observed => Confidence::new(0.5),
+                ConfidenceTier::Confident => Confidence::new(0.8),
             };
 
             // Get the first result
@@ -2686,9 +2767,9 @@ mod tests {
 
         for (category, value, tier) in just_inside_boundary_cases {
             let confidence = match tier {
-                ConfidenceTier::Tentative => Confidence(0.2),
-                ConfidenceTier::Observed => Confidence(0.5),
-                ConfidenceTier::Confident => Confidence(0.8),
+                ConfidenceTier::Tentative => Confidence::new(0.2),
+                ConfidenceTier::Observed => Confidence::new(0.5),
+                ConfidenceTier::Confident => Confidence::new(0.8),
             };
 
             let first_result = vocab.describe(&category, value, confidence);
@@ -2740,16 +2821,16 @@ mod tests {
         let node42 = graph.ensure_concept(ConceptId(key42.clone()), ConceptCategory::Material, 0);
         if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
             n.name = "Test Material".to_string();
-            n.confidence = Confidence(0.8);
+            n.confidence = Confidence::new(0.8);
             n.add_observation(Observation {
                 category: ObservationCategory::ThermalBehavior,
-                confidence: Confidence(0.8),
+                confidence: Confidence::new(0.8),
                 description: "Reliably withstands heat".to_string(),
                 recorded_at: 100,
             });
             n.add_observation(Observation {
                 category: ObservationCategory::SurfaceAppearance,
-                confidence: Confidence(0.5),
+                confidence: Confidence::new(0.5),
                 description: "Smooth metallic surface".to_string(),
                 recorded_at: 150,
             });
@@ -2759,10 +2840,10 @@ mod tests {
         let node99 = graph.ensure_concept(ConceptId(key99.clone()), ConceptCategory::Material, 0);
         if let Some(n) = graph.graph_mut().node_weight_mut(node99) {
             n.name = "Another Material".to_string();
-            n.confidence = Confidence(0.9);
+            n.confidence = Confidence::new(0.9);
             n.add_observation(Observation {
                 category: ObservationCategory::Weight,
-                confidence: Confidence(0.9),
+                confidence: Confidence::new(0.9),
                 description: "Notably heavy".to_string(),
                 recorded_at: 200,
             });
@@ -2788,19 +2869,19 @@ mod tests {
 
         // Expected: original * 0.6, not below 0.2 floor
         assert!(
-            (thermal.confidence.0 - 0.8 * 0.6).abs() < 1e-5,
+            (thermal.confidence.value() - 0.8 * 0.6).abs() < 1e-5,
             "thermal: {}",
-            thermal.confidence.0
+            thermal.confidence.value()
         );
         assert!(
-            (weight.confidence.0 - 0.9 * 0.6).abs() < 1e-5,
+            (weight.confidence.value() - 0.9 * 0.6).abs() < 1e-5,
             "weight: {}",
-            weight.confidence.0
+            weight.confidence.value()
         );
         assert!(
-            (surface.confidence.0 - 0.5 * 0.6).abs() < 1e-5,
+            (surface.confidence.value() - 0.5 * 0.6).abs() < 1e-5,
             "surface: {}",
-            surface.confidence.0
+            surface.confidence.value()
         );
     }
 
@@ -2828,7 +2909,7 @@ mod tests {
         if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
             n.add_observation(Observation {
                 category: ObservationCategory::ThermalBehavior,
-                confidence: Confidence(0.4),
+                confidence: Confidence::new(0.4),
                 description: "Seemed to react to heat".to_string(),
                 recorded_at: 100,
             });
@@ -2848,7 +2929,7 @@ mod tests {
             .node(node42)
             .unwrap()
             .observations_by_category(&ObservationCategory::ThermalBehavior)[0];
-        assert_eq!(thermal.confidence.0, 0.3);
+        assert_eq!(thermal.confidence.value(), 0.3);
     }
 
     #[test]
@@ -3016,7 +3097,7 @@ mod tests {
         let current_time = 2000; // Within recovery window
 
         // Test confidence accumulation in death-relevant domain (thermal)
-        let mut thermal_confidence = Confidence(0.3); // Starting confidence after death
+        let mut thermal_confidence = Confidence::new(0.3); // Starting confidence after death
         let thermal_multiplier = death_context.recovery_multiplier(
             &ObservationCategory::ThermalBehavior,
             current_time,
@@ -3025,7 +3106,7 @@ mod tests {
         thermal_confidence.accumulate(config.base_observation_weight * thermal_multiplier);
 
         // Test confidence accumulation in unrelated domain (weight)
-        let mut weight_confidence = Confidence(0.3); // Same starting confidence
+        let mut weight_confidence = Confidence::new(0.3); // Same starting confidence
         let weight_multiplier =
             death_context.recovery_multiplier(&ObservationCategory::Weight, current_time, &config);
         weight_confidence.accumulate(config.base_observation_weight * weight_multiplier);


### PR DESCRIPTION
## Summary

Privatize the inner `f32` field of the `Confidence(f32)` tuple struct and enforce all access through typed methods.

## Changes

- `pub struct Confidence(pub f32)` → `pub struct Confidence(f32)` (field made private)
- Added `Confidence::new(v: f32) -> Self` — clamps input to `[0.0, 1.0]`, treats NaN as `0.0`
- Added `Confidence::value() -> f32` — accessor for the inner value
- All construction sites updated: `Confidence(x)` → `Confidence::new(x)`
- All field-access sites updated: `.confidence.0` → `.confidence.value()`
- Doc comments that referenced `Confidence(f32)` as a type cleaned up to just say `Confidence`

## Files changed

- `src/observation.rs` — struct definition + impl block; ~85 construction sites; doc comments
- `src/carry.rs` — 3 construction sites
- `src/knowledge_graph.rs` — 12 construction sites
- `src/heat.rs` — 1 construction site
- `src/interaction.rs` — 1 construction site
- `src/fabricator.rs` — 1 construction site (full-path form)
- `src/journal_tests.rs` — 126 construction sites; field accesses

## Testing

701 unit tests pass. All pre-commit checks pass (fmt, clippy, cargo test, doc-tests).

## Notes

Pre-existing build errors (E0432 unresolved import `MaterialSeed`, E0308 mismatched types in carry/heat/knowledge_graph) are unrelated to this change and were present on `develop` before this branch.