### PR TITLE
feat: restore MaterialSeed and PlanetSeed domain newtypes

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::input::InputAction;
 use crate::interaction::HeldItem;
 use crate::journal::{JournalKey, Observation, ObservationCategory};
-use crate::materials::{GameMaterial, MaterialObject};
+use crate::materials::{GameMaterial, MaterialObject, MaterialSeed};
 use crate::observation::Confidence;
 use crate::observation::RecordObservation;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
@@ -1408,7 +1408,7 @@ pub fn record_weight_observation(
             seed: material.seed,
         },
         name: material.name.clone(),
-        material_seed: Some(material.seed),
+        material_seed: Some(MaterialSeed(material.seed)),
         planet_seed: material.origin_planet_seed,
         observation: Observation {
             category: ObservationCategory::Weight,
@@ -2254,8 +2254,8 @@ exponent = 1.0
         for (label, origin_planet_seed, expected) in [
             (
                 "with planet origin",
-                Some(0xDEAD_BEEFu64),
-                Some(0xDEAD_BEEFu64),
+                Some(crate::world_generation::PlanetSeed(0xDEAD_BEEFu64)),
+                Some(crate::world_generation::PlanetSeed(0xDEAD_BEEFu64)),
             ),
             ("without planet origin", None, None),
         ] {

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -296,7 +296,10 @@ fn tick_processing(
         // Pass input material seeds so the knowledge graph can wire DerivedFrom
         // edges from the output concept to each input material (Story 10.5).
         planet_seed: None,
-        input_seeds: input_mats.iter().map(|m| m.seed).collect(),
+        input_seeds: input_mats
+            .iter()
+            .map(|m| crate::materials::MaterialSeed(m.seed))
+            .collect(),
         context_location: None,
     });
 

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -18,7 +18,7 @@ use bevy::prelude::*;
 
 use crate::descriptions::describe_thermal_observation;
 use crate::journal::{JournalKey, Observation, ObservationCategory};
-use crate::materials::{GameMaterial, MaterialObject, PropertyVisibility};
+use crate::materials::{GameMaterial, MaterialObject, MaterialSeed, PropertyVisibility};
 use crate::observation::Confidence;
 use crate::observation::RecordObservation;
 use crate::scene::{FurnitureConfig, HeatSourceConfig, Workbench};
@@ -313,7 +313,7 @@ fn reveal_thermal_property(
             journal_writer.write(RecordObservation {
                 key: JournalKey::MaterialInstance { seed: mat.seed },
                 name: mat.name.clone(),
-                material_seed: Some(mat.seed),
+                material_seed: Some(MaterialSeed(mat.seed)),
                 planet_seed: mat.origin_planet_seed,
                 observation: Observation {
                     category: ObservationCategory::ThermalBehavior,
@@ -615,7 +615,7 @@ mod tests {
             MaterialObject,
             {
                 let mut mat = test_material(7);
-                mat.origin_planet_seed = Some(expected_seed);
+                mat.origin_planet_seed = Some(PlanetSeed(expected_seed));
                 mat
             },
             HeatExposure {
@@ -640,7 +640,7 @@ mod tests {
                 assert_eq!(*seed, 7, "material seed should match the test material");
                 assert_eq!(
                     recorded[0].planet_seed,
-                    Some(expected_seed),
+                    Some(PlanetSeed(expected_seed)),
                     "observation must capture the WorldProfile's planet seed so the journal's current-planet filter can match it"
                 );
             }

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -24,7 +24,7 @@ use crate::carry::{CarryConfig, CarryState, ObserveWeight, StashHeldForPickup};
 use crate::descriptions::describe_density;
 use crate::fabricator::{ActivateIntent, InputSlot, OutputSlot};
 use crate::input::InputAction;
-use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject};
+use crate::materials::{GameMaterial, MATERIAL_SURFACE_GAP, MaterialObject, MaterialSeed};
 use crate::observation::Confidence;
 use crate::player::{Player, PlayerCamera, cursor_is_captured};
 use crate::scene::{PlayerSceneConfig, Surface};
@@ -832,7 +832,7 @@ fn build_examine_text(
 ) -> String {
     // Look up what the player has revealed about this material instance.
     let revealed = graph
-        .lookup_material_by_seed(mat.seed)
+        .lookup_material_by_seed(MaterialSeed(mat.seed))
         .and_then(|idx| graph.node_weight(idx))
         .map(|node| &node.revealed_properties);
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -20,7 +20,7 @@ use crate::input::InputAction;
 use crate::knowledge_graph::{ConceptId, ConceptNode, KnowledgeGraph};
 use crate::observation::Confidence;
 use crate::player::{Player, cursor_is_captured, spawn_player};
-use crate::world_generation::BiomeType;
+use crate::world_generation::{BiomeType, PlanetSeed};
 
 // ── Biome key type safety ──────────────────────────────────────────────
 
@@ -242,8 +242,8 @@ pub enum JournalKey {
     /// targets from material entries.
     Location {
         /// The planet seed that uniquely identifies this location within
-        /// the world generation system.  Matches `WorldProfile::planet_seed.0`.
-        planet_seed: u64,
+        /// the world generation system.  Matches `WorldProfile::planet_seed`.
+        planet_seed: PlanetSeed,
     },
 }
 
@@ -254,7 +254,7 @@ impl JournalKey {
     /// `Location` keys return their planet seed directly. All other variants
     /// return `None` — planet provenance for material instances is stored on
     /// the KnowledgeGraph node as a `FoundOn` edge, not on the key.
-    pub fn planet_seed(&self) -> Option<u64> {
+    pub fn planet_seed(&self) -> Option<PlanetSeed> {
         match self {
             JournalKey::MaterialInstance { .. } => None,
             JournalKey::Material { .. } => None,
@@ -372,7 +372,7 @@ pub fn matches_filter_node(node: &ConceptNode, filter: &JournalFilter) -> bool {
 
     let context_match = filter.context.as_ref().is_none_or(|ctx| match ctx {
         JournalContext::CurrentPlanet { planet_seed } => {
-            node.origin_planet_seed == Some(*planet_seed)
+            node.origin_planet_seed == Some(PlanetSeed(*planet_seed))
         }
         JournalContext::CurrentBiome { .. } => true,
     });

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::knowledge_graph::{ConceptId, ConceptNode, KnowledgeGraph};
 use crate::observation::Confidence;
-use crate::world_generation::BiomeType;
+use crate::world_generation::{BiomeType, PlanetSeed};
 
 fn build_entry_list_text(
     nodes: &[NodeIndex],
@@ -302,7 +302,7 @@ fn node_with_observation_on_planet(
     planet_seed: Option<u64>,
 ) -> ConceptNode {
     let mut entry = ConceptNode::new(key, "Subject", 0);
-    entry.origin_planet_seed = planet_seed;
+    entry.origin_planet_seed = planet_seed.map(PlanetSeed);
     entry.add_observation(Observation {
         category,
         confidence: Confidence(0.2),
@@ -479,8 +479,11 @@ fn journal_key_planet_seed_accessor() {
         None
     );
     assert_eq!(
-        JournalKey::Location { planet_seed: 42 }.planet_seed(),
-        Some(42)
+        JournalKey::Location {
+            planet_seed: PlanetSeed(42),
+        }
+        .planet_seed(),
+        Some(PlanetSeed(42))
     );
 }
 

--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::journal::JournalKey;
 use crate::observation::{Confidence, ConfidenceConfig};
+use crate::world_generation::PlanetSeed;
 
 // ── Plugin ────────────────────────────────────────────────────────────────
 
@@ -120,7 +121,7 @@ pub struct ConceptNode {
     /// the first observation that carries a planet seed. `None` for fabricated
     /// materials and concepts recorded without planetary context. Used by the
     /// `CurrentPlanet` journal filter.
-    pub origin_planet_seed: Option<u64>,
+    pub origin_planet_seed: Option<PlanetSeed>,
     /// Which named properties the player has directly observed on this concept.
     ///
     /// Keys match [`crate::journal::ObservationCategory::display_label`] so
@@ -646,9 +647,12 @@ impl KnowledgeGraph {
     /// prevents that by finding the existing node by seed.
     ///
     /// Returns `None` when no material with that seed exists in the graph yet.
-    pub fn lookup_material_by_seed(&self, seed: u64) -> Option<NodeIndex> {
+    pub fn lookup_material_by_seed(
+        &self,
+        seed: crate::materials::MaterialSeed,
+    ) -> Option<NodeIndex> {
         self.concept_index.iter().find_map(|(id, &idx)| {
-            if matches!(&id.0, crate::journal::JournalKey::MaterialInstance { seed: s } if *s == seed) {
+            if matches!(&id.0, crate::journal::JournalKey::MaterialInstance { seed: s } if *s == seed.0) {
                 Some(idx)
             } else {
                 None
@@ -1027,7 +1031,7 @@ fn update_knowledge_graph(
                     .lookup_material_by_seed(input_seed)
                     .unwrap_or_else(|| {
                         let input_key =
-                            crate::journal::JournalKey::MaterialInstance { seed: input_seed };
+                            crate::journal::JournalKey::MaterialInstance { seed: input_seed.0 };
                         graph.ensure_concept(ConceptId(input_key), ConceptCategory::Material, tick)
                     });
                 graph.relate(
@@ -1055,11 +1059,11 @@ fn update_knowledge_graph(
             let seed_b = obs.input_seeds[1];
 
             let node_a = graph.lookup_material_by_seed(seed_a).unwrap_or_else(|| {
-                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_a };
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_a.0 };
                 graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
             });
             let node_b = graph.lookup_material_by_seed(seed_b).unwrap_or_else(|| {
-                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_b };
+                let key = crate::journal::JournalKey::MaterialInstance { seed: seed_b.0 };
                 graph.ensure_concept(ConceptId(key), ConceptCategory::Material, tick)
             });
 
@@ -1272,7 +1276,7 @@ fn detect_similar_on_observation(
         let crate::journal::JournalKey::MaterialInstance { seed } = obs.key else {
             continue;
         };
-        let Some(material) = catalog.get_by_seed(seed) else {
+        let Some(material) = catalog.get_by_seed(crate::materials::MaterialSeed(seed)) else {
             continue;
         };
         detect_and_wire_similar_materials(
@@ -1299,7 +1303,9 @@ mod tests {
     }
 
     fn loc_id(planet_seed: u64) -> ConceptId {
-        ConceptId(JournalKey::Location { planet_seed })
+        ConceptId(JournalKey::Location {
+            planet_seed: PlanetSeed(planet_seed),
+        })
     }
 
     // ── Phase 1 tests ─────────────────────────────────────────────────

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -28,6 +28,16 @@ use crate::seed_util::{
     MAT_DENSITY_CHANNEL, MAT_REACTIVITY_CHANNEL, MAT_THERMAL_RESISTANCE_CHANNEL,
     MAT_TOXICITY_CHANNEL, mix_seed,
 };
+use crate::world_generation::PlanetSeed;
+
+/// Typed seed for a material instance.
+///
+/// Wraps the raw `u64` seed so that material seeds cannot be silently confused
+/// with planet seeds or other seed domains at the type level.  Bare `u64` is
+/// only permitted at serialisation / asset-loading edges; everywhere else pass
+/// `MaterialSeed`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
+pub struct MaterialSeed(pub u64);
 /// Registers the material data model, catalog, and world-object spawning systems.
 pub struct MaterialPlugin;
 
@@ -312,7 +322,7 @@ pub struct GameMaterial {
     ///
     /// `None` in contexts where no planetary world profile exists (early
     /// bring-up, fabricated materials, integration tests).
-    pub origin_planet_seed: Option<u64>,
+    pub origin_planet_seed: Option<PlanetSeed>,
     /// How heavy the material feels — affects mesh shape selection.
     pub density: MaterialProperty,
     /// Resistance to heat transfer.
@@ -507,8 +517,8 @@ impl MaterialCatalog {
 
     /// Look up a material by its seed, returning `None` if not yet registered.
     #[allow(dead_code)]
-    pub fn get_by_seed(&self, seed: u64) -> Option<&GameMaterial> {
-        self.by_seed.get(&seed)
+    pub fn get_by_seed(&self, seed: MaterialSeed) -> Option<&GameMaterial> {
+        self.by_seed.get(&seed.0)
     }
 
     /// Look up a material by its display name, returning `None` if not found.
@@ -1219,7 +1229,7 @@ visibility = "Hidden"
         for &wk in WellKnownMaterial::all() {
             let seed = wk.seed();
             assert!(
-                catalog.get_by_seed(seed).is_some(),
+                catalog.get_by_seed(MaterialSeed(seed)).is_some(),
                 "well-known seed {seed} must be present in the catalog after startup",
             );
         }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -2739,7 +2739,7 @@ mod tests {
         // Populate the KnowledgeGraph with concept nodes carrying observations.
         let mut graph = KnowledgeGraph::default();
 
-        let key42 = JournalKey::MaterialInstance { seed: crate::materials::MaterialSeed(42) };
+        let key42 = JournalKey::MaterialInstance { seed: 42 };
         let node42 = graph.ensure_concept(ConceptId(key42.clone()), ConceptCategory::Material, 0);
         if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
             n.name = "Test Material".to_string();
@@ -2758,7 +2758,7 @@ mod tests {
             });
         }
 
-        let key99 = JournalKey::MaterialInstance { seed: crate::materials::MaterialSeed(99) };
+        let key99 = JournalKey::MaterialInstance { seed: 99 };
         let node99 = graph.ensure_concept(ConceptId(key99.clone()), ConceptCategory::Material, 0);
         if let Some(n) = graph.graph_mut().node_weight_mut(node99) {
             n.name = "Another Material".to_string();
@@ -2826,7 +2826,7 @@ mod tests {
             .insert_resource(Time::<()>::default());
 
         let mut graph = KnowledgeGraph::default();
-        let key42 = JournalKey::MaterialInstance { seed: crate::materials::MaterialSeed(42) };
+        let key42 = JournalKey::MaterialInstance { seed: 42 };
         let node42 = graph.ensure_concept(ConceptId(key42.clone()), ConceptCategory::Material, 0);
         if let Some(n) = graph.graph_mut().node_weight_mut(node42) {
             n.add_observation(Observation {

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -594,7 +594,20 @@ impl Plugin for WorldGenerationPlugin {
 /// runtime. That choice is deliberate: the point of Story 5.1 is to make
 /// determinism obvious and testable. A config-backed seed means anyone can read
 /// the world seed, rerun the game, and get the same foundational world state.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Reflect,
+)]
 pub struct PlanetSeed(pub u64);
 
 /// Signed chunk coordinate on the exterior X/Z ground plane.

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -636,7 +636,7 @@ fn sync_active_exterior_chunks(
                 .clone();
             // Tag the spawn origin so observation systems can wire the FoundOn
             // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
-            deposit_material.origin_planet_seed = Some(world_profile.planet_seed.0);
+            deposit_material.origin_planet_seed = Some(world_profile.planet_seed);
             let mesh = deposit_material.mesh_for_density(&mut meshes);
             let render_material = render_materials.add(StandardMaterial {
                 base_color: deposit_material.bevy_color(),

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -3617,12 +3617,14 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
     // Every material in catalog A must exist in catalog B with identical
     // name, color, and all scalar properties.
     for mat_a in catalog_a.values() {
-        let mat_b = catalog_b.get_by_seed(mat_a.seed).unwrap_or_else(|| {
-            panic!(
-                "seed {} ({}) present in run 1 but missing in run 2",
-                mat_a.seed, mat_a.name
-            )
-        });
+        let mat_b = catalog_b
+            .get_by_seed(crate::materials::MaterialSeed(mat_a.seed))
+            .unwrap_or_else(|| {
+                panic!(
+                    "seed {} ({}) present in run 1 but missing in run 2",
+                    mat_a.seed, mat_a.name
+                )
+            });
 
         assert_eq!(
             mat_a.name, mat_b.name,
@@ -3911,7 +3913,7 @@ fn restart_system_seed_chain_yields_identical_world() {
     for mat_a in session_a.materials.values() {
         let mat_b = session_b
             .materials
-            .get_by_seed(mat_a.seed)
+            .get_by_seed(crate::materials::MaterialSeed(mat_a.seed))
             .unwrap_or_else(|| {
                 panic!(
                     "seed {} ({}) present in run 1 but missing in run 2",


### PR DESCRIPTION
## Summary

Restores `MaterialSeed` and `PlanetSeed` as proper domain-typed newtypes throughout the codebase, replacing raw `u64` at all internal function parameters and struct fields that represent material or planet identity.

## Changes

- **materials.rs**: Add `MaterialSeed(u64)` newtype with full derive set; `GameMaterial::origin_planet_seed: Option<PlanetSeed>`; `get_by_seed` accepts `MaterialSeed`
- **world_generation.rs**: Add `PartialOrd`, `Ord`, `Reflect` to `PlanetSeed` (required by `JournalKey` Ord derive and `GameMaterial` Reflect derive)
- **world_generation/exterior.rs**: `origin_planet_seed` assignment uses `PlanetSeed` directly
- **knowledge_graph.rs**: `KnowledgeNode::origin_planet_seed: Option<PlanetSeed>`; `lookup_material_by_seed` accepts `MaterialSeed`; DerivedFrom/CombinedWith blocks unwrap to `u64` at `JournalKey::MaterialInstance` boundary
- **journal.rs**: `JournalKey::Location.planet_seed: PlanetSeed`; CurrentPlanet filter comparison fixed
- **carry.rs**, **heat.rs**, **fabricator.rs**, **interaction.rs**: `MaterialSeed` wrapping at all internal callsites
- **journal_tests.rs**: PlanetSeed literal and map fixes
- **observation.rs**: Revert erroneous `MaterialSeed` wraps at `JournalKey::MaterialInstance` boundary

## Boundaries that intentionally stay u64

- `JournalKey::MaterialInstance { seed: u64 }` — journal identity boundary
- `JournalContext::CurrentPlanet { planet_seed: u64 }` — UI/filter boundary (documented as cheap clone/store)
- `MaterialCatalog::by_seed HashMap<u64, ...>` — internal map key
- `detect_and_wire_similar_materials(new_seed: u64)` — called from journal boundary with raw `u64`

## Testing

- `cargo check`: clean (only pre-existing let-chain lint errors unrelated to this change)
- `cargo test`: 706 lib tests + all integration/doc tests pass, 0 failures

Closes t_0a3ee6c1