### PR TITLE
feat(persistence): add Serialize/Deserialize to domain component types

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -204,10 +204,25 @@ pub struct InCarry;
 /// - future persistence or ownership tags
 ///
 /// Starting with a struct now avoids rewriting every caller later.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CarriedItem {
     /// The ECS entity representing this carried material.
+    ///
+    /// Entity IDs are runtime-only handles — they are meaningless across
+    /// sessions and cannot be serialised faithfully. This field is skipped
+    /// during serialisation; on deserialisation it is restored to
+    /// [`Entity::PLACEHOLDER`] and must be re-linked to a live entity by the
+    /// persistence load system.
+    #[serde(skip, default = "entity_placeholder")]
     pub entity: Entity,
+}
+
+/// Returns [`Entity::PLACEHOLDER`] for use as a `serde(default)` function.
+///
+/// `serde`'s `default = "..."` attribute requires a zero-argument function path;
+/// associated constants cannot be used directly. This wrapper bridges the gap.
+fn entity_placeholder() -> Entity {
+    Entity::PLACEHOLDER
 }
 
 impl CarriedItem {
@@ -223,7 +238,7 @@ impl CarriedItem {
 /// `effective_capacity` is the presently usable capacity after applying the
 /// current carry-device rule. Later stories may change that value over time as
 /// devices are equipped or strength accretes.
-#[derive(Component, Clone, Debug, PartialEq)]
+#[derive(Component, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CarryState {
     /// Sum of density values for all items currently in carry.
     pub current_weight: f32,
@@ -363,7 +378,7 @@ impl CarryState {
 /// player starts with an explicit, configurable strength value instead of future
 /// stories inventing one ad hoc. Growth rate is owned by [`CarryConfig`], not
 /// duplicated here, since it is a tuning constant rather than mutable player state.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CarryStrength {
     /// The player's current carry strength value (grows over time while carrying weight).
     pub current: f32,
@@ -375,7 +390,7 @@ pub struct CarryStrength {
 /// This is intentionally modeled as item identity rather than a boolean because
 /// the design direction is "carry may come from a real fabricated or acquired
 /// object later," not "carry is always an innate stat."
-#[derive(Component, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Component, Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 struct CarryDeviceState {
     pub required_item_key: Option<String>,
     pub equipped_item_key: Option<String>,
@@ -2285,5 +2300,62 @@ exponent = 1.0
                 other => panic!("{label}: expected JournalKey::MaterialInstance, got {other:?}"),
             }
         }
+    }
+
+    // ── Serde round-trip tests ────────────────────────────────────────────
+
+    #[test]
+    fn carried_item_serde_round_trip_entity_skipped() {
+        let item = CarriedItem {
+            entity: Entity::from_bits(42),
+        };
+        let json = serde_json::to_string(&item).expect("CarriedItem must serialise");
+        let restored: CarriedItem =
+            serde_json::from_str(&json).expect("CarriedItem must deserialise");
+        // The entity field is skipped — the restored value is the placeholder.
+        assert_eq!(restored.entity, Entity::PLACEHOLDER);
+    }
+
+    #[test]
+    fn carry_state_serde_round_trip() {
+        let state = CarryState {
+            current_weight: 3.5,
+            effective_capacity: 10.0,
+            hard_limit_enabled: true,
+            carried_items: vec![CarriedItem {
+                entity: Entity::from_bits(1),
+            }],
+        };
+        let json = serde_json::to_string(&state).expect("CarryState must serialise");
+        let restored: CarryState =
+            serde_json::from_str(&json).expect("CarryState must deserialise");
+        assert_eq!(restored.current_weight, state.current_weight);
+        assert_eq!(restored.effective_capacity, state.effective_capacity);
+        assert_eq!(restored.hard_limit_enabled, state.hard_limit_enabled);
+        assert_eq!(restored.carried_items.len(), state.carried_items.len());
+        // Entities are skipped, so they come back as PLACEHOLDER.
+        assert_eq!(restored.carried_items[0].entity, Entity::PLACEHOLDER);
+    }
+
+    #[test]
+    fn carry_strength_serde_round_trip() {
+        let strength = CarryStrength { current: 2.75 };
+        let json = serde_json::to_string(&strength).expect("CarryStrength must serialise");
+        let restored: CarryStrength =
+            serde_json::from_str(&json).expect("CarryStrength must deserialise");
+        assert_eq!(restored.current, strength.current);
+    }
+
+    #[test]
+    fn carry_device_state_serde_round_trip() {
+        let state = CarryDeviceState {
+            required_item_key: Some("carry-pack".to_string()),
+            equipped_item_key: Some("carry-pack".to_string()),
+        };
+        let json = serde_json::to_string(&state).expect("CarryDeviceState must serialise");
+        let restored: CarryDeviceState =
+            serde_json::from_str(&json).expect("CarryDeviceState must deserialise");
+        assert_eq!(restored.required_item_key, state.required_item_key);
+        assert_eq!(restored.equipped_item_key, state.equipped_item_key);
     }
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1098,6 +1098,30 @@ pub struct ConfidenceTracker {
     counts: HashMap<ObsKey, u32>,
 }
 
+// Manual Serialize/Deserialize for ConfidenceTracker.
+//
+// `HashMap<(u64, PropertyName), u32>` cannot be serialised with serde_json's default
+// HashMap serialiser because JSON object keys must be strings, not tuples.  We
+// represent the map as a flat `Vec<((u64, PropertyName), u32)>` instead, which is
+// portable across all serde formats (JSON, bincode, …).
+#[allow(deprecated)]
+impl serde::Serialize for ConfidenceTracker {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let pairs: Vec<(&ObsKey, &u32)> = self.counts.iter().collect();
+        pairs.serialize(serializer)
+    }
+}
+
+#[allow(deprecated)]
+impl<'de> serde::Deserialize<'de> for ConfidenceTracker {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let pairs: Vec<(ObsKey, u32)> = Vec::deserialize(deserializer)?;
+        Ok(ConfidenceTracker {
+            counts: pairs.into_iter().collect(),
+        })
+    }
+}
+
 // Implementing methods on a deprecated type requires suppressing the deprecation warning on
 // the impl block itself. ConfidenceTracker is deprecated in favour of journal-based
 // RecordObservation messages but the impl must remain compilable during the migration
@@ -3303,5 +3327,36 @@ mod tests {
         // weight: 0.3 + (1.0 - 0.3) * (0.2 * 0.7) = 0.3 + 0.7 * 0.14 = 0.3 + 0.098 = 0.398
         let expected_weight = 0.3 + (1.0 - 0.3) * (0.2 * 0.7);
         assert!((weight_confidence.0 - expected_weight).abs() < 0.001);
+    }
+
+    // ── Serde round-trip tests ────────────────────────────────────────────
+
+    #[test]
+    #[allow(deprecated)]
+    fn confidence_tracker_serde_round_trip() {
+        let mut tracker = ConfidenceTracker::default();
+        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(7, PropertyName::Density);
+
+        let json = serde_json::to_string(&tracker).expect("ConfidenceTracker must serialise");
+        let restored: ConfidenceTracker =
+            serde_json::from_str(&json).expect("ConfidenceTracker must deserialise");
+
+        assert_eq!(
+            restored.count(42, PropertyName::ThermalResistance),
+            2,
+            "ThermalResistance count must survive round-trip"
+        );
+        assert_eq!(
+            restored.count(7, PropertyName::Density),
+            1,
+            "Density count must survive round-trip"
+        );
+        assert_eq!(
+            restored.count(99, PropertyName::Density),
+            0,
+            "unseen key must return zero"
+        );
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,6 +13,7 @@
 use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, CursorOptions};
 use leafwing_input_manager::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::carry::CarryMovementState;
 use crate::input::InputAction;
@@ -36,7 +37,7 @@ const PLAYER_COLLISION_RADIUS: f32 = 0.2;
 ///
 /// This is intentionally enough to make weight feel physical without pretending
 /// we already have the final progression system.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 struct StaminaState {
     pub current: f32,
     pub max: f32,
@@ -618,5 +619,20 @@ mod tests {
     fn calculate_effective_speed_zero_modifier() {
         let result = calculate_effective_speed(5.0, 0.0, true, 2.0);
         assert_eq!(result, 0.0);
+    }
+
+    // ── Serde round-trip tests ────────────────────────────────────────────
+
+    #[test]
+    fn stamina_state_serde_round_trip() {
+        let state = StaminaState {
+            current: 0.75,
+            max: 1.0,
+        };
+        let json = serde_json::to_string(&state).expect("StaminaState must serialise");
+        let restored: StaminaState =
+            serde_json::from_str(&json).expect("StaminaState must deserialise");
+        assert_eq!(restored.current, state.current);
+        assert_eq!(restored.max, state.max);
     }
 }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -371,7 +371,7 @@ struct ChunkRemovalDeltas {
 /// Unlike [`GeneratedObjectId`], which is derived deterministically from the
 /// world seed, player-added IDs are simply sequential. They only need to be
 /// unique within a single session (and eventually within a save file).
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Serialize, Deserialize)]
 struct PlayerAddedIdCounter {
     next_id: u64,
 }

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -4134,3 +4134,23 @@ fn higher_weight_palette_entry_appears_more_often() {
         );
     }
 }
+
+// ── Serde round-trip tests ────────────────────────────────────────────────────
+
+#[test]
+fn player_added_id_counter_serde_round_trip() {
+    let mut counter = PlayerAddedIdCounter::default();
+    counter.next(); // advance to 1
+    counter.next(); // advance to 2
+
+    let json = serde_json::to_string(&counter).expect("PlayerAddedIdCounter must serialise");
+    let mut restored: PlayerAddedIdCounter =
+        serde_json::from_str(&json).expect("PlayerAddedIdCounter must deserialise");
+
+    // Counter resumes from the serialised value, not from zero.
+    assert_eq!(
+        restored.next(),
+        2,
+        "counter should resume at 2 after round-trip"
+    );
+}


### PR DESCRIPTION
## Summary

Closes task t_81f66790.

Adds `serde::Serialize + serde::Deserialize` to the component and resource types that the persistence layer will need to snapshot and restore:

| Type | File | Notes |
|------|------|-------|
| `CarriedItem` | `src/carry.rs` | Entity field `#[serde(skip, default = "entity_placeholder")]` — Entity is a runtime handle; restored to `Entity::PLACEHOLDER` on load, must be re-linked by the load system. Adds `entity_placeholder()` helper fn. |
| `CarryState` | `src/carry.rs` | Depends on CarriedItem being serializable |
| `CarryStrength` | `src/carry.rs` | Trivial f32 wrapper |
| `CarryDeviceState` | `src/carry.rs` | `Option<String>` fields |
| `ConfidenceTracker` | `src/observation.rs` | Manual Serialize/Deserialize impl — HashMap keys are `(u64, PropertyName)` tuples which JSON cannot use as object keys. Serialized as `Vec<(ObsKey, u32)>` pairs instead. |
| `StaminaState` | `src/player.rs` | Added `use serde::{Deserialize, Serialize};` import |
| `PlayerAddedIdCounter` | `src/world_generation/exterior.rs` | u64 counter |

## Tests

Round-trip test added for every type, following the existing `*_serde_round_trip` naming convention used throughout the codebase:

- `carried_item_serde_round_trip_entity_skipped`
- `carry_state_serde_round_trip`
- `carry_strength_serde_round_trip`
- `carry_device_state_serde_round_trip`
- `confidence_tracker_serde_round_trip`
- `stamina_state_serde_round_trip`
- `player_added_id_counter_serde_round_trip`

`cargo test serde` → **19 passed, 0 failed** (7 new + 12 pre-existing)  
Full suite → **714 lib + 27 integration + 5 doctests, 0 failed**

## Design notes

- No new dependencies added (serde and serde_json were already present)
- `ConfidenceTracker` is deprecated — manual impls sit alongside the existing struct without touching the deprecated API surface
- `Entity` fields are intentionally skipped; persistence load systems must re-link handles after deserializing