### PR TITLE
feat(kanban): persist selected view in localStorage (gh_kanban_view)

### DIFF
--- a/kanban/src/App.jsx
+++ b/kanban/src/App.jsx
@@ -42,7 +42,14 @@ export default function App({ config }) {
     return localStorage.getItem("gh_kanban_repo") || "";
   });
 
-  const [view, setView] = useState("board");
+  const [view, setView] = useState(
+    () => localStorage.getItem("gh_kanban_view") || "board"
+  );
+
+  function handleViewChange(v) {
+    localStorage.setItem("gh_kanban_view", v);
+    setView(v);
+  }
 
   useEffect(() => {
     async function bootstrap() {
@@ -88,7 +95,7 @@ export default function App({ config }) {
 
   return (
     <div style={styles.app}>
-      <Header repo={repo} onRepoChange={handleRepoChange} view={view} onViewChange={setView} />
+      <Header repo={repo} onRepoChange={handleRepoChange} view={view} onViewChange={handleViewChange} />
       <div style={styles.body}>
         {view === "board" ? (
           <>


### PR DESCRIPTION
## Summary

KB-1.2 view switcher scaffold was already merged in #275 (Board/Backlog tabs, content switching, BacklogView placeholder). This PR adds the one missing piece from the acceptance criteria: **localStorage persistence** for the selected tab.

### Changes

- `kanban/src/App.jsx`: Replace hardcoded `"board"` initial state with a lazy initializer that reads `gh_kanban_view` from localStorage. Introduce `handleViewChange` that writes to localStorage before updating state. Wire `onViewChange` prop to `handleViewChange` instead of raw `setView`.

### Acceptance Criteria Checklist

- [x] Two tabs visible: Board and Backlog (implemented in #275)
- [x] Switching tabs swaps the main content area without full page reload (implemented in #275)
- [x] Selected tab persists across reloads (**this PR**)
- [x] Column visibility toggle remains accessible and functional (Sidebar present in Board view, unchanged)

### Verification

`make kb-check` passes: 0 errors, 5 pre-existing warnings, build OK.

Closes #253