### PR TITLE
feat: 25.1 - privatize zero-consumer pub(crate) items

### DIFF
--- a/src/carry.rs
+++ b/src/carry.rs
@@ -91,13 +91,13 @@ pub struct CycleCarryIntent;
 /// stash leaves the player confused. This event is the hook that lets future
 /// visual/audio systems translate "you can't do that" into something observable.
 #[derive(Message, Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct CarryActionRejected {
-    pub reason: CarryRejectionReason,
+struct CarryActionRejected {
+    reason: CarryRejectionReason,
 }
 
 /// Why a carry action was rejected.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CarryRejectionReason {
+enum CarryRejectionReason {
     /// Stash attempted but nothing is held in hand.
     NothingHeld,
     /// Stash attempted but adding the item would exceed effective capacity.
@@ -330,7 +330,7 @@ impl CarryState {
     /// capacity check — [`Self::can_stash`] and [`can_stash_material`]
     /// both delegate here so all callers share the same accept/reject
     /// boundary.
-    pub(crate) fn can_accept(&self, weight: f32) -> bool {
+    fn can_accept(&self, weight: f32) -> bool {
         if !self.hard_limit_enabled {
             return true;
         }
@@ -344,7 +344,7 @@ impl CarryState {
     /// This prevents the carry from soft-locking on a dead entity while accepting
     /// that weight accounting may drift slightly. A future integrity-check system
     /// can reconcile weight by scanning remaining items.
-    pub(crate) fn evict_stale_entity(&mut self, entity: Entity) -> bool {
+    fn evict_stale_entity(&mut self, entity: Entity) -> bool {
         let Some(index) = self
             .carried_items
             .iter()

--- a/src/diegetic_ui.rs
+++ b/src/diegetic_ui.rs
@@ -215,7 +215,7 @@ pub struct ReadableSurfaceContent {
 ///   `OutOfRange → Perceivable { proximity } → Focused`
 ///
 /// Runs in [`DiegeticUiSet::FocusUpdate`].
-pub(crate) fn update_diegetic_focus(
+fn update_diegetic_focus(
     player_query: Query<&Transform, With<Player>>,
     mut surfaces: Query<
         (&Transform, &DiegeticSurfaceKind, &mut DiegeticFocusState),
@@ -281,7 +281,7 @@ pub(crate) fn update_diegetic_focus(
 /// LOD accordingly — this system only manages show/hide.
 ///
 /// Runs in [`DiegeticUiSet::VisibilitySync`], after [`DiegeticUiSet::FocusUpdate`].
-pub(crate) fn sync_readable_surface_visibility(
+fn sync_readable_surface_visibility(
     mut surfaces: Query<(&DiegeticFocusState, &mut Visibility), With<DiegeticSurface>>,
 ) {
     for (focus_state, mut visibility) in surfaces.iter_mut() {

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -334,7 +334,7 @@ impl PlanetSurface {
     /// with lacunarity 2, persistence 0.5). The base `continuous_value_field_01`
     /// returns values in `[0, 1]`, so we center each sample around 0.5 to get
     /// positive and negative deviations from `base_y`.
-    pub(crate) fn sample_elevation(&self, x: f32, z: f32) -> f32 {
+    pub fn sample_elevation(&self, x: f32, z: f32) -> f32 {
         let x = self.fold_elevation_coord(x);
         let z = self.fold_elevation_coord(z);
         let mut total = 0.0_f32;


### PR DESCRIPTION
## Summary

Story 25.1 of Epic 25: removes all `pub(crate)` items that had zero external consumers.

## Changes

**src/carry.rs**
- `CarryActionRejected` struct → private (only used within carry.rs)
- `CarryRejectionReason` enum → private (only used within carry.rs)
- `CarryState::can_accept` → private (no callers outside carry.rs)
- `CarryState::evict_stale_entity` → private (no callers outside carry.rs)

**src/diegetic_ui.rs**
- `update_diegetic_focus` → private (system fn registered in plugin within same file)
- `sync_readable_surface_visibility` → private (same)

**src/world_generation.rs**
- `PlanetSurface::sample_elevation` → `pub` (has many external consumers: scene.rs, debug_overlay.rs, interaction.rs, player.rs — can't be made private; promoted to full pub per principle #7)

## Result

`pub(crate)` count: 8 → 0 (only a commented-out stub remains in carry.rs)

Enforces core principle #7: **No `pub(crate)`**.

## Tests

All tests pass, `make check` clean.

Closes #245