### PR TITLE
fix: replace hardcoded Confidence(0.1) in heat.rs with ConfidenceConfig

### DIFF
--- a/assets/config/confidence.toml
+++ b/assets/config/confidence.toml
@@ -33,3 +33,12 @@ passive_recovery_multiplier = 0.7
 # Higher values = fewer observations needed for high confidence
 # Lower values = more repeated testing required
 base_observation_weight = 0.2
+
+# Initial Observation Settings
+# -----------------------------
+
+# Starting confidence value seeded into an entity's first observation in a category.
+# Non-zero so the first experiment registers as meaningful (Tentative tier) rather
+# than requiring repeat tests just to escape zero. Should sit clearly in the
+# Tentative tier (< 0.3) so the player still feels compelled to re-test.
+initial_observation_confidence = 0.2

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -267,6 +267,7 @@ fn apply_thermal_reaction(
 fn reveal_thermal_property(
     mut commands: Commands,
     hs_cfg: Res<HeatSourceConfig>,
+    conf_cfg: Res<crate::observation::ConfidenceConfig>,
     mut journal_writer: MessageWriter<RecordObservation>,
     descriptor_vocab: Res<crate::observation::DescriptorVocabulary>,
     mut material_query: Query<
@@ -306,9 +307,9 @@ fn reveal_thermal_property(
                 .entity(entity)
                 .insert(ThermalObservationRecordedThisCycle);
 
-            // Use initial confidence for new observations - the journal system
-            // will handle accumulation automatically for repeated observations
-            let initial_confidence = Confidence::new(0.2);
+            // Use initial confidence from ConfidenceConfig so tuning is centralized
+            // in assets/config/confidence.toml rather than hardcoded here.
+            let initial_confidence = Confidence(conf_cfg.initial_observation_confidence);
 
             journal_writer.write(RecordObservation {
                 key: JournalKey::MaterialInstance { seed: mat.seed },

--- a/src/heat.rs
+++ b/src/heat.rs
@@ -309,7 +309,7 @@ fn reveal_thermal_property(
 
             // Use initial confidence from ConfidenceConfig so tuning is centralized
             // in assets/config/confidence.toml rather than hardcoded here.
-            let initial_confidence = Confidence(conf_cfg.initial_observation_confidence);
+            let initial_confidence = Confidence::new(conf_cfg.initial_observation_confidence);
 
             journal_writer.write(RecordObservation {
                 key: JournalKey::MaterialInstance { seed: mat.seed },
@@ -472,6 +472,7 @@ mod tests {
         let mut app = App::new();
         app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
+        app.insert_resource(crate::observation::ConfidenceConfig::default());
         // ConfidenceTracker removed - confidence is now tracked per-observation in journal
         app.insert_resource(crate::observation::DescriptorVocabulary::default());
         app.add_systems(Update, reveal_thermal_property);
@@ -538,6 +539,7 @@ mod tests {
         let mut app = App::new();
         app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
+        app.insert_resource(crate::observation::ConfidenceConfig::default());
         // ConfidenceTracker removed - confidence is now tracked per-observation in journal
         app.insert_resource(crate::observation::DescriptorVocabulary::default());
         app.add_systems(Update, reveal_thermal_property);
@@ -607,6 +609,7 @@ mod tests {
         let mut app = App::new();
         app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
+        app.insert_resource(crate::observation::ConfidenceConfig::default());
         // ConfidenceTracker removed - confidence is now tracked per-observation in journal
         app.insert_resource(crate::observation::DescriptorVocabulary::default());
         app.insert_resource(profile);
@@ -662,6 +665,7 @@ mod tests {
         let mut app = App::new();
         app.add_message::<RecordObservation>();
         app.insert_resource(HeatSourceConfig::default());
+        app.insert_resource(crate::observation::ConfidenceConfig::default());
         // ConfidenceTracker removed - confidence is now tracked per-observation in journal
         app.insert_resource(crate::observation::DescriptorVocabulary::default());
         // Deliberately do *not* insert WorldProfile.

--- a/src/journal_tests.rs
+++ b/src/journal_tests.rs
@@ -5732,6 +5732,7 @@ fn language_in_journal_regresses_after_death_and_recovers_with_new_observations(
         passive_recovery_multiplier: 0.8,
         base_observation_weight: 0.25, // Reasonable accumulation rate
         similarity_threshold: 0.85,
+        initial_observation_confidence: 0.2,
     };
 
     // ── Phase 1: Establish confident language ──────────────────────────────

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -235,6 +235,19 @@ pub struct ConfidenceConfig {
     /// Typical range: 0.80-0.95
     #[serde(default = "default_similarity_threshold")]
     pub similarity_threshold: f32,
+
+    /// Starting confidence value assigned to an entity's first observation in a category.
+    ///
+    /// When a player records a brand-new observation in a domain they have never
+    /// tested before, this value seeds the initial confidence rather than
+    /// starting from zero. A non-zero seed ensures the very first experiment
+    /// registers as meaningful (Tentative tier) without requiring repeat tests
+    /// just to escape the floor.
+    ///
+    /// Should be low enough that it clearly sits in the Tentative tier so the
+    /// player still feels the need to repeat experiments. Typical range: 0.1-0.3
+    #[serde(default = "default_initial_observation_confidence")]
+    pub initial_observation_confidence: f32,
 }
 
 /// Default value for death_degradation_factor field.
@@ -267,6 +280,11 @@ fn default_similarity_threshold() -> f32 {
     0.85
 }
 
+/// Default value for initial_observation_confidence field.
+fn default_initial_observation_confidence() -> f32 {
+    0.2
+}
+
 impl Default for ConfidenceConfig {
     /// Default confidence configuration values.
     ///
@@ -275,12 +293,13 @@ impl Default for ConfidenceConfig {
     /// meaningful but not punishing confidence degradation.
     fn default() -> Self {
         Self {
-            death_degradation_factor: 0.6,    // Lose 40% confidence on death
-            death_floor: 0.2,                 // Never drop below 20% confidence
-            domain_recovery_multiplier: 2.0,  // 2x recovery in death domain
-            passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
-            base_observation_weight: 0.2,     // Standard observation strength
-            similarity_threshold: 0.85,       // 85% cosine similarity = "similar materials"
+            death_degradation_factor: 0.6,       // Lose 40% confidence on death
+            death_floor: 0.2,                    // Never drop below 20% confidence
+            domain_recovery_multiplier: 2.0,     // 2x recovery in death domain
+            passive_recovery_multiplier: 0.7,    // 0.7x recovery elsewhere
+            base_observation_weight: 0.2,        // Standard observation strength
+            similarity_threshold: 0.85,          // 85% cosine similarity = "similar materials"
+            initial_observation_confidence: 0.2, // Seed first observation at Tentative tier
         }
     }
 }
@@ -1730,6 +1749,7 @@ mod tests {
         assert_eq!(config.domain_recovery_multiplier, 2.0);
         assert_eq!(config.passive_recovery_multiplier, 0.7);
         assert_eq!(config.base_observation_weight, 0.2);
+        assert_eq!(config.initial_observation_confidence, 0.2);
     }
 
     #[test]
@@ -1741,6 +1761,7 @@ mod tests {
             passive_recovery_multiplier: 0.8,
             base_observation_weight: 0.25,
             similarity_threshold: 0.85,
+            initial_observation_confidence: 0.2,
         };
 
         let toml = toml::to_string(&config).expect("ConfidenceConfig should serialize to TOML");
@@ -1769,6 +1790,35 @@ mod tests {
         assert_eq!(config.death_floor, 0.2);
         assert_eq!(config.domain_recovery_multiplier, 2.0);
         assert_eq!(config.passive_recovery_multiplier, 0.7);
+    }
+
+    #[test]
+    fn confidence_config_initial_observation_confidence_defaults_to_0_2() {
+        // Verify the new field defaults correctly when absent from TOML.
+        let partial_toml = r#"
+            death_degradation_factor = 0.8
+        "#;
+
+        let config: ConfidenceConfig =
+            toml::from_str(partial_toml).expect("Partial TOML should deserialize with defaults");
+
+        // The new field must default to 0.2 (Tentative-tier seed).
+        assert_eq!(config.initial_observation_confidence, 0.2);
+    }
+
+    #[test]
+    fn confidence_config_initial_observation_confidence_round_trips() {
+        // Verify the new field serializes and deserializes correctly.
+        let config = ConfidenceConfig {
+            initial_observation_confidence: 0.15,
+            ..Default::default()
+        };
+
+        let toml = toml::to_string(&config).expect("ConfidenceConfig should serialize to TOML");
+        let deserialized: ConfidenceConfig =
+            toml::from_str(&toml).expect("ConfidenceConfig should deserialize from TOML");
+
+        assert_eq!(deserialized.initial_observation_confidence, 0.15);
     }
 
     // ── DescriptorEntry tests ───────────────────────────────────────────
@@ -2977,6 +3027,7 @@ mod tests {
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
                 similarity_threshold: 0.85,
+                initial_observation_confidence: 0.2,
             })
             .insert_resource(Time::<()>::default());
 
@@ -3066,6 +3117,7 @@ mod tests {
                 passive_recovery_multiplier: 0.7,
                 base_observation_weight: 0.2,
                 similarity_threshold: 0.85,
+                initial_observation_confidence: 0.2,
             })
             .insert_resource(Time::<()>::default());
 
@@ -3179,6 +3231,7 @@ mod tests {
             passive_recovery_multiplier: 0.7,
             base_observation_weight: 0.2,
             similarity_threshold: 0.85,
+            initial_observation_confidence: 0.2,
         };
 
         let context = DeathContext::new(DeathCause::HeatSystem, 1000);
@@ -3256,6 +3309,7 @@ mod tests {
             passive_recovery_multiplier: 0.7, // 0.7x recovery elsewhere
             base_observation_weight: 0.2,
             similarity_threshold: 0.85,
+            initial_observation_confidence: 0.2,
         };
 
         // Create death context for heat system death


### PR DESCRIPTION
## Summary

Replaces the hardcoded `Confidence(0.2)` literal in `reveal_thermal_property` (heat.rs:311) with `conf_cfg.initial_observation_confidence` from the centralized `ConfidenceConfig`.

## Changes

- Added `conf_cfg: Res<crate::observation::ConfidenceConfig>` to `reveal_thermal_property` system parameters
- Replaced `Confidence(0.2)` literal with `Confidence(conf_cfg.initial_observation_confidence)`

## Notes

- Branched from `feat/add-initial-observation-confidence` (PR #430) since that PR adds the `initial_observation_confidence` field to `ConfidenceConfig`
- Pre-existing build errors on the parent branch (origin_planet_seed type mismatches) are unrelated to this change and were present before

Depends on #430.

Closes kanban task t_9646b502
Closes #372