### PR TITLE
docs: add example structure mod — solar-array

### DIFF
--- a/mods/example.solar-array/README.md
+++ b/mods/example.solar-array/README.md
@@ -1,0 +1,206 @@
+# Solar Array — Example Structure Mod for Apeiron Cipher
+
+This is the **reference example for structure mods** that ships with Apeiron Cipher's
+modding documentation. It adds the Solar Array — a buildable photovoltaic structure
+that harvests stellar radiation — as a fully defined structure ready to integrate with
+the game's construction and power systems.
+
+---
+
+## What this mod does
+
+The Solar Array mod defines a complete, minimal structure from the ground up:
+
+- **New material:** Solite (seed 9101) — a photovoltaic semiconductor found in
+  irradiated surface deposits near luminous stars
+- **New deposit type:** Solite deposits on exterior surfaces (additive, rare weight 0.6)
+- **New structure:** `solar_array` — a 4m×4m exterior-placement power structure built
+  from Photovoltaic Panels, an Orientation Frame, and a Power Junction
+
+The structure definition demonstrates every field the construction system will consume:
+blueprint footprint, build cost by component, forward-compatible effects, sprite paths,
+and deconstruction recovery rules.
+
+---
+
+## What is playable today vs. future epics
+
+The construction and power systems are planned for Epic 8+. Before that:
+
+| Capability | Status |
+|---|---|
+| Solite material classification loads, classifies observed samples | Ready today — uses existing MaterialPlugin |
+| Solite deposit type spawns on exterior surfaces | Ready today — uses existing exterior deposit system |
+| Structure definition file loads, logs `AssetEvent::Added` | Ready when structure asset loader ships (Epic 8+) |
+| Blueprint editor shows Solar Array in build menu | Requires Epic 8+ construction system |
+| Structure builds from Photovoltaic Panel + Orientation Frame + Power Junction | Requires Epic 8+ construction system |
+| Power output scales with star luminosity | Requires Epic 8+ power system |
+| Environmental modifiers reduce output in corrosive/dim conditions | Requires Epic 8+ simulation layer |
+| Deconstruction returns 75% of materials | Requires Epic 8+ construction system |
+
+**Today:** The material classification and deposit files load and function immediately.
+Solite samples spawn on terrain, appear in the journal, and are classifiable. The
+structure definition file is structurally valid — when the construction system ships,
+it discovers this file automatically. No re-authoring needed.
+
+---
+
+## The Solar Array
+
+A photovoltaic array mounted on a motorized orientation frame. Four panels track the
+local star across the sky. Output is proportional to stellar luminosity and degrades
+slightly over time as panel surfaces weather.
+
+When fully built on a temperate world orbiting a G-type star, a single solar array
+produces enough energy to power a small fabrication workspace. On a high-luminosity
+hot star, output nearly doubles. On a dim red dwarf, the same array struggles to
+power a single appliance.
+
+### Build cost
+
+| Component | Quantity | Materials |
+|---|---|---|
+| Photovoltaic Panel | 4 | 3× Solite + 1× Silite per panel |
+| Orientation Frame | 1 | 6× Ferrite + 2× Osmium |
+| Power Junction | 1 | 4× Cobaltine + 2× Ferrite |
+
+### Effects
+
+- **Power output:** 12.0 energy units / game-day at baseline (G-type star, 1 AU)
+- **Scaling:** linear with star luminosity, inverse with orbital distance
+- **Corrosive atmosphere:** ×0.6 output multiplier
+- **Low light (luminosity < 0.3):** ×0.2 output multiplier
+- **Degradation:** –0.5% condition / game-day (replace panels periodically)
+
+### Deconstruction
+
+- 75% material recovery at full condition (scales with condition)
+- Orientation Frame is guaranteed recovery (precision component, fully disassembles)
+
+---
+
+## Mod layout
+
+```
+example.solar-array/
+├── mod.toml                                  <- manifest (required)
+├── README.md                                 <- this file
+└── assets/
+    ├── materials/
+    │   └── classifications.toml             <- Solite material classification (seed 9101)
+    ├── exterior/
+    │   └── surface_mineral_deposits.toml    <- Solite deposit type (additive)
+    └── structures/
+        └── solar_array.toml                 <- structure definition (forward-compatible)
+```
+
+---
+
+## How to install
+
+1. Copy the `example.solar-array/` directory into the game data `mods/` folder.
+2. Launch the game. Solite deposits begin spawning on terrain immediately.
+3. Collect Solite samples — they appear blue-white and slightly translucent in bright
+   environments. The journal classifies them once thermal resistance is revealed.
+4. When the construction system ships: enter blueprint mode, find Solar Array under the
+   Power category, check the build cost, collect the remaining materials, and confirm.
+
+---
+
+## Discovering Solite in-game
+
+Solite is rare. It spawns in irradiated surface layers — look for planets close to
+their star or with documented radiation events in the journal. The deposit clusters
+are small (4–7 nodes) and tightly grouped. When you find a cluster, collect all of
+it — there won't be much nearby.
+
+The journal classifies Solite once you've observed enough samples to reveal its
+thermal resistance. Its density profile (very light) and conductivity (high) are
+the first tells. Once classified, the journal shows its name.
+
+---
+
+## How to adapt this template
+
+### Defining a new structure
+
+1. Create `assets/structures/your_structure.toml`. Copy from `solar_array.toml`.
+2. Set a unique `structure.id` (snake_case). This ID ties the structure to its cost
+   entries, effects, and blueprint preview.
+3. Set `category` to one of: `"power"`, `"storage"`, `"extraction"`, `"habitat"`,
+   `"defense"`, `"decoration"`.
+4. Set `blueprint.placement` to `"exterior"`, `"interior"`, or `"both"`.
+5. Define `[[cost.components]]` entries — each component is staged separately.
+   Each component gets `[[cost.components.materials]]` entries with `material_seed`
+   and `quantity`.
+6. Define `[effects]` — the simulation layer reads these when the structure is active.
+7. Optionally define `[deconstruction]` — if absent, the game uses the default
+   (50% material recovery, no guaranteed components).
+
+### Adding a new material for your structure
+
+1. Choose a seed above 9000. Verify no other mod you depend on uses it.
+2. Create `assets/materials/classifications.toml` in your mod.
+3. Add a `[[classification]]` entry with `name`, `display_name`, and property ranges.
+4. Keep the ranges clearly distinct from base game entries
+   (see docs/modding/best-practices.md). Run the overlap check:
+   `python3 -c "import tomllib; ..."` or use `cargo test` once asset_validation
+   is available. Solite's density range was adjusted during development to avoid
+   overlapping Calcium's density [0.09, 0.20] at the compound density×tr check.
+5. Reference your seed in `[[cost.components.materials]]` in the structure definition.
+
+### Making the material discoverable on terrain
+
+1. Create `assets/exterior/surface_mineral_deposits.toml` in your mod.
+2. Add a `[[deposits]]` entry. Choose a low `selection_weight` (0.3–0.8) for rare
+   materials so the player has to seek them out.
+3. The key is your deposit identifier; it does not need to match the material name.
+
+---
+
+## Forward-compatibility notes
+
+### Why forward-declare the structure if it doesn't build yet?
+
+For the same reason the language example mod forward-declares vocabulary before the
+language system ships: when the construction system comes online, it scans all
+`assets/structures/*.toml` files — in the base game and in every loaded mod — and
+populates the structure registry. If the file exists and is valid, the structure
+appears in the build menu automatically.
+
+Authoring the file now means:
+- The mod is structurally testable today via `cargo test --test asset_validation`
+- Modders have a concrete annotated example to learn from before the system ships
+- No re-authoring needed when Epic 8+ lands
+
+### What "forward-compatible" means in practice
+
+Every `structures/*.toml` file must pass the asset validator. That validator checks:
+- `schema_version` is present and is a positive integer
+- Required fields (`structure.id`, `structure.display_name`, `blueprint.*`) are present
+- `placement` is one of the allowed values
+- All `material_seed` references are positive integers (existence is not validated
+  until the material system ships)
+- TOML syntax is well-formed
+
+The structure system will add additional semantic validation (does the footprint
+fit on the terrain type? do all referenced material seeds exist?) when it ships.
+For now, structural validity is sufficient.
+
+---
+
+## Compatibility notes
+
+- **No source code changes required.** This mod is 100% data-only.
+- **Additive content only.** The new deposit type and material classification do not
+  replace any base game entry. See docs/modding/best-practices.md.
+- **Seed 9101 is claimed.** If you fork this mod, choose a different seed for your
+  version of Solite to avoid cross-mod classification conflicts.
+- **Forward-compatible schema.** All files carry `schema_version = 1`. The loader
+  migrates older files forward automatically when the schema increments.
+
+---
+
+## License
+
+CC-BY-4.0 — free to use, adapt, and redistribute with attribution.

--- a/mods/example.solar-array/assets/exterior/surface_mineral_deposits.toml
+++ b/mods/example.solar-array/assets/exterior/surface_mineral_deposits.toml
@@ -1,0 +1,27 @@
+schema_version = 1
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Surface mineral deposit additions for Solite.
+#
+# Solite appears in irradiated surface layers — planets close to luminous stars
+# or exposed to prolonged radiation events. It clusters in small, shallow
+# deposits with moderate density.
+#
+# This entry is additive: it adds Solite deposits to the pool without removing
+# any base game deposit types. See docs/modding/best-practices.md —
+# "Use additive content where possible".
+#
+# Selection weights are proportional. Adding Solite with weight 0.6 reduces
+# every other type's relative frequency slightly. The total pool grows.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[[deposits]]
+key               = "solite_deposit"    # snake_case identifier
+selection_weight  = 0.6                 # Less common than base types — rare find
+scale_min         = 0.7
+scale_max         = 1.0
+deposit_radius_min = 1.8
+deposit_radius_max = 2.8
+child_count_min   = 4
+child_count_max   = 7
+cluster_compactness = 0.60              # Moderately tight cluster

--- a/mods/example.solar-array/assets/materials/classifications.toml
+++ b/mods/example.solar-array/assets/materials/classifications.toml
@@ -1,0 +1,44 @@
+schema_version = 1
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Solite — Material Classification
+#
+# Solite is a photovoltaic semiconductor discovered in irradiated surface layers
+# on planets near luminous stars. Its high thermal_resistance keeps it stable
+# under direct stellar radiation, while its distinctive conductivity profile
+# makes it valuable for energy-conversion components.
+#
+# Modders adding new materials should use seeds above 9000. The base game
+# reserves seeds 1001–8999. This mod uses seed 9101.
+#
+# See docs/modding/data-formats.md — "Do not collide with base game seed space".
+# ──────────────────────────────────────────────────────────────────────────────
+
+[[classification]]
+name         = "solite"         # internal key, snake_case — used in combination rules
+display_name = "Solite"         # shown in the journal
+
+# Property ranges (all values inclusive, 0.0–1.0).
+# These ranges are intentionally distinct from all base game entries:
+#   density 0.21–0.30 × thermal_resistance 0.75–0.90
+# Density min 0.21 sits above Calcium's max (0.20), preventing any compound overlap.
+# Check docs/modding/best-practices.md — "Do not overlap classification ranges".
+[classification.density]
+min = 0.21
+max = 0.30
+
+[classification.thermal_resistance]
+min = 0.75
+max = 0.90
+
+[classification.conductivity]
+min = 0.60
+max = 0.80
+
+[classification.reactivity]
+min = 0.05
+max = 0.25
+
+[classification.toxicity]
+min = 0.00
+max = 0.10

--- a/mods/example.solar-array/assets/structures/solar_array.toml
+++ b/mods/example.solar-array/assets/structures/solar_array.toml
@@ -1,0 +1,169 @@
+schema_version = 1
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Solar Array Structure Definition
+#
+# The solar array is a buildable structure that harvests stellar radiation and
+# converts it to usable energy output. It is built from fabricated photovoltaic
+# panels (Solite-coated substrate), an orientation frame, and a power junction.
+#
+# This file defines the structure's properties so the construction system can
+# route it to the blueprint editor, cost estimator, and buildability checker
+# when the structure system ships (Epic 8+).
+#
+# The structure is intentionally minimal — one component type, low material
+# cost, exterior placement only — making it the canonical "hello world" for
+# structure mods.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[structure]
+# Globally unique structure identifier. snake_case.
+id           = "solar_array"
+
+# Human-readable name shown in the blueprint editor and build journal.
+display_name = "Solar Array"
+
+# Description rendered in the blueprint editor detail panel.
+description  = "A photovoltaic array mounted on an orientation frame. Harvests stellar radiation and routes it to an attached power junction. Output scales with star luminosity and panel condition."
+
+# Category used to group structures in the blueprint editor.
+# Values: "power", "storage", "extraction", "habitat", "defense", "decoration"
+category     = "power"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Blueprint
+#
+# Describes the structure's 3D footprint. The blueprint editor uses this to
+# preview placement and check for terrain conflicts before confirmation.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[blueprint]
+# Footprint in Bevy world units (X = east/west, Z = north/south).
+# The editor snaps the footprint to the grid before placement confirmation.
+footprint_x       = 4.0   # meters
+footprint_z       = 4.0   # meters
+
+# Height of the structure above its base plane.
+height            = 2.5   # meters
+
+# Whether the structure can be placed on the exterior surface.
+# false = interior only (room structures), true = exterior only, "both" = either.
+placement         = "exterior"
+
+# Whether to align the array's tilt axis to the star direction at placement time.
+# The game calls the orientation helper on confirmation if true.
+orient_to_star    = true
+
+# Clearance required between this structure and any other structure's footprint.
+min_clearance     = 1.0   # meters
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Build cost
+#
+# Materials consumed by the fabricator to produce each component. Components
+# are staged in order — the player builds component 1 first, then 2, etc.
+# Any component can be partially built (progress is saved).
+#
+# material_seed references the seed used to derive the material's properties.
+# See docs/modding/data-formats.md — Well-known material seeds.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[[cost.components]]
+component_id    = "photovoltaic_panel"
+display_name    = "Photovoltaic Panel"
+quantity        = 4            # 4 panels per array
+
+# Each panel requires:
+[[cost.components.materials]]
+material_seed   = 9101         # Solite — see assets/materials/classifications.toml
+quantity        = 3.0          # units of Solite per panel
+
+[[cost.components.materials]]
+material_seed   = 1009         # Silite (base game — structural glass substrate)
+quantity        = 1.0
+
+[[cost.components]]
+component_id    = "orientation_frame"
+display_name    = "Orientation Frame"
+quantity        = 1
+
+[[cost.components.materials]]
+material_seed   = 1001         # Ferrite (base game — structural member)
+quantity        = 6.0
+
+[[cost.components.materials]]
+material_seed   = 1006         # Osmium (base game — high-mass pivot joints)
+quantity        = 2.0
+
+[[cost.components]]
+component_id    = "power_junction"
+display_name    = "Power Junction"
+quantity        = 1
+
+[[cost.components.materials]]
+material_seed   = 1008         # Cobaltine (base game — conductive wiring)
+quantity        = 4.0
+
+[[cost.components.materials]]
+material_seed   = 1001         # Ferrite (base game — housing)
+quantity        = 2.0
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Effects
+#
+# What the structure does once fully built and operational. Effects are
+# evaluated by the simulation layer — they are not UI numbers.
+#
+# The power system is planned for Epic 8+. These entries are forward-declared
+# here exactly as the language mod forward-declares language system hooks.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[effects]
+# Power output in arbitrary energy units per game-day at baseline luminosity
+# (1.0 luminosity = a G-type main sequence star at 1 AU).
+# Scales linearly with the current star's luminosity and inversely with
+# distance from the star in AU.
+power_output_base    = 12.0
+
+# The structure degrades over time. At 0.0 condition it produces no power.
+# Condition degrades at `degradation_rate_per_day` per in-game day.
+degradation_rate_per_day = 0.005
+
+# Environmental modifiers. Each condition that applies multiplies the output.
+# "corrosive_atmosphere" — applies on planets with high-reactivity surface.
+# "low_light"           — applies when star luminosity < 0.3.
+[[effects.environmental_modifiers]]
+condition    = "corrosive_atmosphere"
+multiplier   = 0.6    # Corrosive air slowly etches the panel surface.
+
+[[effects.environmental_modifiers]]
+condition    = "low_light"
+multiplier   = 0.2    # Dim star, dim output.
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sprites
+#
+# Sprite paths are relative to the mod's assets/ directory.
+# Resolution conventions: structures use 128×128 icon sprites and
+# 256×256 build-preview sprites. The game falls back to a generated
+# placeholder if the sprite is absent.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[sprites]
+icon          = "structures/solar_array_icon.png"
+build_preview = "structures/solar_array_preview.png"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Deconstruction
+#
+# What the player recovers when they deconstruct a fully built array.
+# Recovery is reduced for degraded structures (linear scale with condition).
+# ──────────────────────────────────────────────────────────────────────────────
+
+[deconstruction]
+# Fraction of each material that is recovered at full condition.
+material_recovery_fraction = 0.75
+
+# The orientation_frame is a precision component — all screws come back.
+[[deconstruction.guaranteed_components]]
+component_id = "orientation_frame"

--- a/mods/example.solar-array/mod.toml
+++ b/mods/example.solar-array/mod.toml
@@ -1,0 +1,28 @@
+# mod.toml — place this at the root of your mod directory.
+# schema_version must always be the first field.
+schema_version = 1
+
+[mod]
+# Globally unique identifier. Use reverse-domain style: author.slug
+# The mod directory name must match this value exactly.
+id        = "example.solar-array"
+
+# Human-readable display name.
+name      = "Solar Array (Example Structure Mod)"
+
+# Semantic version string.
+version   = "1.0.0"
+
+# Minimum Apeiron Cipher version this mod targets.
+# The game logs a warning (but still loads) if the running version is lower.
+game_version_min = "0.1.0"
+
+[licensing]
+# SPDX license identifier. Required for workshop discoverability.
+# CC-BY-4.0 — permissive, attribution required.
+spdx_license = "CC-BY-4.0"
+
+# Monetization parity rule: if your mod is sold on any paid platform,
+# you must also provide an identical free version. Leave empty if not
+# monetized (see docs/modding/mod-structure.md for the full policy).
+free_distribution_url = ""


### PR DESCRIPTION
## Summary

Adds `mods/example.solar-array/` — the reference example for structure mods
that ships with Apeiron Cipher's modding documentation.

Follows the same pattern as `example.deep-sign` (PR #458): data-only,
forward-compatible with future epics, annotated for modders to learn from.

## Files added

- `mod.toml` — manifest (schema_version=1)
- `README.md` — install guide, build cost table, Epic 8+ compatibility notes, adapt-this-template section
- `assets/materials/classifications.toml` — Solite material (seed 9101), no range overlap with base game materials (verified)
- `assets/exterior/surface_mineral_deposits.toml` — Solite deposit type (additive, weight 0.6)
- `assets/structures/solar_array.toml` — full structure definition: blueprint, 3-component build cost, power effects + environmental modifiers, deconstruction recovery, sprite paths

## What works today vs. Epic 8+

| Capability | Status |
|---|---|
| Solite classification loads, classifies samples | **Ready today** — existing MaterialPlugin |
| Solite deposits spawn on exterior terrain | **Ready today** — existing deposit system |
| Structure definition loads, registers in structure system | Ready when construction system ships (Epic 8+) |
| Blueprint editor shows Solar Array | Epic 8+ |
| Build from components, power output | Epic 8+ |

## Test plan

- All 4 TOML files parse cleanly (schema_version=1, well-formed)
- Solite density range [0.21, 0.30] × thermal_resistance [0.75, 0.90] — no overlap with any base game material classification (verified programmatically against assets/materials/classifications.toml)
- `cargo test` passes (all 14 tests)

Closes part of the modding documentation suite (companion to PR #458).