### PR TITLE
docs: update knowledge-driven-presentation.md and diegetic-feedback.md for GDD v1.1

### DIFF
--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/diegetic-feedback.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/diegetic-feedback.md
@@ -1,3 +1,25 @@
 # Cross-Cutting Concern: Diegetic Feedback Contract
 
 The game never tells, only shows. No HUD popups, no progress bars, no explanatory UI. Every system must express state changes through world objects, visual consequences, or NPC reactions. This is an architectural constraint, not a style preference.
+
+## Terrain Texture as Diegetic Channel
+
+Terrain texture is the player's first-read signal about material physical properties. Crystalline, sedimentary, soil, and ice textures are diegetic information — not background art. The rendering system encodes material properties into texture by architectural rule. A crystalline surface looks crystalline because it has the physical properties of a crystal. The player learns material behavior by looking at the world, not by reading a tooltip.
+
+This is a direct consequence of intrinsic material rendering: the same property vector that drives simulation also drives texture. The diegetic channel is the rendering output itself.
+
+## Giant Flora Hazard Communication
+
+Hazard states within giant flora interiors must be communicated entirely through in-world observable behavior:
+
+- Visible flora movement as a seasonal or threat signal (closing petals, retracting tendrils)
+- Fauna presence or absence as an environmental indicator
+- Chemical visual effects in the atmosphere or on surfaces
+
+No popup. No HUD indicator. No text. If a flower is closing, the player sees it closing. If a chemical is being released, it has a visible presence in the space. The player reads the world; the world does not read itself aloud to the player.
+
+## Found Ship Brokenness
+
+The found ship expresses its repair needs through visible damage and inoperable systems, not through tutorial UI, objective markers, or explanatory text. A broken thruster looks broken. A dark console has no power. A cracked hull has a visible crack.
+
+The brokenness is self-evident by design. The player understands the repair task by inspecting the ship, not by reading a quest objective. This applies to every subsystem: each must have a visible broken state that communicates what is wrong without supplementary UI.

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/knowledge-driven-presentation.md
@@ -9,6 +9,16 @@ Knowledge state is a continuous spectrum (not boolean gates) that affects three 
 
 Every system must handle the full gradient from "player knows nothing" to "player knows everything."
 
+## Intrinsic Material Rendering vs Knowledge-Gated Rendering
+
+These are two different things and must not be conflated.
+
+**Intrinsic rendering** — terrain texture and surface detail are always the visual output of material property parameters. The rendering system derives texture from the same property vector that drives simulation. This output is unconditional: it does not change based on player knowledge state. What changes with knowledge is the player's ability to *interpret* what they see, not what the system shows.
+
+**Knowledge-gated rendering** — inspect panel detail, dialogue options, and fabrication availability change based on KnowledgeGraph state. These systems explicitly query the graph before deciding what to present.
+
+The rule: if a visual output is derived directly from a world property, it is intrinsic and always visible. If a UI or interaction element is conditioned on what the player knows, it queries the KnowledgeGraph.
+
 ## Architecture: KnowledgeGraph as Source of Truth
 
 **The KnowledgeGraph is the sole store for player knowledge.** The Journal is a stateless query layer over it — it holds no knowledge state of its own.
@@ -31,6 +41,10 @@ Any system that needs to know "what does the player know about X" must query the
 - **Revealed property flags** — which properties the player has observed on each node (density revealed on pickup, thermal resistance revealed by heat exposure, etc.)
 - **Sighting records** — where and when an entity was encountered (planet, tick)
 - **Confidence** — continuous f32 per observation, grows with repeated encounters
+
+### Observable Entities: No Special Case for Substrate Type
+
+Biological materials observed inside giant flora interiors are first-class graph nodes — same architecture as inorganic materials. The knowledge graph has no special case for material substrate type. A resin from inside a giant flower is recorded and queried the same way as a metallic ore from a cave wall.
 
 ## What Does NOT Belong on Entity Components
 


### PR DESCRIPTION
## Summary

GDD v1.1 requires two architecture doc updates to formalize terrain/flora/ship additions.

### knowledge-driven-presentation.md
- Added **Intrinsic Material Rendering vs Knowledge-Gated Rendering** section distinguishing unconditional property-derived rendering from KnowledgeGraph-conditioned presentation
- Added **Observable Entities: No Special Case for Substrate Type** subsection clarifying biological materials (e.g. flora interiors) are first-class graph nodes with identical architecture to inorganic materials

### diegetic-feedback.md
- Added **Terrain Texture as Diegetic Channel** — encodes material properties into texture by architectural rule; the rendering output IS the diegetic signal
- Added **Giant Flora Hazard Communication** — all hazard states communicated via in-world observable behavior only (no popup, no HUD, no text)
- Added **Found Ship Brokenness** — repair needs expressed through visible damage and inoperable systems, not tutorial UI or objective markers

Docs-only changes. No code modified.