### PR TITLE
feat: add example mod — glimmersteel new material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ kanban/dist/
 # Aider scratch files
 .aider*
 node_modules/
+
+# User-installed mods (not tracked in VCS).
+# The example mods under mods/ are tracked intentionally.
+# Add your own mod directories here to keep them local:
+# mods/my-name.my-mod/

--- a/mods/example.glimmersteel/README.md
+++ b/mods/example.glimmersteel/README.md
@@ -1,0 +1,94 @@
+# Glimmersteel — Example Mod for Apeiron Cipher
+
+This is the **reference example mod** that ships with Apeiron Cipher's modding
+documentation. It adds a single new material type — Glimmersteel — to the
+material registry. Use it as a starter template for your own material mods.
+
+---
+
+## What this mod does
+
+Glimmersteel is a dense, moderately heat-resistant material with an iridescent
+metallic sheen. It occupies the high-density band above the base game's Osmium,
+making it the heaviest classifiable material in the journal.
+
+| Property           | Derived value (seed 9001) |
+|--------------------|--------------------------|
+| Density            | 0.8158                   |
+| Thermal resistance | 0.4732                   |
+| Reactivity         | 0.0618 (very stable)     |
+| Conductivity       | 0.3061                   |
+| Toxicity           | 0.5298                   |
+
+The material appears in the player's journal once they observe a material
+instance whose density and thermal resistance fall inside Glimmersteel's
+classification ranges.
+
+---
+
+## Mod layout
+
+```
+example.glimmersteel/
+├── mod.toml                              <- manifest (required)
+├── README.md                             <- this file
+└── assets/
+    └── materials/
+        └── classifications.toml         <- the single new classification entry
+```
+
+---
+
+## How to install
+
+1. Copy the `example.glimmersteel/` directory into the game data `mods/`
+   folder (next to the base game `assets/`).
+2. Launch the game. The mod is discovered automatically — no registration step
+   is needed.
+3. Explore. Once you encounter a material instance whose density falls in the
+   0.81–0.88 band and thermal resistance in the 0.42–0.53 band, the journal
+   will label it **Glimmersteel**.
+
+---
+
+## How to adapt this template
+
+### Adding a new material type
+
+1. Pick a seed value **above 9000**. The base game uses 1001–1999; 2000–8999
+   is reserved for future use by the developers.
+2. Compute the derived properties for your seed using the formula in
+   [`docs/modding/data-formats.md`](../../docs/modding/data-formats.md)
+   (or run `derive_material_from_seed` from a debug build).
+3. Choose density and thermal_resistance ranges that do not overlap with any
+   base game entry (see
+   [`assets/materials/classifications.toml`](../../assets/materials/classifications.toml)
+   for the full list).
+4. Add a `[[classification]]` block to your mod's
+   `assets/materials/classifications.toml` with the new entry.
+5. Optionally, reference the seed in `assets/config/biomes.toml` to make the
+   material appear in biome palettes, or add combination rules in
+   `assets/config/combinations.toml`.
+
+### File format reference
+
+See [`docs/modding/data-formats.md`](../../docs/modding/data-formats.md) for
+the full schema of every moddable file.
+
+---
+
+## Compatibility notes
+
+- **No source code changes required.** This mod is 100% data-only.
+- **No conflicts with base game materials.** Glimmersteel's density range
+  (0.81–0.88) starts above Osmium's maximum (0.80), so the two entries never
+  match the same observed instance.
+- **Hot-reload supported.** In debug builds, saving
+  `assets/materials/classifications.toml` while the game is running updates
+  the registry immediately.
+
+---
+
+## License
+
+CC-BY-4.0 — free to use, adapt, and redistribute with attribution.

--- a/mods/example.glimmersteel/assets/materials/classifications.toml
+++ b/mods/example.glimmersteel/assets/materials/classifications.toml
@@ -1,0 +1,46 @@
+# assets/materials/classifications.toml (mod addition)
+# schema_version must be the first field in every asset file.
+schema_version = 1
+
+# ── Glimmersteel ──────────────────────────────────────────────────────────
+#
+# Glimmersteel is a dense, moderately heat-resistant material with an
+# iridescent metallic sheen. It occupies the high-density band above Osmium,
+# making it the heaviest classifiable material in the registry.
+#
+# Property derivation (seed 9001, computed via derive_material_from_seed):
+#   density:           0.8158
+#   thermal_resistance: 0.4732
+#   reactivity:        0.0618  (low — stable under most conditions)
+#   conductivity:      0.3061
+#   toxicity:          0.5298
+#
+# Range choice rationale:
+#   density min/max: 0.80 – 0.88
+#     - Osmium's max is 0.80 (base game classifications.toml).
+#       Our min of 0.80 is exclusive of overlapping that entry because
+#       Osmium's max is 0.80 and we start at 0.80 as well — but Osmium uses
+#       the range 0.68–0.80 and our midpoint is 0.8158 so in practice the
+#       player's journal will not see both entries match simultaneously.
+#       To be safe, set density min = 0.81 so there is zero overlap.
+#   thermal min/max: 0.42 – 0.53
+#     - Verified no base game material sits at (density > 0.80, thermal 0.42–0.53).
+#       Osmium (seed 1006) has thermal=0.5620 which is outside our band.
+#
+# Warning: modders adding further materials in the high-density band must
+# choose density ranges that do not overlap with 0.81–0.88. The journal
+# classifier uses first-match on load order — overlapping ranges produce
+# non-deterministic output.
+
+[[classification]]
+name         = "glimmersteel"
+display_name = "Glimmersteel"
+# Seed 9001: density=0.8158, thermal_resistance=0.4732
+
+[classification.density]
+min = 0.81
+max = 0.88
+
+[classification.thermal_resistance]
+min = 0.42
+max = 0.53

--- a/mods/example.glimmersteel/mod.toml
+++ b/mods/example.glimmersteel/mod.toml
@@ -1,0 +1,28 @@
+# mod.toml — place this at the root of your mod directory.
+# schema_version must always be the first field.
+schema_version = 1
+
+[mod]
+# Globally unique identifier. Use reverse-domain style: author.slug
+# The mod directory name must match this value.
+id        = "example.glimmersteel"
+
+# Human-readable display name.
+name      = "Glimmersteel (Example Mod)"
+
+# Semantic version string.
+version   = "1.0.0"
+
+# Minimum Apeiron Cipher version this mod targets.
+# The game logs a warning (but still loads) if the running version is lower.
+game_version_min = "0.1.0"
+
+[licensing]
+# SPDX license identifier. Required for workshop discoverability.
+# CC-BY-4.0 — permissive, attribution required.
+spdx_license = "CC-BY-4.0"
+
+# Monetization parity rule: if your mod is sold on any paid platform,
+# you must also provide an identical free version. Leave empty if not
+# monetized (see docs/modding/mod-structure.md for the full policy).
+free_distribution_url = ""


### PR DESCRIPTION
## Summary

Adds `mods/example.glimmersteel/` — a complete, minimal reference mod that demonstrates how to add a new material type (Glimmersteel) to Apeiron Cipher.

## What's included

| File | Purpose |
|---|---|
| `mods/example.glimmersteel/mod.toml` | Mod manifest (schema_version, id, name, version, licensing) |
| `mods/example.glimmersteel/assets/materials/classifications.toml` | Single new classification entry — Glimmersteel (seed 9001) |
| `mods/example.glimmersteel/README.md` | Installation guide + template walkthrough |
| `.gitignore` | Documents the mods/ convention (examples tracked; user-local mods excluded) |

## Acceptance criteria

- [x] Proper `mod.toml` manifest matching the schema in `docs/modding/mod-structure.md`
- [x] Material definition file follows `docs/modding/data-formats.md` format
- [x] Classification ranges derived from `derive_material_from_seed(9001)` — no overlap with any base-game material range
- [x] README explains installation, properties, and how to adapt the template
- [x] `make check` passes

## Property values

Seed 9001 (verified via Python simulation of `derive_material_from_seed`):
- density: 0.8158 → classification range 0.81–0.88 (above Osmium max 0.80, no overlap)
- thermal_resistance: 0.4732 → classification range 0.42–0.53

Closes kanban task t_5a7771db

Follows modding docs from PR #458 (`docs/modding-guide` branch).