### PR TITLE
docs: update architecture docs for GDD v1.1 (terrain, flora, ships, material substrate)

### DIFF
--- a/docs/bmad/planning-artifacts/architecture/cross-cutting/asset-pipeline.md
+++ b/docs/bmad/planning-artifacts/architecture/cross-cutting/asset-pipeline.md
@@ -1,3 +1,9 @@
 # Cross-Cutting Concern: Asset Pipeline Architecture
 
 All game tuning and material properties reside in data files, making the asset pipeline the nervous system of the application. Must support: hot-reloading for dev iteration, versioned schemas for save/load compatibility across game versions, and async loading that does not break determinism guarantees. This is infrastructure that every plugin depends on.
+
+**Terrain texture derivation:**
+Terrain texture is generated at runtime from material property data. The pipeline supports this derivation path alongside hot-reloading for source material parameter files. There are no pre-authored terrain texture assets — the texture is a runtime output of the material property vector.
+
+**Flora collision geometry validation:**
+Flora mesh assets must have exact collision geometry derived from the visual surface mesh. No flora asset is accepted with bounding box or convex hull collision. The pipeline validates the presence of a surface-traced collision mesh on load.

--- a/docs/bmad/planning-artifacts/architecture/decisions/asset-pipeline-conventions.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/asset-pipeline-conventions.md
@@ -17,7 +17,8 @@
 - **Load-time (runtime layer):** Custom `AssetLoader` validates field ranges, required fields, and cross-references after deserialization. Invalid assets emit `error!()` through the tracing stack (Decision 3) and return a typed error. Bevy surfaces this as a failed asset handle. Systems check handle state and degrade gracefully — no panic on bad data.
 
 **Custom `AssetLoader` for all data files:**
-- Every data file type (`MaterialDefinition`, `CraftingRecipe`, `BiomeConfig`, `GameConfig`, etc.) gets a Bevy `AssetLoader` implementation. No manual serde-at-startup.
+- Every data file type (`MaterialDefinition`, `CraftingRecipe`, `BiomeConfig`, `GameConfig`, `FloraStructureDefinition`, `ShipDefinition`, `HullComponentDefinition`, etc.) gets a Bevy `AssetLoader` implementation. No manual serde-at-startup.
+- `FloraStructureDefinition` loader validation must assert that a surface-traced collision mesh is present. Bounding box and convex hull collision meshes are rejected.
 - Loader pipeline: read bytes → deserialize TOML/RON → check `schema_version` → migrate if needed → validate → return typed asset.
 - This provides Bevy's hot-reload, async loading, dependency tracking, and handle-based cross-references for free.
 - Registry Resources (Decision 1) are populated by systems reacting to `AssetEvent::Added` / `AssetEvent::Modified` — loaded assets propagate into registries automatically. Hot-reload propagates to registries through the same path.
@@ -33,6 +34,8 @@
 - `assets/biomes/` — biome/terrain definitions
 - `assets/crafting/` — recipes, fabricator configurations
 - `assets/exterior/` — surface generation data
+- `assets/flora/` — flora structure definitions
+- `assets/vehicles/` — ship and vehicle definitions
 - New gameplay domains get new top-level directories. Subdirectories within a domain only when file count exceeds ~20.
 
 **File conventions:**
@@ -40,4 +43,4 @@
 - No version numbers in filenames — version lives inside the file as `schema_version`.
 - TOML for anything a designer/player might edit. RON for serialized Bevy types where Reflect/serde roundtripping matters.
 
-**Rationale:** Custom `AssetLoader`s are the correct integration point for data-driven content in Bevy — they provide hot-reload, async loading, and handle-based dependency tracking without reimplementation. Schema versioning with mandatory migration (never rejection) ensures save compatibility across rings. Dual-layer validation catches errors both in CI (without launching the game) and at runtime (graceful degradation). The `AssetEvent`-driven registry population pattern connects the asset pipeline to Decision 1's registry architecture cleanly.
+**Rationale:** Custom `AssetLoader`s are the correct integration point for data-driven content in Bevy — they provide hot-reload, async loading, and handle-based dependency tracking without reimplementation. Schema versioning with mandatory migration (never rejection) ensures save compatibility across rings. Dual-layer validation catches errors both in CI (without launching the game) and at runtime (graceful degradation). The `AssetEvent`-driven registry population pattern connects the asset pipeline to Decision 1's registry architecture cleanly. Terrain texture parameters live in `assets/materials/` — they are the visual expression of material properties, not a separate art domain.

--- a/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/data-architecture.md
@@ -13,6 +13,7 @@
 - Entities carry lightweight ID components (`MaterialId`, `BiomeId`) for O(1) registry lookup
 - Material similarity computed directly on property vectors — no vector DB needed at this scale
 - Registries are effectively write-rarely, read-constantly — `Res<T>` access only after initial insertion
+- Terrain visual representation is a derived output of material property parameters at region load time — not pre-authored texture assets. Planet seed + position + material parameters → visual texture. No separate texture registry.
 
 **Player Knowledge (Journal, Encyclopedia, Associative Web):**
 - `KnowledgeGraph` resource backed by `petgraph::Graph` (not `StableGraph`), behind a trait interface for swappability — this is the **sole store** for all player knowledge; the Journal is a stateless query layer over it, not a parallel storage layer
@@ -41,5 +42,17 @@
 - Entity components may store transient world state (transform, held/placed status, current heat exposure, temporary visual reaction state) but must not store player knowledge state (`PropertyVisibility` on a `GameMaterial` is transient world state; what the player *knows* about that material lives exclusively in the KnowledgeGraph).
 - If two entities share the same property profile, learning a property from one sample makes that knowledge available everywhere the same profile is encountered — because knowledge is keyed by the KnowledgeGraph node for that observed instance, and the Journal query groups nodes by range-match at query time.
 - Planet of origin is recorded as a sighting on the KnowledgeGraph node, not encoded into any key or identifier.
+
+**Giant Flora Entity State:**
+- Mesh-fidelity collision data as entity component (not bounding box)
+- Seasonal phase as mutable entity state component
+- Interior biological material palette follows seed-derived registry, same as inorganic
+- Base locations within flora are region-scoped entities, not special-cased
+
+**Found Ship State:**
+- World-spawned entity at specific region location, not procedurally replicated
+- Broken component state stored as entity components
+- Hull materials follow material-identity model — seed-derived, no type at spawn
+- Ship repair generates KnowledgeGraph edges: used-in (material → fabrication event), fabrication event → installed component
 
 **Rationale:** The hybrid model separates immutable ground-truth (seed-derived, write-once registries) from mutable player progression (append-only knowledge graph). Registry lookups are O(1) via entity ID components. The knowledge graph uses a real graph library rather than hand-rolling adjacency lists, getting BFS traversal, connected components, and serde serialization for free. Journal visualization queries map directly to bounded graph operations.

--- a/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/material-identity-and-knowledge-model.md
@@ -58,6 +58,8 @@ Classification ranges live in `assets/` (data-driven, Core Principle 6). The Jou
 
 World generation uses planet seed + position to produce raw property values. Property values are what gets stored in the graph. Classification into named types ("iron", "ferrite") is a **query-time operation**, not a generation-time assignment.
 
+Material property values drive both gameplay simulation and visual representation. The same property vector produces both. The rendering system is a consumer of material property data, the same as heat simulation or fabrication. There is no separate cosmetic property set.
+
 ```
 planet_seed + position → raw property values → KnowledgeGraph node (on observation)
                                                       ↓
@@ -140,6 +142,9 @@ The correct architecture requires inverting the Journal/KnowledgeGraph relations
    - Story N.4: Material generation produces raw property values only — no type assignment at spawn
 
 5. **Classification** is always query-time, never generation-time. Material type names are never stored on entities or in the graph — they are the result of matching observed property values against asset-defined ranges.
+
+**Material Substrate Universality:**
+Biological materials (flora tissue, biological compounds, chemical secretions) follow the same architecture: seed-derived properties, classification by range-match, no type at spawn. Classification ranges in `assets/` must include biological categories. No special handling for material substrate.
 
 ---
 

--- a/docs/bmad/planning-artifacts/architecture/decisions/testing-architecture.md
+++ b/docs/bmad/planning-artifacts/architecture/decisions/testing-architecture.md
@@ -19,6 +19,9 @@
 
 **Seed-instance consistency tests:**
 - When the architecture says knowledge is seed-level (Decision 1 — Material Seed Canonicality), tests must prove that learning from one entity updates the behavior of other same-seed entities in inspect, journal, and other player-facing systems. If two entities share a seed and a property is discovered on one, the second entity must reflect that knowledge immediately. This is an explicit test category, not an implied consequence.
+- **Terrain texture determinism:** Same `MaterialSeed` → same `TerrainTextureSeed` → same texture parameters across two independent runs. Golden file for a known `MaterialSeed` value.
+- **Ship repair fabrication path equivalence:** `TryRepairHull` and `TryFabricate` use the same underlying material-to-component validation. Integration test with equivalent inputs to both, asserting the same validation fires.
+- **Flora seasonal + base invalidation:** Integration test advancing to a flora-closing event, asserting a `DiegeticResponse` event is emitted, and asserting no UI text event is emitted.
 
 **Unified test harness** — shared utilities in `tests/common/mod.rs`:
 - **App builders provide infrastructure only, NOT the plugin under test.** Builders configure `SchedulingPlugin` + a `TestObservabilityPlugin` that replaces the production tracing stack with the `Vec<LogEvent>` capture layer. Each integration test file adds its own plugin: `app.add_plugins(MaterialPlugin)`. This enforces the per-plugin-boundary rule from Decision 5.
@@ -26,7 +29,7 @@
 - **Event assertions:** `assert_event_emitted::<T>(&app)`, `assert_no_event::<T>(&app)`. Wraps the boilerplate of reading `Events<T>` from the world.
 - **Fixture utilities:** Load helpers for reading golden files and input fixtures from `tests/fixtures/`.
 - **Determinism helpers:** Run-compare utility that executes a closure twice with identical inputs and asserts output equality.
-- **Diegetic compliance enforcement — automatic, not opt-in.** The test harness automatically validates diegetic compliance on every integration test run. After each test's tick execution, the harness iterates all `Intent`-marked events fired during the test and asserts a corresponding `DiegeticResponse`-marked event exists for each. A system that rejects an intent without producing a diegetic response fails the test automatically. No plugin opts into this — the harness enforces it globally.
+- **Diegetic compliance enforcement — automatic, not opt-in.** The test harness automatically validates diegetic compliance on every integration test run. After each test's tick execution, the harness iterates all `Intent`-marked events fired during the test and asserts a corresponding `DiegeticResponse`-marked event exists for each. A system that rejects an intent without producing a diegetic response fails the test automatically. No plugin opts into this — the harness enforces it globally. Diegetic compliance enforcement covers world-initiated events (flora closure, chemical change) in addition to player-initiated intents.
 
 **Test parallelism (documented, not configured):** Cargo runs integration test files as separate binaries in parallel. Tests within each binary run serially. For Bevy testing with `App` instances, serial-within-binary is correct — each test gets its own `App`, no shared global state. This is Cargo's default behavior and is the correct behavior for this project.
 
@@ -48,6 +51,7 @@
 - **Not part of `make check`.** Fuzz tests explore the seed space and input space stochastically — they're for intentional exploration sessions, not CI gates. A separate `make fuzz` target runs them.
 - **Primary candidates:** Material seed derivation (invariants hold across random seeds), knowledge graph operations (append-only growth invariant, no orphan edges), world generation (determinism invariant across random seeds), intent validation (no panic on arbitrary input combinations).
 - **Invariant-style assertions only.** Fuzz tests don't assert specific outputs. They assert invariants: "for any seed, derived material density is within [0.0, max]", "for any sequence of DiscoveryEvents, the knowledge graph has no orphan edges."
+- **Flora collision geometry invariant:** For any `GiantFloraSeed`, collision geometry must not be a bounding box or convex hull. If the mesh has concave regions (e.g. an open flower top), the collision mesh must also be concave. The test asserts the AABB of the collision geometry contains open space not blocked by collision faces.
 
 **Benchmark testing — baseline from Ring 1, separate suite:**
 - `criterion` as a dev-dependency. Benchmarks in `benches/` directory (standard Cargo convention).


### PR DESCRIPTION
## Summary

GDD v1.1 additions reflected across 5 architecture docs.

### data-architecture.md
- Terrain visual representation is a derived output of material property parameters — no separate texture registry
- Giant Flora Entity State: mesh-fidelity collision, seasonal phase component, biological material palette via seed-derived registry, region-scoped base locations
- Found Ship State: region-spawned entity, broken component state as ECS components, seed-derived hull materials, KnowledgeGraph repair edges

### material-identity-and-knowledge-model.md
- Material property vector drives both gameplay simulation and visual rendering — no separate cosmetic property set
- Material Substrate Universality: biological materials follow same seed-derived/range-match architecture, no special handling, biological categories required in assets/

### asset-pipeline.md
- Terrain texture derivation path supported alongside hot-reload for material parameter files
- Flora mesh assets must have surface-traced collision geometry; bounding box/convex hull rejected at pipeline validation

### asset-pipeline-conventions.md
- Added `assets/flora/` and `assets/vehicles/` to directory structure
- Added `FloraStructureDefinition` (with surface-traced collision assertion), `ShipDefinition`, `HullComponentDefinition` to AssetLoader list
- Rationale updated: terrain texture params live in `assets/materials/`, not a separate art domain

### testing-architecture.md
- Property-based test: flora collision geometry invariant (AABB open space check for any GiantFloraSeed)
- Seed-consistency test: terrain texture determinism (MaterialSeed → TerrainTextureSeed → texture params, golden file)
- Seed-consistency test: ship repair fabrication path equivalence (TryRepairHull and TryFabricate use same validation)
- Seed-consistency test: flora seasonal + base invalidation (DiegeticResponse emitted, no UI text event)
- Diegetic compliance enforcement extended to world-initiated events (flora closure, chemical change)

Closes kanban task t_bfb60f91