### PR TITLE
refactor: migrate MaterialCatalog and ConfidenceTracker to MaterialSeed

### DIFF
--- a/src/materials.rs
+++ b/src/materials.rs
@@ -38,6 +38,13 @@ use crate::world_generation::PlanetSeed;
 /// `MaterialSeed`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub struct MaterialSeed(pub u64);
+
+impl std::fmt::Display for MaterialSeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#018x}", self.0)
+    }
+}
+
 /// Registers the material data model, catalog, and world-object spawning systems.
 pub struct MaterialPlugin;
 
@@ -471,9 +478,9 @@ pub fn derive_material_from_seed(seed: u64) -> GameMaterial {
 #[derive(Resource, Debug, Default)]
 pub struct MaterialCatalog {
     /// Primary index: seed → material.
-    by_seed: HashMap<u64, GameMaterial>,
+    by_seed: HashMap<MaterialSeed, GameMaterial>,
     /// Secondary index: name → seed (for name-based lookups).
-    by_name: HashMap<String, u64>,
+    by_name: HashMap<String, MaterialSeed>,
 }
 
 impl MaterialCatalog {
@@ -484,13 +491,13 @@ impl MaterialCatalog {
     /// entry unchanged.  If the procedurally generated name collides with a
     /// *different* seed's material, a deterministic disambiguator derived from
     /// the seed is appended (e.g. `"Vexorite-a3f1"`) until the name is unique.
-    pub fn derive_and_register(&mut self, seed: u64) -> &GameMaterial {
+    pub fn derive_and_register(&mut self, seed: MaterialSeed) -> &GameMaterial {
         // Fast path: already registered by seed — O(1) lookup.
         if self.by_seed.contains_key(&seed) {
             return &self.by_seed[&seed];
         }
 
-        let mut mat = derive_material_from_seed(seed);
+        let mut mat = derive_material_from_seed(seed.0);
         mat.name = Self::disambiguated_name(&mat.name, seed, &self.by_name);
         self.by_name.insert(mat.name.clone(), seed);
         self.by_seed.insert(seed, mat);
@@ -504,21 +511,21 @@ impl MaterialCatalog {
     /// material is inserted after applying name disambiguation, and a reference
     /// to the newly-inserted entry is returned.
     pub fn register_fabricated(&mut self, mut mat: GameMaterial) -> &GameMaterial {
-        if self.by_seed.contains_key(&mat.seed) {
-            return &self.by_seed[&mat.seed];
+        let key = MaterialSeed(mat.seed);
+        if self.by_seed.contains_key(&key) {
+            return &self.by_seed[&key];
         }
 
-        mat.name = Self::disambiguated_name(&mat.name, mat.seed, &self.by_name);
-        let seed = mat.seed;
-        self.by_name.insert(mat.name.clone(), seed);
-        self.by_seed.insert(seed, mat);
-        &self.by_seed[&seed]
+        mat.name = Self::disambiguated_name(&mat.name, key, &self.by_name);
+        self.by_name.insert(mat.name.clone(), key);
+        self.by_seed.insert(key, mat);
+        &self.by_seed[&key]
     }
 
     /// Look up a material by its seed, returning `None` if not yet registered.
     #[allow(dead_code)]
     pub fn get_by_seed(&self, seed: MaterialSeed) -> Option<&GameMaterial> {
-        self.by_seed.get(&seed.0)
+        self.by_seed.get(&seed)
     }
 
     /// Look up a material by its display name, returning `None` if not found.
@@ -553,7 +560,7 @@ impl MaterialCatalog {
 
     /// Iterate over all seeds in the catalog.
     #[allow(dead_code)]
-    pub fn seeds(&self) -> impl Iterator<Item = &u64> {
+    pub fn seeds(&self) -> impl Iterator<Item = &MaterialSeed> {
         self.by_seed.keys()
     }
 
@@ -566,8 +573,8 @@ impl MaterialCatalog {
     /// seed representation which is unique by definition (different seeds).
     fn disambiguated_name(
         base_name: &str,
-        seed: u64,
-        existing_names: &HashMap<String, u64>,
+        seed: MaterialSeed,
+        existing_names: &HashMap<String, MaterialSeed>,
     ) -> String {
         if !existing_names.contains_key(base_name) {
             return base_name.to_owned();
@@ -575,7 +582,7 @@ impl MaterialCatalog {
 
         // Try successive 16-bit windows of the seed as a 4-hex-char suffix.
         for shift in (0..64).step_by(16) {
-            let fragment = (seed >> shift) as u16;
+            let fragment = (seed.0 >> shift) as u16;
             let candidate = format!("{base_name}-{fragment:04x}");
             if !existing_names.contains_key(&candidate) {
                 return candidate;
@@ -583,7 +590,7 @@ impl MaterialCatalog {
         }
 
         // Ultimate fallback: full seed hex (guaranteed unique for distinct seeds).
-        format!("{base_name}-{seed:016x}")
+        format!("{base_name}-{:016x}", seed.0)
     }
 }
 
@@ -609,7 +616,7 @@ fn load_material_catalog(mut commands: Commands) {
     // scenes (which spawn material objects at PostStartup) have something to
     // display before exterior chunk generation populates the catalog further.
     for mat in WellKnownMaterial::all() {
-        catalog.derive_and_register(mat.seed());
+        catalog.derive_and_register(MaterialSeed(mat.seed()));
     }
 
     info!(
@@ -952,8 +959,8 @@ visibility = "Hidden"
     #[test]
     fn derive_and_register_returns_same_entry_for_same_seed() {
         let mut catalog = MaterialCatalog::default();
-        let name1 = catalog.derive_and_register(42).name.clone();
-        let name2 = catalog.derive_and_register(42).name.clone();
+        let name1 = catalog.derive_and_register(MaterialSeed(42)).name.clone();
+        let name2 = catalog.derive_and_register(MaterialSeed(42)).name.clone();
         assert_eq!(name1, name2);
         assert_eq!(catalog.len(), 1);
     }
@@ -968,10 +975,12 @@ visibility = "Hidden"
         let mut imposter = derive_material_from_seed(0xBEEF);
         imposter.name = base_name.clone();
         imposter.seed = 0xBEEF; // different seed, same name
-        catalog.by_name.insert(base_name.clone(), 0xBEEF);
-        catalog.by_seed.insert(0xBEEF, imposter);
+        catalog
+            .by_name
+            .insert(base_name.clone(), MaterialSeed(0xBEEF));
+        catalog.by_seed.insert(MaterialSeed(0xBEEF), imposter);
 
-        let registered = catalog.derive_and_register(999);
+        let registered = catalog.derive_and_register(MaterialSeed(999));
         // Name must differ from the pre-existing entry.
         assert_ne!(registered.name, base_name);
         // Must contain the base name as a prefix with a hex suffix.
@@ -992,16 +1001,19 @@ visibility = "Hidden"
     #[test]
     fn disambiguated_name_no_collision_returns_base() {
         let existing = HashMap::new();
-        let result = MaterialCatalog::disambiguated_name("Vexorite", 42, &existing);
+        let result = MaterialCatalog::disambiguated_name("Vexorite", MaterialSeed(42), &existing);
         assert_eq!(result, "Vexorite");
     }
 
     #[test]
     fn disambiguated_name_with_collision_appends_suffix() {
-        let mut existing: HashMap<String, u64> = HashMap::new();
-        existing.insert("Vexorite".to_string(), 0xAAAA);
-        let result =
-            MaterialCatalog::disambiguated_name("Vexorite", 0x1234_5678_9ABC_DEF0, &existing);
+        let mut existing: HashMap<String, MaterialSeed> = HashMap::new();
+        existing.insert("Vexorite".to_string(), MaterialSeed(0xAAAA));
+        let result = MaterialCatalog::disambiguated_name(
+            "Vexorite",
+            MaterialSeed(0x1234_5678_9ABC_DEF0),
+            &existing,
+        );
         assert_eq!(result, "Vexorite-def0");
     }
 
@@ -1018,7 +1030,7 @@ visibility = "Hidden"
             .collect();
 
         for &seed in &seeds {
-            catalog.derive_and_register(seed);
+            catalog.derive_and_register(MaterialSeed(seed));
         }
 
         // Every entry in the catalog must have a unique name (dual-index
@@ -1040,10 +1052,10 @@ visibility = "Hidden"
 
     #[test]
     fn disambiguated_name_deterministic() {
-        let mut existing: HashMap<String, u64> = HashMap::new();
-        existing.insert("Coranite".to_string(), 0xBBBB);
-        let a = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
-        let b = MaterialCatalog::disambiguated_name("Coranite", 777, &existing);
+        let mut existing: HashMap<String, MaterialSeed> = HashMap::new();
+        existing.insert("Coranite".to_string(), MaterialSeed(0xBBBB));
+        let a = MaterialCatalog::disambiguated_name("Coranite", MaterialSeed(777), &existing);
+        let b = MaterialCatalog::disambiguated_name("Coranite", MaterialSeed(777), &existing);
         assert_eq!(a, b);
     }
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1073,7 +1073,7 @@ pub enum PropertyName {
 }
 
 /// Canonical key: (material seed, property name).
-type ObsKey = (u64, PropertyName);
+type ObsKey = (MaterialSeed, PropertyName);
 
 /// Stores how many times the player has observed each (material, property)
 /// combination through environmental testing.
@@ -1116,7 +1116,7 @@ impl ConfidenceTracker {
     // Retained for backward compatibility while call-sites migrate to journal-based
     // RecordObservation messages. Remove once all consumers are migrated.
     #[allow(dead_code)]
-    pub fn record(&mut self, seed: u64, property: PropertyName) -> u32 {
+    pub fn record(&mut self, seed: MaterialSeed, property: PropertyName) -> u32 {
         let key = (seed, property);
         let count = self.counts.entry(key).or_insert(0);
         *count += 1;
@@ -1133,7 +1133,7 @@ impl ConfidenceTracker {
     )]
     /// Kept for API compatibility during transition to journal-based confidence tracking.
     #[allow(dead_code)]
-    pub fn count(&self, seed: u64, property: PropertyName) -> u32 {
+    pub fn count(&self, seed: MaterialSeed, property: PropertyName) -> u32 {
         self.counts.get(&(seed, property)).copied().unwrap_or(0)
     }
 
@@ -1146,7 +1146,7 @@ impl ConfidenceTracker {
         note = "Use Confidence in journal observations instead of ConfidenceLevel"
     )]
     #[allow(dead_code)]
-    pub fn level(&self, seed: u64, property: PropertyName) -> ConfidenceLevel {
+    pub fn level(&self, seed: MaterialSeed, property: PropertyName) -> ConfidenceLevel {
         ConfidenceLevel::from_count(self.count(seed, property))
     }
 }
@@ -1427,33 +1427,54 @@ mod tests {
     #[test]
     fn fresh_tracker_has_zero_count() {
         let tracker = ConfidenceTracker::default();
-        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 0);
+        assert_eq!(
+            tracker.count(MaterialSeed(42), PropertyName::ThermalResistance),
+            0
+        );
     }
 
     #[test]
     fn record_increments_count() {
         let mut tracker = ConfidenceTracker::default();
-        assert_eq!(tracker.record(42, PropertyName::ThermalResistance), 1);
-        assert_eq!(tracker.record(42, PropertyName::ThermalResistance), 2);
-        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 2);
+        assert_eq!(
+            tracker.record(MaterialSeed(42), PropertyName::ThermalResistance),
+            1
+        );
+        assert_eq!(
+            tracker.record(MaterialSeed(42), PropertyName::ThermalResistance),
+            2
+        );
+        assert_eq!(
+            tracker.count(MaterialSeed(42), PropertyName::ThermalResistance),
+            2
+        );
     }
 
     #[test]
     fn different_seeds_tracked_independently() {
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(42, PropertyName::ThermalResistance);
-        tracker.record(99, PropertyName::ThermalResistance);
-        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 1);
-        assert_eq!(tracker.count(99, PropertyName::ThermalResistance), 1);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(99), PropertyName::ThermalResistance);
+        assert_eq!(
+            tracker.count(MaterialSeed(42), PropertyName::ThermalResistance),
+            1
+        );
+        assert_eq!(
+            tracker.count(MaterialSeed(99), PropertyName::ThermalResistance),
+            1
+        );
     }
 
     #[test]
     fn different_properties_tracked_independently() {
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(42, PropertyName::ThermalResistance);
-        tracker.record(42, PropertyName::Density);
-        assert_eq!(tracker.count(42, PropertyName::ThermalResistance), 1);
-        assert_eq!(tracker.count(42, PropertyName::Density), 1);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::Density);
+        assert_eq!(
+            tracker.count(MaterialSeed(42), PropertyName::ThermalResistance),
+            1
+        );
+        assert_eq!(tracker.count(MaterialSeed(42), PropertyName::Density), 1);
     }
 
     #[test]
@@ -1470,27 +1491,27 @@ mod tests {
     fn level_method_uses_internal_count() {
         let mut tracker = ConfidenceTracker::default();
         assert_eq!(
-            tracker.level(42, PropertyName::ThermalResistance),
+            tracker.level(MaterialSeed(42), PropertyName::ThermalResistance),
             ConfidenceLevel::Tentative
         );
-        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, PropertyName::ThermalResistance),
+            tracker.level(MaterialSeed(42), PropertyName::ThermalResistance),
             ConfidenceLevel::Tentative
         );
-        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, PropertyName::ThermalResistance),
+            tracker.level(MaterialSeed(42), PropertyName::ThermalResistance),
             ConfidenceLevel::Observed
         );
-        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, PropertyName::ThermalResistance),
+            tracker.level(MaterialSeed(42), PropertyName::ThermalResistance),
             ConfidenceLevel::Observed
         );
-        tracker.record(42, PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
         assert_eq!(
-            tracker.level(42, PropertyName::ThermalResistance),
+            tracker.level(MaterialSeed(42), PropertyName::ThermalResistance),
             ConfidenceLevel::Confident
         );
     }

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -56,7 +56,7 @@ use super::{
 };
 use crate::carry::InCarry;
 use crate::interaction::HeldItem;
-use crate::materials::{GameMaterial, MaterialCatalog, MaterialObject};
+use crate::materials::{GameMaterial, MaterialCatalog, MaterialObject, MaterialSeed};
 use crate::scene::{ExteriorGroundPatch, PositionXZ, RectXZ};
 use crate::seed_util::lerp;
 
@@ -632,7 +632,7 @@ fn sync_active_exterior_chunks(
             }
 
             let mut deposit_material = material_catalog
-                .derive_and_register(placement.material_seed)
+                .derive_and_register(MaterialSeed(placement.material_seed))
                 .clone();
             // Tag the spawn origin so observation systems can wire the FoundOn
             // KnowledgeGraph edge and the CurrentPlanet journal filter can match.

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -2632,7 +2632,7 @@ fn deposit_site_has_no_material_key_field() {
 ///    high).
 #[test]
 fn first_chunk_generation_populates_catalog_from_biome_palette() {
-    use crate::materials::MaterialCatalog;
+    use crate::materials::{MaterialCatalog, MaterialSeed};
 
     let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
     let biome = ChunkBiome {
@@ -2696,7 +2696,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     );
 
     for placement in &valid_placements {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
     }
 
     // 1. Catalog is no longer empty.
@@ -2706,7 +2706,8 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     );
 
     // 2. Every registered seed belongs to the biome palette.
-    let palette_seed_set: HashSet<u64> = palette_seeds.iter().copied().collect();
+    let palette_seed_set: HashSet<MaterialSeed> =
+        palette_seeds.iter().copied().map(MaterialSeed).collect();
     for seed in mat_catalog.seeds() {
         assert!(
             palette_seed_set.contains(seed),
@@ -2725,7 +2726,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
 
 #[test]
 fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
-    use crate::materials::MaterialCatalog;
+    use crate::materials::{MaterialCatalog, MaterialSeed};
 
     let palette_seeds: Vec<u64> = vec![1001, 1003, 1006];
     let biome = ChunkBiome {
@@ -2781,7 +2782,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
     // Register all materials from the first batch.
     let mut mat_catalog = MaterialCatalog::default();
     for placement in &valid_first {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
     }
 
     let catalog_size_after_first_batch = mat_catalog.len();
@@ -2815,7 +2816,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     // Register all materials from the second batch.
     for placement in &valid_second {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
     }
 
     // The catalog size must not have grown: all seeds from the second batch
@@ -2830,7 +2831,8 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
     );
 
     // Every seed in the catalog belongs to the palette.
-    let palette_seed_set: HashSet<u64> = palette_seeds.iter().copied().collect();
+    let palette_seed_set: HashSet<MaterialSeed> =
+        palette_seeds.iter().copied().map(MaterialSeed).collect();
     for seed in mat_catalog.seeds() {
         assert!(
             palette_seed_set.contains(seed),
@@ -2971,8 +2973,7 @@ fn palette_swap_does_not_change_deposit_count() {
 ///   coverage).
 #[test]
 fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
-    use crate::materials::MaterialCatalog;
-    use crate::world_generation::{BiomeRegistry, derive_chunk_biome};
+    use crate::materials::{MaterialCatalog, MaterialSeed};
     use std::collections::HashSet;
 
     let config = WorldGenerationConfig {
@@ -3061,7 +3062,8 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
                 );
 
                 // Material must register without panicking.
-                let registered = mat_catalog.derive_and_register(placement.material_seed);
+                let registered =
+                    mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
                 assert_eq!(
                     registered.seed, placement.material_seed,
                     "registered material seed mismatch"
@@ -3415,7 +3417,7 @@ fn every_deposit_material_is_pickup_ready() {
                     continue;
                 }
 
-                let mat = mat_catalog.derive_and_register(placement.material_seed);
+                let mat = mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
 
                 // Name must be non-empty (the pickup HUD displays it).
                 assert!(
@@ -3584,7 +3586,7 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
                 );
                 for placement in &placements {
                     if placement.material_seed != 0 {
-                        mat_catalog.derive_and_register(placement.material_seed);
+                        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
                     }
                 }
             }
@@ -3805,7 +3807,7 @@ fn restart_system_seed_chain_yields_identical_world() {
             );
             for placement in &placements {
                 if placement.material_seed != 0 {
-                    mat_catalog.derive_and_register(placement.material_seed);
+                    mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
                 }
             }
         }

--- a/tests/material_regression.rs
+++ b/tests/material_regression.rs
@@ -6,7 +6,7 @@
 
 mod scenarios;
 
-use apeiron_cipher::materials::{MaterialCatalog, derive_material_from_seed};
+use apeiron_cipher::materials::{MaterialCatalog, MaterialSeed, derive_material_from_seed};
 use apeiron_cipher::world_generation::{
     BiomeRegistry, BiomeType, ChunkCoord, PaletteMaterial, WorldGenerationConfig, WorldProfile,
     derive_chunk_biome,
@@ -152,7 +152,7 @@ fn no_duplicate_names_in_catalog_across_many_seeds() {
     // Register 500 materials — the catalog should disambiguate any
     // collisions so every entry has a unique name.
     for seed in 0..500_u64 {
-        catalog.derive_and_register(seed);
+        catalog.derive_and_register(MaterialSeed(seed));
     }
 
     assert_eq!(


### PR DESCRIPTION
## Summary

Migrate `MaterialCatalog`'s internal key type from `u64` to `MaterialSeed`, and update `ConfidenceTracker`'s `ObsKey` and `record`/`count`/`level` signatures to `MaterialSeed`.

## Changes

### `src/materials.rs`
- `by_seed: HashMap<u64, GameMaterial>` → `HashMap<MaterialSeed, GameMaterial>`
- `by_name: HashMap<String, u64>` → `HashMap<String, MaterialSeed>`
- `derive_and_register`, `register_fabricated`, `get_by_seed`, `seeds()`, `disambiguated_name` all updated
- Add `Display` impl for `MaterialSeed` (hex format)
- All unit tests updated

### `src/observation.rs`
- `type ObsKey = (u64, PropertyName)` → `(MaterialSeed, PropertyName)`
- `ConfidenceTracker::record`, `count`, `level` signatures updated
- All unit tests updated

### External call sites
- `exterior.rs`: import `MaterialSeed`, wrap `placement.material_seed` in `MaterialSeed(...)`
- `exterior_tests.rs`: same wrapping for all 7 test call sites; `HashSet<u64>` → `HashSet<MaterialSeed>` for `palette_seed_set`
- `tests/material_regression.rs`: import `MaterialSeed`; wrap loop seed

## Invariants preserved
- `GameMaterial::seed: u64` unchanged (serialisation boundary)
- `derive_material_from_seed(u64)` free-function unchanged (called internally with `seed.0`)
- `register_fabricated` public signature unchanged (wraps `mat.seed` at the boundary internally)

## Tests
- 707 unit tests: ✅ all pass
- 9 material_regression tests: ✅ all pass
- Integration tests: ✅ all pass
- cargo clippy: ✅ clean

Closes task t_3a0fc561