### PR TITLE
feat(seeds): migrate WorldProfile sub-seeds and related structs to domain newtypes

### DIFF
--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -45,6 +45,7 @@ use crate::seed_util::{
     PLACEMENT_DENSITY_CHANNEL, PLACEMENT_VARIATION_CHANNEL, PLANET_SURFACE_RADIUS_CHANNEL,
     mix_seed,
 };
+use crate::seeds::{BiomeSeed, MaterialSeed, ObjectIdentitySeed, PlacementSeed};
 use crate::solar_system::{
     OrbitalConfig, OrbitalLayout, PlanetEnvironment, PlanetEnvironmentConfig,
     SolarSystemRegistries, SolarSystemSeed, StarProfile, StarTypeRegistry, derive_orbital_layout,
@@ -236,6 +237,10 @@ pub fn surface_alignment_rotation(normal: [f32; 3]) -> [f32; 4] {
 #[derive(Clone, Debug)]
 pub struct PlanetSurface {
     /// Per-planet elevation seed (from `WorldProfile::elevation_seed`).
+    ///
+    /// Stored as a bare `u64` here because `continuous_value_field_01` (the
+    /// noise utility) operates on raw integers. The typed `ElevationSeed`
+    /// newtype does not exist yet; until it does, this boundary is explicit.
     pub elevation_seed: u64,
     /// Sea-level reference height (world units).
     pub base_y: f32,
@@ -1089,18 +1094,18 @@ pub struct WorldProfile {
     /// Number of chunks around the player to keep active.
     pub active_chunk_radius: i32,
     /// Seed used to determine object placement density per chunk.
-    pub placement_density_seed: u64,
+    pub placement_density_seed: PlacementSeed,
     /// Seed used to vary object positions within a chunk.
-    pub placement_variation_seed: u64,
+    pub placement_variation_seed: PlacementSeed,
     /// Seed used to deterministically assign object identities.
-    pub object_identity_seed: u64,
+    pub object_identity_seed: ObjectIdentitySeed,
     /// Per-planet biome climate seed, derived from the planet seed.
     ///
     /// This seed is mixed with temperature and moisture sub-channel constants
     /// (defined in `BiomeRegistry`) to produce two independent coherent noise
     /// fields. Each chunk samples both fields at its canonical center to
     /// determine its biome.
-    pub biome_climate_seed: u64,
+    pub biome_climate_seed: BiomeSeed,
     /// The planet surface radius in chunks, derived from the planet seed.
     ///
     /// The full surface is a square grid of `planet_surface_diameter × diameter`
@@ -1114,6 +1119,10 @@ pub struct WorldProfile {
     /// Per-planet elevation seed, derived from the planet seed via
     /// `ELEVATION_CHANNEL`. Drives the multi-octave noise field that
     /// produces terrain height variation.
+    ///
+    /// Stored as a bare `u64` because the `ElevationSeed` newtype does not
+    /// exist yet. When that newtype is introduced (Epic 5 terrain stories),
+    /// this field should be migrated to `ElevationSeed`.
     pub elevation_seed: u64,
     /// Solar system context when running in system-derived mode.
     ///
@@ -1220,10 +1229,19 @@ impl WorldProfile {
             planet_seed,
             chunk_size_world_units: config.chunk_size_world_units,
             active_chunk_radius: config.active_chunk_radius,
-            placement_density_seed: mix_seed(planet_seed.0, PLACEMENT_DENSITY_CHANNEL),
-            placement_variation_seed: mix_seed(planet_seed.0, PLACEMENT_VARIATION_CHANNEL),
-            object_identity_seed: mix_seed(planet_seed.0, OBJECT_IDENTITY_CHANNEL),
-            biome_climate_seed: mix_seed(planet_seed.0, BIOME_CLIMATE_CHANNEL),
+            placement_density_seed: PlacementSeed(mix_seed(
+                planet_seed.0,
+                PLACEMENT_DENSITY_CHANNEL,
+            )),
+            placement_variation_seed: PlacementSeed(mix_seed(
+                planet_seed.0,
+                PLACEMENT_VARIATION_CHANNEL,
+            )),
+            object_identity_seed: ObjectIdentitySeed(mix_seed(
+                planet_seed.0,
+                OBJECT_IDENTITY_CHANNEL,
+            )),
+            biome_climate_seed: BiomeSeed(mix_seed(planet_seed.0, BIOME_CLIMATE_CHANNEL)),
             planet_surface_radius,
             planet_surface_diameter,
             elevation_seed: mix_seed(planet_seed.0, ELEVATION_CHANNEL),
@@ -1256,11 +1274,11 @@ pub struct ChunkGenerationKey {
     /// The chunk these keys belong to.
     pub chunk_coord: ChunkCoord,
     /// Per-chunk key for placement density noise.
-    pub placement_density_key: u64,
+    pub placement_density_key: PlacementSeed,
     /// Per-chunk key for placement variation noise.
-    pub placement_variation_key: u64,
+    pub placement_variation_key: PlacementSeed,
     /// Per-chunk key for deterministic object identity assignment.
-    pub object_identity_key: u64,
+    pub object_identity_key: ObjectIdentitySeed,
 }
 
 /// Stable identity for one generated baseline object.
@@ -1595,9 +1613,18 @@ pub fn derive_chunk_generation_key(
 
     ChunkGenerationKey {
         chunk_coord: canonical,
-        placement_density_key: mix_seed(profile.placement_density_seed, chunk_mixer),
-        placement_variation_key: mix_seed(profile.placement_variation_seed, chunk_mixer),
-        object_identity_key: mix_seed(profile.object_identity_seed, chunk_mixer),
+        placement_density_key: PlacementSeed(mix_seed(
+            profile.placement_density_seed.0,
+            chunk_mixer,
+        )),
+        placement_variation_key: PlacementSeed(mix_seed(
+            profile.placement_variation_seed.0,
+            chunk_mixer,
+        )),
+        object_identity_key: ObjectIdentitySeed(mix_seed(
+            profile.object_identity_seed.0,
+            chunk_mixer,
+        )),
     }
 }
 
@@ -1764,31 +1791,31 @@ fn default_fallback_biome_type() -> BiomeType {
 fn default_fallback_material_palette() -> Vec<PaletteMaterial> {
     vec![
         PaletteMaterial {
-            material_seed: 1002,
+            material_seed: MaterialSeed(1002),
             selection_weight: 2.0,
         }, // Calcium
         PaletteMaterial {
-            material_seed: 1005,
+            material_seed: MaterialSeed(1005),
             selection_weight: 2.5,
         }, // Verdant
         PaletteMaterial {
-            material_seed: 1008,
+            material_seed: MaterialSeed(1008),
             selection_weight: 2.0,
         }, // Cobaltine
         PaletteMaterial {
-            material_seed: 1009,
+            material_seed: MaterialSeed(1009),
             selection_weight: 1.5,
         }, // Silite
         PaletteMaterial {
-            material_seed: 1001,
+            material_seed: MaterialSeed(1001),
             selection_weight: 1.0,
         }, // Ferrite
         PaletteMaterial {
-            material_seed: 1003,
+            material_seed: MaterialSeed(1003),
             selection_weight: 0.5,
         }, // Sulfurite
         PaletteMaterial {
-            material_seed: 1010,
+            material_seed: MaterialSeed(1010),
             selection_weight: 0.8,
         }, // Phosphite
     ]
@@ -1822,7 +1849,7 @@ pub struct PaletteMaterial {
     ///
     /// The same seed always produces the same `GameMaterial` (density, color,
     /// name, etc.) regardless of which biome references it.
-    pub material_seed: u64,
+    pub material_seed: MaterialSeed,
     /// Relative likelihood of this material being selected when placing a
     /// deposit in the biome.
     ///
@@ -1914,27 +1941,27 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 3.0,
                 }, // Ferrite
                 PaletteMaterial {
-                    material_seed: 1003,
+                    material_seed: MaterialSeed(1003),
                     selection_weight: 2.5,
                 }, // Sulfurite
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 2.0,
                 }, // Osmium
                 PaletteMaterial {
-                    material_seed: 1007,
+                    material_seed: MaterialSeed(1007),
                     selection_weight: 1.5,
                 }, // Volatite
                 PaletteMaterial {
-                    material_seed: 1002,
+                    material_seed: MaterialSeed(1002),
                     selection_weight: 0.5,
                 }, // Calcium
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 0.3,
                 }, // Silite
             ],
@@ -1965,27 +1992,27 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1004,
+                    material_seed: MaterialSeed(1004),
                     selection_weight: 3.0,
                 }, // Prismate
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 2.0,
                 }, // Silite
                 PaletteMaterial {
-                    material_seed: 1010,
+                    material_seed: MaterialSeed(1010),
                     selection_weight: 2.5,
                 }, // Phosphite
                 PaletteMaterial {
-                    material_seed: 1008,
+                    material_seed: MaterialSeed(1008),
                     selection_weight: 1.0,
                 }, // Cobaltine
                 PaletteMaterial {
-                    material_seed: 1005,
+                    material_seed: MaterialSeed(1005),
                     selection_weight: 0.3,
                 }, // Verdant
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 0.5,
                 }, // Osmium
             ],
@@ -2054,10 +2081,13 @@ pub fn derive_chunk_biome(
     let chunk_center = PositionXZ::new(canonical.x as f32 + 0.5, canonical.z as f32 + 0.5);
 
     let temperature_seed = mix_seed(
-        profile.biome_climate_seed,
+        profile.biome_climate_seed.0,
         registry.temperature_noise_channel,
     );
-    let moisture_seed = mix_seed(profile.biome_climate_seed, registry.moisture_noise_channel);
+    let moisture_seed = mix_seed(
+        profile.biome_climate_seed.0,
+        registry.moisture_noise_channel,
+    );
 
     let temperature = exterior::continuous_value_field_01(
         temperature_seed,

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -59,6 +59,7 @@ use crate::interaction::HeldItem;
 use crate::materials::{GameMaterial, MaterialCatalog, MaterialObject};
 use crate::scene::{ExteriorGroundPatch, PositionXZ, RectXZ};
 use crate::seed_util::lerp;
+use crate::seeds::MaterialSeed;
 
 const DEPOSIT_CONFIG_PATH: &str = "assets/exterior/surface_mineral_deposits.toml";
 const SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION: u32 = 1;
@@ -262,7 +263,7 @@ struct GeneratedSurfaceMineralPlacement {
     generated_id: GeneratedObjectId,
     deposit_site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     position_xz: PositionXZ,
     surface_y: f32,
     /// Surface normal at the placement point, used for object alignment.
@@ -280,7 +281,7 @@ struct GeneratedSurfaceMineralPlacement {
 struct GeneratedSurfaceMineralDepositSite {
     site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     center_xz: PositionXZ,
     radius_world_units: f32,
     child_count: u32,
@@ -627,12 +628,12 @@ fn sync_active_exterior_chunks(
 
         for placement in placements {
             // Skip deposits with no material (biome had an empty palette).
-            if placement.material_seed == 0 {
+            if placement.material_seed == MaterialSeed(0) {
                 continue;
             }
 
             let mut deposit_material = material_catalog
-                .derive_and_register(placement.material_seed)
+                .derive_and_register(placement.material_seed.0)
                 .clone();
             // Tag the spawn origin so observation systems can wire the FoundOn
             // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
@@ -1029,7 +1030,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let density = continuous_value_field_01(
-                generation_key.placement_density_key,
+                generation_key.placement_density_key.0,
                 cell_center_xz,
                 catalog.site_density_field_scale_world_units,
             );
@@ -1043,7 +1044,7 @@ fn generate_surface_mineral_deposit_sites(
             // different biomes favor different materials.
             let Some(definition) = choose_deposit_definition(
                 &catalog.deposits,
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 &biome.deposit_weight_modifiers,
@@ -1053,7 +1054,7 @@ fn generate_surface_mineral_deposit_sites(
             };
 
             let jitter_offset = jitter_offset_xz(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 spacing * catalog.site_jitter_fraction,
@@ -1073,7 +1074,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let radius_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0001,
@@ -1085,7 +1086,7 @@ fn generate_surface_mineral_deposit_sites(
             );
 
             let child_count_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0002,
@@ -1124,7 +1125,7 @@ fn generate_surface_mineral_deposit_sites(
                 definition_key: definition.key.clone(),
                 material_seed: choose_material_seed_from_palette(
                     &biome.material_palette,
-                    generation_key.placement_variation_key,
+                    generation_key.placement_variation_key.0,
                     chunk_coord,
                     local_site_index,
                 ),
@@ -1282,9 +1283,9 @@ fn choose_material_seed_from_palette(
     variation_key: u64,
     chunk_coord: ChunkCoord,
     local_candidate_index: u32,
-) -> u64 {
+) -> MaterialSeed {
     if palette.is_empty() {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let total_weight: f32 = palette
@@ -1292,7 +1293,7 @@ fn choose_material_seed_from_palette(
         .map(|entry| entry.selection_weight.max(0.0))
         .sum();
     if total_weight <= f32::EPSILON {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let roll = unit_interval_01(mix_candidate_input(
@@ -1311,7 +1312,10 @@ fn choose_material_seed_from_palette(
     }
 
     // Fallback to last entry (float rounding edge case).
-    palette.last().map(|e| e.material_seed).unwrap_or(0)
+    palette
+        .last()
+        .map(|e| e.material_seed)
+        .unwrap_or(MaterialSeed(0))
 }
 
 fn jitter_offset_xz(

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seeds::MaterialSeed;
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
 use crate::world_generation::{BiomeType, PlanetSeed, WorldGenerationConfig};
 
@@ -2293,8 +2294,8 @@ fn deposit_sites_carry_material_seed_from_palette() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed_a: u64 = 0xFE00_0000_0000_0001;
-    let seed_b: u64 = 0xFE00_0000_0000_0002;
+    let seed_a: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0001);
+    let seed_b: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0002);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
@@ -2325,12 +2326,14 @@ fn deposit_sites_carry_material_seed_from_palette() {
         "biome with a material palette should produce deposit sites"
     );
 
+    let seed_a_raw = seed_a.0;
+    let seed_b_raw = seed_b.0;
     for site in &sites {
         assert!(
             site.material_seed == seed_a || site.material_seed == seed_b,
             "deposit site material_seed ({:#018X}) must come from the biome palette, \
-                 expected one of {seed_a:#018X} or {seed_b:#018X}",
-            site.material_seed,
+                 expected one of {seed_a_raw:#018X} or {seed_b_raw:#018X}",
+            site.material_seed.0,
         );
     }
 }
@@ -2341,7 +2344,7 @@ fn deposit_placements_inherit_material_seed_from_site() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed: u64 = 0xAB00_0000_0000_0099;
+    let seed: MaterialSeed = MaterialSeed(0xAB00_0000_0000_0099);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.3, 0.3, 0.3],
@@ -2407,7 +2410,8 @@ fn empty_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "empty palette must produce material_seed 0"
                 );
             }
@@ -2450,7 +2454,8 @@ fn empty_palette_baseline_placements_exist_but_all_have_zero_seed() {
             for p in &placements {
                 total_placements += 1;
                 assert_eq!(
-                    p.material_seed, 0,
+                    p.material_seed,
+                    MaterialSeed(0),
                     "all placements from an empty-palette biome must have material_seed 0"
                 );
             }
@@ -2480,15 +2485,15 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0001,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0001),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0002,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0002),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0003,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0003),
                 selection_weight: 0.0,
             },
         ],
@@ -2507,9 +2512,12 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "all-zero-weight palette must produce material_seed 0, got {} for site in chunk ({}, {})",
-                    site.material_seed, cx, cz
+                    site.material_seed.0,
+                    cx,
+                    cz
                 );
             }
         }
@@ -2530,7 +2538,7 @@ fn single_palette_entry_always_selected() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let sole_seed: u64 = 0xAA00_0000_0000_0042;
+    let sole_seed: MaterialSeed = MaterialSeed(0xAA00_0000_0000_0042);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.4, 0.4, 0.4],
@@ -2558,7 +2566,7 @@ fn single_palette_entry_always_selected() {
                     site.material_seed, sole_seed,
                     "single-entry palette must always select the sole seed; \
                          got {:#018X} at chunk ({cx}, {cz})",
-                    site.material_seed,
+                    site.material_seed.0,
                 );
             }
         }
@@ -2584,7 +2592,7 @@ fn deposit_site_has_no_material_key_field() {
             generator_version: 1,
         },
         definition_key: "test".to_string(),
-        material_seed: 0xDEAD_BEEF,
+        material_seed: MaterialSeed(0xDEAD_BEEF),
         center_xz: PositionXZ::new(0.0, 0.0),
         radius_world_units: 1.0,
         child_count: 1,
@@ -2594,7 +2602,7 @@ fn deposit_site_has_no_material_key_field() {
         scale_max: 1.0,
         cluster_compactness: 0.5,
     };
-    assert_eq!(site.material_seed, 0xDEAD_BEEF);
+    assert_eq!(site.material_seed, MaterialSeed(0xDEAD_BEEF));
 
     // Same for the placement struct.
     let placement = GeneratedSurfaceMineralPlacement {
@@ -2607,14 +2615,14 @@ fn deposit_site_has_no_material_key_field() {
         },
         deposit_site_id: site.site_id.clone(),
         definition_key: "test".to_string(),
-        material_seed: 0xCAFE_BABE,
+        material_seed: MaterialSeed(0xCAFE_BABE),
         position_xz: PositionXZ::new(0.0, 0.0),
         surface_y: 0.0,
         surface_normal: [0.0, 1.0, 0.0],
         visual_scale: 1.0,
         local_child_index: 0,
     };
-    assert_eq!(placement.material_seed, 0xCAFE_BABE);
+    assert_eq!(placement.material_seed, MaterialSeed(0xCAFE_BABE));
 }
 
 /// Story 5a.4 – Phase 5: first chunk generation populates the material
@@ -2643,7 +2651,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2679,7 +2687,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     // Filter to placements with valid material seeds (non-zero).
     let valid_placements: Vec<_> = all_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
 
     // We expect at least some deposits were generated.
@@ -2696,7 +2704,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     );
 
     for placement in &valid_placements {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     // 1. Catalog is no longer empty.
@@ -2736,7 +2744,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2771,7 +2779,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_first: Vec<_> = first_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_first.is_empty(),
@@ -2781,7 +2789,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
     // Register all materials from the first batch.
     let mut mat_catalog = MaterialCatalog::default();
     for placement in &valid_first {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     let catalog_size_after_first_batch = mat_catalog.len();
@@ -2806,7 +2814,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_second: Vec<_> = second_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_second.is_empty(),
@@ -2815,7 +2823,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     // Register all materials from the second batch.
     for placement in &valid_second {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     // The catalog size must not have grown: all seeds from the second batch
@@ -2864,21 +2872,21 @@ fn palette_swap_does_not_change_deposit_count() {
 
     let palette_a = vec![
         PaletteMaterial {
-            material_seed: 1001,
+            material_seed: MaterialSeed(1001),
             selection_weight: 3.0,
         },
         PaletteMaterial {
-            material_seed: 1003,
+            material_seed: MaterialSeed(1003),
             selection_weight: 2.0,
         },
     ];
     let palette_b = vec![
         PaletteMaterial {
-            material_seed: 1004,
+            material_seed: MaterialSeed(1004),
             selection_weight: 1.5,
         },
         PaletteMaterial {
-            material_seed: 1010,
+            material_seed: MaterialSeed(1010),
             selection_weight: 4.0,
         },
     ];
@@ -2929,13 +2937,13 @@ fn palette_swap_does_not_change_deposit_count() {
             count_b += placements_b.len();
 
             for p in &placements_a {
-                if p.material_seed != 0 {
-                    seeds_a.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_a.insert(p.material_seed.0);
                 }
             }
             for p in &placements_b {
-                if p.material_seed != 0 {
-                    seeds_b.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_b.insert(p.material_seed.0);
                 }
             }
         }
@@ -3028,7 +3036,7 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
         let palette_seeds: HashSet<u64> = biome
             .material_palette
             .iter()
-            .map(|p| p.material_seed)
+            .map(|p| p.material_seed.0)
             .collect();
 
         let placements =
@@ -3051,19 +3059,19 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
 
             // Deposits from a biome with a non-empty palette must carry a
             // non-zero seed drawn from that palette.
-            if !palette_seeds.is_empty() && placement.material_seed != 0 {
+            if !palette_seeds.is_empty() && placement.material_seed != MaterialSeed(0) {
                 assert!(
-                    palette_seeds.contains(&placement.material_seed),
+                    palette_seeds.contains(&placement.material_seed.0),
                     "deposit material_seed {:#018X} not in biome '{:?}' palette \
                          (chunk {chunk:?})",
-                    placement.material_seed,
+                    placement.material_seed.0,
                     biome.biome_type,
                 );
 
                 // Material must register without panicking.
-                let registered = mat_catalog.derive_and_register(placement.material_seed);
+                let registered = mat_catalog.derive_and_register(placement.material_seed.0);
                 assert_eq!(
-                    registered.seed, placement.material_seed,
+                    registered.seed, placement.material_seed.0,
                     "registered material seed mismatch"
                 );
             }
@@ -3106,15 +3114,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3128,15 +3136,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1004,
+                material_seed: MaterialSeed(1004),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1010,
+                material_seed: MaterialSeed(1010),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1008,
+                material_seed: MaterialSeed(1008),
                 selection_weight: 1.0,
             },
         ],
@@ -3145,12 +3153,12 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
     let scorched_palette_seeds: std::collections::HashSet<u64> = scorched_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
     let frost_palette_seeds: std::collections::HashSet<u64> = frost_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
 
     // Sanity: the two palettes share no seeds.
@@ -3177,8 +3185,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &scorched_biome,
             ) {
-                if site.material_seed != 0 {
-                    scorched_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    scorched_observed.insert(site.material_seed.0);
                 }
             }
 
@@ -3189,8 +3197,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &frost_biome,
             ) {
-                if site.material_seed != 0 {
-                    frost_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    frost_observed.insert(site.material_seed.0);
                 }
             }
         }
@@ -3386,15 +3394,15 @@ fn every_deposit_material_is_pickup_ready() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.0,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3411,17 +3419,17 @@ fn every_deposit_material_is_pickup_ready() {
             );
 
             for placement in &placements {
-                if placement.material_seed == 0 {
+                if placement.material_seed == MaterialSeed(0) {
                     continue;
                 }
 
-                let mat = mat_catalog.derive_and_register(placement.material_seed);
+                let mat = mat_catalog.derive_and_register(placement.material_seed.0);
 
                 // Name must be non-empty (the pickup HUD displays it).
                 assert!(
                     !mat.name.is_empty(),
                     "deposit seed {} produced an empty name",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 // Color channels must be finite and in [0, 1].
@@ -3429,7 +3437,7 @@ fn every_deposit_material_is_pickup_ready() {
                     assert!(
                         c.is_finite() && (0.0..=1.0).contains(&c),
                         "deposit seed {} color[{i}] = {c} out of range",
-                        placement.material_seed,
+                        placement.material_seed.0,
                     );
                 }
 
@@ -3443,7 +3451,7 @@ fn every_deposit_material_is_pickup_ready() {
                 assert!(
                     any_nonzero,
                     "deposit seed {} has all-zero properties",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 checked += 1;
@@ -3490,15 +3498,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1003,
+                    material_seed: MaterialSeed(1003),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 2.0,
                 },
             ],
@@ -3510,19 +3518,19 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1002,
+                    material_seed: MaterialSeed(1002),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1005,
+                    material_seed: MaterialSeed(1005),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1008,
+                    material_seed: MaterialSeed(1008),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 1.0,
                 },
             ],
@@ -3534,15 +3542,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1004,
+                    material_seed: MaterialSeed(1004),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1010,
+                    material_seed: MaterialSeed(1010),
                     selection_weight: 2.5,
                 },
             ],
@@ -3583,8 +3591,8 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
                     biome,
                 );
                 for placement in &placements {
-                    if placement.material_seed != 0 {
-                        mat_catalog.derive_and_register(placement.material_seed);
+                    if placement.material_seed != MaterialSeed(0) {
+                        mat_catalog.derive_and_register(placement.material_seed.0);
                     }
                 }
             }
@@ -3804,8 +3812,8 @@ fn restart_system_seed_chain_yields_identical_world() {
                 &biome,
             );
             for placement in &placements {
-                if placement.material_seed != 0 {
-                    mat_catalog.derive_and_register(placement.material_seed);
+                if placement.material_seed != MaterialSeed(0) {
+                    mat_catalog.derive_and_register(placement.material_seed.0);
                 }
             }
         }
@@ -4003,11 +4011,11 @@ fn sample_biome_with_palette() -> ChunkBiome {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0001,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0002,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0002),
                 selection_weight: 1.0,
             },
         ],
@@ -4075,7 +4083,7 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
                 &biome,
             );
             for p in &placements {
-                seen_seeds.insert(p.material_seed);
+                seen_seeds.insert(p.material_seed.0);
             }
         }
     }
@@ -4083,10 +4091,10 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
     // Both palette seeds should appear.
     for pm in &biome.material_palette {
         assert!(
-            seen_seeds.contains(&pm.material_seed),
+            seen_seeds.contains(&pm.material_seed.0),
             "palette seed {:#x} never appeared in deposits \
                  across 100 chunks",
-            pm.material_seed,
+            pm.material_seed.0,
         );
     }
 }
@@ -4111,9 +4119,9 @@ fn higher_weight_palette_entry_appears_more_often() {
                 &biome,
             );
             for p in &placements {
-                if p.material_seed == 0xFE00_0000_0000_0001 {
+                if p.material_seed == MaterialSeed(0xFE00_0000_0000_0001) {
                     count_seed_1 += 1;
-                } else if p.material_seed == 0xFE00_0000_0000_0002 {
+                } else if p.material_seed == MaterialSeed(0xFE00_0000_0000_0002) {
                     count_seed_2 += 1;
                 }
             }

--- a/src/world_generation_tests.rs
+++ b/src/world_generation_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seeds::{BiomeSeed, MaterialSeed, ObjectIdentitySeed, PlacementSeed};
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
 
 #[test]
@@ -116,10 +117,13 @@ fn world_profile_derives_distinct_sub_seeds() {
         profile.placement_density_seed,
         profile.placement_variation_seed
     );
-    assert_ne!(profile.placement_density_seed, profile.object_identity_seed);
     assert_ne!(
-        profile.placement_variation_seed,
-        profile.object_identity_seed
+        profile.placement_density_seed.0,
+        profile.object_identity_seed.0
+    );
+    assert_ne!(
+        profile.placement_variation_seed.0,
+        profile.object_identity_seed.0
     );
 }
 
@@ -757,9 +761,15 @@ fn biome_climate_seed_is_distinct_from_other_seeds() {
     // in WorldProfile to avoid correlated noise fields.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
 
-    assert_ne!(profile.biome_climate_seed, profile.placement_density_seed);
-    assert_ne!(profile.biome_climate_seed, profile.placement_variation_seed);
-    assert_ne!(profile.biome_climate_seed, profile.planet_seed.0);
+    assert_ne!(
+        profile.biome_climate_seed.0,
+        profile.placement_density_seed.0
+    );
+    assert_ne!(
+        profile.biome_climate_seed.0,
+        profile.placement_variation_seed.0
+    );
+    assert_ne!(profile.biome_climate_seed.0, profile.planet_seed.0);
 }
 
 #[test]
@@ -768,10 +778,10 @@ fn elevation_seed_is_distinct_from_other_seeds() {
     // in WorldProfile to avoid correlated noise fields.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
 
-    assert_ne!(profile.elevation_seed, profile.placement_density_seed);
-    assert_ne!(profile.elevation_seed, profile.placement_variation_seed);
-    assert_ne!(profile.elevation_seed, profile.object_identity_seed);
-    assert_ne!(profile.elevation_seed, profile.biome_climate_seed);
+    assert_ne!(profile.elevation_seed, profile.placement_density_seed.0);
+    assert_ne!(profile.elevation_seed, profile.placement_variation_seed.0);
+    assert_ne!(profile.elevation_seed, profile.object_identity_seed.0);
+    assert_ne!(profile.elevation_seed, profile.biome_climate_seed.0);
     assert_ne!(profile.elevation_seed, profile.planet_seed.0);
 }
 
@@ -825,15 +835,15 @@ fn biome_registry_toml_round_trip_with_palette_entries() {
     let palette = &mut registry.biomes[0].material_palette;
     palette.clear();
     palette.push(PaletteMaterial {
-        material_seed: 0xFE00_0000_0000_0001,
+        material_seed: MaterialSeed(0xFE00_0000_0000_0001),
         selection_weight: 3.0,
     });
     palette.push(PaletteMaterial {
-        material_seed: 0xFE00_0000_0000_0002,
+        material_seed: MaterialSeed(0xFE00_0000_0000_0002),
         selection_weight: 0.5,
     });
     palette.push(PaletteMaterial {
-        material_seed: 42,
+        material_seed: MaterialSeed(42),
         selection_weight: 1.0,
     });
 
@@ -882,7 +892,7 @@ fn biome_toml_round_trip_empty_palette() {
 #[test]
 fn biome_toml_round_trip_shared_seed_across_biomes() {
     // The same material seed can appear in multiple biomes with different weights.
-    let shared_seed: u64 = 0xABCD_0000_0000_0099;
+    let shared_seed: MaterialSeed = MaterialSeed(0xABCD_0000_0000_0099);
     let mut registry = BiomeRegistry::default();
 
     // Ensure at least two biomes exist.
@@ -1067,7 +1077,7 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
             let palette = b
                 .material_palette
                 .iter()
-                .map(|p| (p.material_seed, p.selection_weight))
+                .map(|p| (p.material_seed.0, p.selection_weight))
                 .collect::<Vec<_>>();
             (b.biome_type, palette)
         })
@@ -1090,7 +1100,7 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
             let actual: Vec<(u64, f32)> = biome
                 .material_palette
                 .iter()
-                .map(|p| (p.material_seed, p.selection_weight))
+                .map(|p| (p.material_seed.0, p.selection_weight))
                 .collect();
 
             assert_eq!(
@@ -1125,11 +1135,11 @@ fn chunk_biome_fallback_carries_fallback_palette() {
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
     let fallback_palette = vec![
         PaletteMaterial {
-            material_seed: 0xAAAA,
+            material_seed: MaterialSeed(0xAAAA),
             selection_weight: 1.0,
         },
         PaletteMaterial {
-            material_seed: 0xBBBB,
+            material_seed: MaterialSeed(0xBBBB),
             selection_weight: 2.0,
         },
     ];
@@ -1217,7 +1227,7 @@ fn chunk_biome_hardcoded_default_has_reasonable_palette() {
         assert!(
             entry.selection_weight > 0.0,
             "palette entry seed {} has non-positive weight {}",
-            entry.material_seed,
+            entry.material_seed.0,
             entry.selection_weight
         );
     }
@@ -2319,10 +2329,10 @@ fn system_mode_is_system_derived_and_all_fields_populated() {
     // guaranteed by the mixing function, but for seed 42 they are
     // empirically distinct and non-zero — if any were zero it would
     // indicate the derivation chain is broken).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert!(profile.planet_surface_diameter > 0);
@@ -2599,10 +2609,10 @@ fn planet_index_last_planet_succeeds() {
     );
 
     // Sub-seeds are populated (derivation chain is intact).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert_eq!(
@@ -2684,10 +2694,10 @@ fn planet_index_one_valid_in_two_planet_system() {
     );
 
     // Sub-seeds are populated (derivation chain is intact).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert_eq!(

--- a/tests/material_regression.rs
+++ b/tests/material_regression.rs
@@ -187,7 +187,7 @@ fn different_biomes_produce_different_material_sets() {
             let seeds: HashSet<u64> = biome
                 .material_palette
                 .iter()
-                .map(|p| p.material_seed)
+                .map(|p| p.material_seed.0)
                 .collect();
             biome_seeds
                 .entry(biome.biome_type)
@@ -239,12 +239,12 @@ fn all_palette_entries_appear_across_many_chunks() {
             let seen = seen_per_biome.entry(biome.biome_type).or_default();
 
             for p in &biome.material_palette {
-                expected.insert(p.material_seed);
+                expected.insert(p.material_seed.0);
                 // The palette is always fully present on every chunk of
                 // that biome — selection happens at deposit placement, not
                 // at biome derivation.  So every palette seed should appear
                 // in every chunk's palette.
-                seen.insert(p.material_seed);
+                seen.insert(p.material_seed.0);
             }
         }
     }
@@ -270,7 +270,7 @@ fn well_known_seeds_produce_distinct_materials() {
     let all_seeds: HashSet<u64> = registry
         .biomes
         .iter()
-        .flat_map(|b| b.material_palette.iter().map(|p| p.material_seed))
+        .flat_map(|b| b.material_palette.iter().map(|p| p.material_seed.0))
         .collect();
 
     assert!(


### PR DESCRIPTION
## Summary

Migrates `WorldProfile` sub-seeds and related structs from bare `u64` to typed newtypes defined in `src/seeds.rs`. Part of Epic 5 seed-domain-typing work. Stacks on top of #441.

## Changes

### Struct fields typed
- `WorldProfile`: `placement_density_seed`, `placement_variation_seed` → `PlacementSeed`; `object_identity_seed` → `ObjectIdentitySeed`; `biome_climate_seed` → `BiomeSeed`
- `ChunkGenerationKey`: `placement_density_key`, `placement_variation_key` → `PlacementSeed`; `object_identity_key` → `ObjectIdentitySeed`
- `PaletteMaterial.material_seed` → `MaterialSeed`
- `GeneratedSurfaceMineralPlacement.material_seed` → `MaterialSeed`
- `GeneratedSurfaceMineralDepositSite.material_seed` → `MaterialSeed`
- `choose_material_seed_from_palette` return type → `MaterialSeed`

### Intentionally left as `u64`
- `WorldProfile.elevation_seed` and `PlanetSurface.elevation_seed` — `ElevationSeed` newtype does not exist yet; doc comment added pointing to Epic 5 terrain stories for future migration

### Mixing boundaries
Utility/noise functions (`mix_seed`, `mix_candidate_input`, `jitter_offset_xz`, `continuous_value_field_01`) remain `u64`-based. Newtypes are unwrapped with `.0` only at those call sites.

## Tests

- 757 tests pass (718 unit + 6 doc + 9 material regression + 9 carry + 7 carry_feedback + 1 carry_scenarios + 1 confidence + 6 doc)
- Zero new compile errors (pre-existing let-chain lint at world_generation.rs:819, 2108-2112 left untouched)