### PR TITLE
docs: add FloraPlugin and ShipPlugin to architecture docs

### DIFF
--- a/docs/bmad/planning-artifacts/architecture/decisions/plugin-dependency-graph.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/plugin-dependency-graph.md
@@ -17,6 +17,21 @@ Core plugins form a mesh — they may depend on each other freely. This reflects
 
 **Leaf plugin definition:** A leaf plugin does not have Intent phase systems (InputPlugin owns intent emission) and does not define events consumed by core plugins. Leaves have Simulation systems (validate and process intents for their domain), WorldResponse systems (translate outcomes into diegetic feedback), and Presentation systems (rendering). Leaves consume core APIs. Leaves never import from other leaves.
 
+**Leaf Plugins:**
+
+| Plugin | Consumes (core) | Consumed by | Responsibility |
+|--------|-----------------|-------------|----------------|
+| `ScenePlugin` | — | — | Scene/camera setup |
+| `PlayerPlugin` | `InputPlugin`, `WorldGenerationPlugin` | — | Player entity, movement |
+| `CarryPlugin` → `InventoryPlugin` | `InputPlugin`, `MaterialPlugin` | — | Item carry/inventory (renamed Epic 4) |
+| `InteractionPlugin` | `InputPlugin`, `KnowledgePlugin` | — | General interaction dispatch |
+| `HeatPlugin` | `MaterialPlugin`, `WorldGenerationPlugin` | — | Material property simulation |
+| `FabricatorPlugin` | `InputPlugin`, `MaterialPlugin`, `KnowledgePlugin` | — | Input/output slot mechanics; owns fabrication core events |
+| `CombinationPlugin` | `InputPlugin`, `MaterialPlugin` | — | Material combination logic |
+| `JournalUIPlugin` | `KnowledgePlugin` | — | Presentation-phase journal rendering |
+| `FloraPlugin` | `WorldGenerationPlugin`, `MaterialPlugin`, `KnowledgePlugin` | — | Flora entity lifecycle, mesh-fidelity collision (consuming WorldGenerationPlugin region data), seasonal state simulation, biological material environment, interior base location support |
+| `ShipPlugin` | `KnowledgePlugin` | — | Ship entity state, broken component tracking, repair interaction handling via core-owned events from FabricatorPlugin, ship flight/travel. Hull repair emits observation events through KnowledgePlugin. Never imports FabricatorPlugin directly — leaf-never-imports-leaf rule. |
+
 **Core Graph (8 plugins):**
 
 | Plugin | Registers (Resources) | Registers (Events) | Registers (Components) | Notes |
@@ -53,6 +68,8 @@ app
     .add_plugins(FabricatorPlugin)
     .add_plugins(CombinationPlugin)
     .add_plugins(JournalUIPlugin)
+    .add_plugins(FloraPlugin)
+    .add_plugins(ShipPlugin)
 ```
 
 Registration order doesn't affect Bevy's runtime execution (SchedulingPlugin's system sets handle that). It documents the dependency direction for the next developer or agent reading `main.rs`.

--- a/docs/bmad/planning-artifacts/architecture/project-structure-boundaries.md
+++ b/docs/bmad/planning-artifacts/architecture/project-structure-boundaries.md
@@ -46,6 +46,8 @@ apeiron-cipher/
 │   │── fabricator.rs                    # FabricatorPlugin (leaf)
 │   │── combination.rs                   # CombinationPlugin (leaf)
 │   │── journal_ui.rs                    # JournalUIPlugin (leaf, new — Presentation phase)
+│   │── flora.rs                         # FloraPlugin — giant flora collision, seasonal state, biological material env
+│   │── ship.rs                          # ShipPlugin — found ship entity, repair state, fabrication integration
 │   │
 ├── tests/
 │   ├── common/
@@ -80,7 +82,9 @@ apeiron-cipher/
 │   │   └── world_generation_config.toml
 │   ├── biomes/                          # Biome generation parameters (TOML)
 │   ├── crafting/                        # Recipe templates (TOML)
-│   ├── exterior/                        # Surface generation data (TOML)
+│   ├── exterior/                        # Surface generation data (TOML). Note: terrain texture parameters derive from material property data; no separate texture files live here.
+│   ├── flora/                           # Giant flora structure definitions, biological material palette configs, hazard parameter files
+│   ├── vehicles/                        # Found ship definition and per-component repair schemas
 │   └── ...                              # New domains get new directories
 │   │
 ├── docs/
@@ -132,6 +136,8 @@ Each integration test file tests one plugin through its public API. The test har
 | Epic 11 — Material Science Depth | `materials.rs` + sub-modules (core) | Evolves from POC, adds registry + seed derivation |
 | Epic 12 — Crafting | `fabricator.rs`, `combination.rs` (leaves) | Consume MaterialPlugin + KnowledgePlugin APIs |
 | Epic 13 — Base Building | New leaf plugin(s) as needed | Consumes core APIs |
+| Epic 13 — Base Building | `flora.rs` (leaf) | `FloraPlugin` — interior base location support, giant flora collision |
+| GDD v1.1 — Ship Systems | `ship.rs` (leaf) | `ShipPlugin` — found ship entity, repair via FabricatorPlugin core events |
 
 **Infrastructure (created before/during Ring 1):**
 


### PR DESCRIPTION
## Summary

Adds FloraPlugin and ShipPlugin entries to the two architecture reference docs per GDD v1.1.

### plugin-dependency-graph.md
- Added leaf plugin table documenting all leaf plugins and their core dependencies
- FloraPlugin: consumes WorldGenerationPlugin, MaterialPlugin, KnowledgePlugin — flora lifecycle, collision, seasonal state, biological material env, interior base location
- ShipPlugin: consumes KnowledgePlugin — ship entity state, repair via FabricatorPlugin core-owned events (never imports FabricatorPlugin directly — leaf-never-imports-leaf rule)
- Added both to the `app.add_plugins` block

### project-structure-boundaries.md
- Added `src/flora.rs` and `src/ship.rs` to directory structure under leaf plugins
- Extended Epic Mapping table: FloraPlugin → Epic 13 (Base Building), ShipPlugin → GDD v1.1 Ship Systems
- Added `assets/flora/` and `assets/vehicles/` directories
- Annotated `assets/exterior/` with terrain texture derivation note

## Changes
- Docs only — no Rust source changes