### PR TITLE
refactor: add #[require] to PlayerCamera and DiegeticSurface

### DIFF
--- a/src/diegetic_ui.rs
+++ b/src/diegetic_ui.rs
@@ -96,6 +96,7 @@ pub enum DiegeticUiSet {
 /// See the module-level documentation for a step-by-step guide on adding
 /// new diegetic surfaces.
 #[derive(Component, Debug, Clone, Copy)]
+#[require(DiegeticFocusState)]
 pub struct DiegeticSurface;
 
 /// Determines how a diegetic surface is perceived and interacted with.

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -814,19 +814,20 @@ fn spawn_journal_ui(mut commands: Commands) {
             // with the DiegeticUiPlugin:
             //   • DiegeticSurface  — marks it as a diegetic information surface
             //     so the CI compliance test can verify no rogue screen-space text exists.
+            //     `DiegeticFocusState` is a required component of `DiegeticSurface`; it
+            //     defaults to `OutOfRange` (journal starts closed) and is injected
+            //     automatically — no need to list it here explicitly.
             //   • DiegeticSurfaceKind::Readable — declares interaction model.
             //     The player "holds up" the datapad (Active state); physical distance
             //     does not drive focus here because the journal is always on the player.
             //     The ranges are set to 0.0 so proximity logic collapses to Focused
             //     the moment the entity exists — actual open/close is managed by
             //     toggle_journal_datapad_focus below.
-            //   • DiegeticFocusState::OutOfRange — journal starts closed.
             DiegeticSurface,
             DiegeticSurfaceKind::Readable {
                 perceivable_range: 0.0,
                 legible_range: 0.0,
             },
-            DiegeticFocusState::OutOfRange,
             // ─────────────────────────────────────────────────────────────
             Node {
                 position_type: PositionType::Absolute,

--- a/src/player.rs
+++ b/src/player.rs
@@ -104,7 +104,11 @@ impl Plugin for PlayerPlugin {
 pub struct Player;
 
 /// Marker component for the player's camera (the "eyes").
+///
+/// Spawning this marker is sufficient — `CameraPitch` and `Camera3d` are
+/// required components and will be inserted automatically with their defaults.
 #[derive(Component)]
+#[require(CameraPitch, Camera3d)]
 pub struct PlayerCamera;
 
 /// Accumulated pitch angle stored alongside the camera so clamping is precise
@@ -150,7 +154,7 @@ pub fn spawn_player(
             },
         ))
         .with_children(|parent| {
-            parent.spawn((PlayerCamera, CameraPitch::default(), Camera3d::default()));
+            parent.spawn(PlayerCamera);
         });
 }
 


### PR DESCRIPTION
## Summary

Adds Bevy `#[require(...)]` attributes to two marker components where companion components are *always* co-present with their default values, reducing spawn-site boilerplate and making the invariant compiler-enforced.

### Changes

**`src/player.rs` — `PlayerCamera`**
- Added `#[require(CameraPitch, Camera3d)]` to `PlayerCamera`
- Simplified the single spawn site from
  `parent.spawn((PlayerCamera, CameraPitch::default(), Camera3d::default()))`
  to `parent.spawn(PlayerCamera)`

**`src/diegetic_ui.rs` — `DiegeticSurface`**
- Added `#[require(DiegeticFocusState)]` to `DiegeticSurface`

**`src/journal.rs` — `spawn_journal_ui`**
- Removed redundant `DiegeticFocusState::OutOfRange` from the `JournalPanel` spawn bundle; it is now injected automatically by the require on `DiegeticSurface`
- Updated the comment block to explain the require relationship

### What was skipped and why
All other marker components were evaluated and excluded:
- `HeldItem`, `InCarry` — dynamically inserted, no universal spawn pattern
- `BreathingCue`, `DebugPanel`, `DebugText`, `Crosshair`, `ExaminePanel/Text`, `JournalFilterBarText` etc. — companion components have varying or non-default values at spawn sites
- `MaterialObject`, `HeatSource`, `Player`, `Workbench`, `Shelf` — varying companion sets across multiple spawn sites

### Tests
- `cargo check`: clean
- `cargo test`: 707/707 pass (pre-commit hook verified)

Closes #