### PR TITLE
docs: update authority-boundary-pattern, persistence, determinism-enforcement, and mirror-system for GDD v1.1

### DIFF
--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/determinism-enforcement.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/determinism-enforcement.md
@@ -1,3 +1,8 @@
 # Cross-Cutting Concern: Determinism Enforcement
 
 Seed-based generation must produce identical results given identical inputs. This constrains: RNG (seeded only), floating-point operations (platform-consistent), and any async operations that could introduce non-determinism. **System ordering requires an explicit strategy** — a documented schedule graph defining execution order for all gameplay systems, not just a general commitment. In Bevy, system ordering is the single most common source of subtle determinism bugs.
+
+**Deterministic pipeline requirements (additions with GDD v1.1):**
+
+- **Terrain texture derivation:** terrain texture parameters are part of the deterministic pipeline. The same `MaterialSeed` must produce the same texture parameters on every platform and every run. Texture parameter derivation is not exempt from platform-consistent floating-point rules.
+- **Flora mesh and collision geometry generation:** flora mesh and collision geometry generation is deterministic. The chain `FloraMeshSeed → mesh → collision` is a single deterministic pipeline. Platform-consistent floating-point rules apply to mesh vertex generation. Any platform-specific floating-point deviation in mesh generation produces divergent collision geometry, which is a physics authority violation.

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/mirror-system.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/mirror-system.md
@@ -1,3 +1,9 @@
 # Cross-Cutting Concern: Mirror System
 
 Observes player behavior across all gameplay systems and deepens the world in the direction of player interest. Every system that produces observable player actions must implement observation hooks. Not a standalone plugin — it is a cross-cutting contract.
+
+**Observable behaviors and Mirror responses (additions with GDD v1.1):**
+
+- **Giant flora inhabitation:** time spent in flora interiors, hazard interaction outcomes, and the choice to establish a base inside flora are all observable. If the player consistently inhabits flora, Mirror deepens flora presence and increases seasonal complexity in the world around them. Mirror hooks must be present from initial flora interior implementation.
+- **Ship repair engagement:** which components the player repairs first, which materials they prioritize, and total time spent on the ship are observable. Mirror hooks must be present from initial ship repair implementation — not deferred to a later pass. Observation during the repair arc informs how Mirror shapes subsequent world generation (e.g. density of compatible materials in new areas).
+- **Terrain material investigation:** if the player examines terrain texture as a form of material knowledge — identifying surface composition through visual inspection — Mirror increases the density of those material types in subsequently generated terrain. The observation hook must fire on material identification events, not just on pickup or fabrication.

--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/persistence.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/persistence.md
@@ -1,3 +1,8 @@
 # Cross-Cutting Concern: Persistence / Save Architecture
 
 Knowledge accumulation is the player's only progression; save corruption or loss is catastrophic and unrecoverable. The save system must: serialize deterministically, support version migration as schemas evolve, handle the full knowledge spectrum (not just checkpoints), and anticipate multiplayer save authority (distributed consensus problem in Ring 5). Persistence is not a late-stage feature — it is core infrastructure from Ring 1.
+
+**Required persistence scope (non-exhaustive, grows with each feature):**
+
+- **Giant flora base state:** player-placed structures inside flora interiors, flora seasonal open/closed state, and interior environmental state (atmospheric composition, light levels, chemical concentrations) must persist. Seasonal state is the product of simulation time accumulation — it must NOT be regenerated from seed on load. Regenerating from seed would erase the history of what happened to any player base inside.
+- **Found ship repair state:** per-component repair status, structural integrity, and flight capability must persist. This is the player's first fabrication history. Losing it on reload would destroy the meaning of the repair progression.

--- a/docs/bmad/planning-artifacts/architecture/decisions/authority-boundary-pattern.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/authority-boundary-pattern.md
@@ -36,12 +36,20 @@ All simulation outcomes — successes, failures, constraints, ambiguous results,
 
 **Every Simulation-level outcome must map to a visible, behavioral, or systemic in-world response** produced through Simulation → WorldResponse. All response events implement a `DiegeticResponse` marker trait for telemetry and test harness hookability. WorldResponse translates Simulation outcomes into:
 
-- **Physical reactions:** resistance, failure to transition state, instability, incomplete execution. The character strains against an object too heavy to lift. A fabricator sputters and stalls on incompatible materials. A structure buckles under unsupported weight.
+- **Physical reactions:** resistance, failure to transition state, instability, incomplete execution. The character strains against an object too heavy to lift. A fabricator sputters and stalls on incompatible materials. A structure buckles under unsupported weight. A giant flora structure closes around a player base: the interior compresses, materials react to the chemical environment change, fauna activates — no UI warning. The world is consistent.
 - **Systemic inconsistencies made observable:** subsystems disagreeing, partial activation, stalled processes. A crafting sequence begins but fails to reach completion. A heat source ignites one material but not the adjacent one. A mechanism engages partway and jams.
 - **Behavioral feedback loops:** attempt → resistance → resolution or failure. The player sees the full arc of the attempt, not a binary state change.
 - **Ambiguous and unexpected results:** Outcomes that are neither success nor failure. A material combination produces something — not what was expected, not nothing, an intermediate or surprising state. The world doesn't owe the player binary outcomes. Discovery lives in the space between intent and result.
 
 Each system expresses failure through its own physics and logic, not through a shared "rejection feedback" abstraction. The fabricator fails differently than lifting fails differently than navigation fails. Diegetic responses emerge from domain-specific behavior, not a generic feedback system.
+
+**Domain-specific intent type examples:**
+- `TryPickUp { entity: Entity }` — pickup, subject to weight and range validation
+- `TryCombine { a: Entity, b: Entity }` — material combination, subject to compatibility validation
+- `TryFabricate { ... }` — fabrication, subject to material availability and fabricator state
+- `TryRepairHull { component: Entity, material: Entity }` — hull repair, uses the same intent/simulation/worldresponse loop as TryFabricate. Not a special-cased tutorial action.
+
+Flora seasonal closure is a diegetic event: when a giant flora structure closes, any player base inside experiences it physically (compression, reduced light, chemical change, fauna activation). This is Simulation-driven mutation producing `WorldResponse` diegetic effects. No UI warning is given — the world communicates entirely through observable physical consequence.
 
 **Journal event log as diegetic understanding surface:**
 - The journal's chronological event log (Decision 1, third visualization layer) serves as the player's "what just happened?" interface.
@@ -49,7 +57,7 @@ Each system expresses failure through its own physics and logic, not through a s
 - The journal event log is the escape hatch for "what did that feedback mean?" It provides an understanding surface without breaking the no-explanation contract — the player is reading their own journal, not receiving system messages.
 - The event log never provides additional knowledge the player hasn't already observed. It re-presents what happened, not why.
 
-**Compliance rule:** A system that rejects an intent without producing a diegetic response is architecturally incomplete.
+**Compliance rule:** A system that rejects an intent without producing a diegetic response is architecturally incomplete. World-initiated state changes (flora closure, chemical shifts) that affect player structures must communicate through observable world behavior, not through text notifications or UI alerts.
 
 **The Accretion Test (foundational design constraint):**
 - When implementing a system, ask: "what does the player understand after this action that they didn't understand before?" If the answer is "nothing new," the action isn't earning its place. If the answer requires a UI notification to communicate, it's a reward moment, not accretion. Knowledge accumulates through consequence and observation, never through confirmation. Every architectural decision in this document is downstream of this constraint.


### PR DESCRIPTION
## Summary

Updates four cross-cutting architecture docs for GDD v1.1.

### authority-boundary-pattern.md
- Added flora seasonal closure as a concrete diegetic physical event example in the Physical reactions bullet
- Added domain-specific intent type examples section including `TryRepairHull { component: Entity, material: Entity }` alongside TryPickUp, TryCombine, TryFabricate
- Extended compliance rule to explicitly cover world-initiated state changes (flora closure, chemical shifts) communicating through observable world behavior only

### persistence.md
- Added giant flora base state: player-placed structures, flora seasonal open/closed state, interior environmental state — must persist (NOT regenerated from seed on load)
- Added found ship repair state: per-component repair status, structural integrity, flight capability — must persist as the player's first fabrication history

### determinism-enforcement.md
- Added terrain texture derivation: same MaterialSeed must produce same texture parameters on every platform and run
- Added flora mesh and collision geometry: FloraMeshSeed → mesh → collision is a single deterministic chain; platform-consistent floating-point rules apply to mesh vertex generation

### mirror-system.md
- Added giant flora inhabitation as observable (time in interiors, hazard interaction, basing choice)
- Added ship repair engagement as observable (components first, materials prioritized, time on ship) — hooks required from initial implementation
- Added terrain material investigation as observable — Mirror hook fires on material identification events, increases density of those material types in subsequent terrain

Closes kanban task t_cf9605e6