### PR TITLE
fix: replace stringly-typed match with direct ConfidenceTier enum match in describe_thermal_observation

### DIFF
--- a/src/descriptions.rs
+++ b/src/descriptions.rs
@@ -7,7 +7,7 @@
 //! normalised `0.0–1.0` value (or similar) into a `&'static str` or
 //! `String` that can go straight into UI text.
 
-use crate::observation::Confidence;
+use crate::observation::{Confidence, ConfidenceTier};
 
 // ── Generic value ───────────────────────────────────────────────────────
 
@@ -94,18 +94,16 @@ fn describe_thermal_behavior(value: f32) -> &'static str {
 /// Thermal observation with confidence-level framing applied.
 pub fn describe_thermal_observation(value: f32, confidence: Confidence) -> String {
     let behavior = describe_thermal_behavior(value);
-    let tier = confidence.tier();
-    match tier.display_label() {
-        "Uncertain" => format!("Seemed to {behavior}"),
-        "Noted" => {
+    match confidence.tier() {
+        ConfidenceTier::Tentative => format!("Seemed to {behavior}"),
+        ConfidenceTier::Observed => {
             let mut chars = behavior.chars();
             let Some(first) = chars.next() else {
                 return String::new();
             };
             format!("{}{}", first.to_uppercase(), chars.as_str())
         }
-        "Confirmed" => format!("Reliably {behavior}"),
-        _ => behavior.to_string(), // fallback for any unexpected labels
+        ConfidenceTier::Confident => format!("Reliably {behavior}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `match confidence.tier().display_label()` pattern in `describe_thermal_observation` (src/descriptions.rs) with a direct match on `ConfidenceTier` enum variants.

**Before:** Matched on string literals `"Uncertain"`, `"Noted"`, `"Confirmed"` which silently break if `display_label()` return values change.

**After:** Matches directly on `ConfidenceTier::Tentative`, `ConfidenceTier::Observed`, `ConfidenceTier::Confident` — exhaustive, compiler-enforced, silent-breakage-free.

## Changes

- Added `ConfidenceTier` to the import in `src/descriptions.rs`
- Replaced stringly-typed match with direct enum variant match
- Removed now-unnecessary fallback `_ => ...` arm (enum match is exhaustive)
- Preserved the capitalization logic in the `Observed` arm unchanged

## Testing

The `cargo test --lib` shows 10 pre-existing errors in `src/observation.rs` (unresolved `MaterialSeed` import) that exist on `develop` before this change — verified by stashing and confirming same errors. No new errors introduced.