### PR TITLE
feat: 25.3 - promote PlanetSurface::sample_elevation from pub(crate) to pub

### DIFF
--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -334,7 +334,7 @@ impl PlanetSurface {
     /// with lacunarity 2, persistence 0.5). The base `continuous_value_field_01`
     /// returns values in `[0, 1]`, so we center each sample around 0.5 to get
     /// positive and negative deviations from `base_y`.
-    pub(crate) fn sample_elevation(&self, x: f32, z: f32) -> f32 {
+    pub fn sample_elevation(&self, x: f32, z: f32) -> f32 {
         let x = self.fold_elevation_coord(x);
         let z = self.fold_elevation_coord(z);
         let mut total = 0.0_f32;


### PR DESCRIPTION
## Summary

Closes #247 (residual gap — the module merge itself shipped in #263/v1.0.0).

The `world_generation` module tree was merged in story 25.3 (#263), but one `pub(crate)` item was left behind: `PlanetSurface::sample_elevation`. This is called from six modules outside `world_generation` (`scene.rs`, `debug_overlay.rs`, `interaction.rs`, `player.rs`, and test files) — it belongs as `pub` per the story's own rule: "Items that other modules legitimately need are re-exported from mod.rs as pub."
## Change

`src/world_generation.rs`: `pub(crate) fn sample_elevation` → `pub fn sample_elevation`

## Acceptance Criteria Check

- ✅ `world_generation.rs` and submodule: **zero** `pub(crate)` items remain
- ✅ `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — all 707 tests pass
- ✅ No external API breakage (callers in other modules were already using this method)

Closes #247