### PR TITLE
docs: add modding guide and manifest-schema reference

### DIFF
--- a/docs/modding/README.md
+++ b/docs/modding/README.md
@@ -1,0 +1,39 @@
+# Apeiron Cipher — Modding Guide
+
+Welcome. This guide tells you everything you need to start building a mod for
+Apeiron Cipher. Read it top-to-bottom once, then use it as a reference.
+
+## What you can do right now
+
+Apeiron Cipher is data-driven by design (Core Principle 6). Everything the game
+reads from `assets/` is already moddable today: materials, biomes, combinations,
+carry tuning, star types, orbital layout, surface deposits, scene configuration,
+and more. A mod is just a parallel directory tree that mirrors `assets/`.
+
+Full compiled-logic modding (Bevy plugins, WASM) is deferred to Epic 23. This
+guide covers what is available and stable today.
+
+## Guide index
+
+| Document | What it covers |
+|---|---|
+| [Mod Structure](./mod-structure.md) | Directory layout, `mod.toml` manifest, quick start |
+| [Manifest Schema](./manifest-schema.md) | Complete `mod.toml` field reference with examples |
+| [Data File Formats](./data-formats.md) | TOML schemas for every moddable domain |
+| [Extensibility Points](./extensibility-points.md) | What each asset domain controls and how |
+| [Best Practices](./best-practices.md) | Compatibility, versioning, testing |
+
+## Quick start
+
+1. Create `mods/your-name.your-mod/` in the game data directory.
+2. Copy `mod.toml` from [Mod Structure](./mod-structure.md) and fill in your info.
+3. Create an `assets/` subdirectory inside your mod directory that mirrors the
+   base game layout — only include the files you want to add or change.
+4. Run the game. Your files load alongside base game assets via the same
+   `AssetServer` pipeline.
+
+## Foundational rule
+
+Mods live entirely in data files. You do not need to recompile the game, modify
+Rust source, or distribute binaries. If your mod adds a `.toml` or `.ron` file
+in the right directory, it works.

--- a/docs/modding/best-practices.md
+++ b/docs/modding/best-practices.md
@@ -1,0 +1,147 @@
+# Best Practices
+
+## Compatibility
+
+### Respect the schema_version field
+
+Always start every data file with `schema_version = 1` (or the current
+version the game expects). The loader will refuse or mangle files without it.
+
+```toml
+schema_version = 1   # <- first line, always
+```
+
+### Do not collide with base game seed space
+
+Material seeds 1001–8999 are reserved for base game use. Use seeds 9000 and
+above for mod-specific materials. Seeds below 1001 are also reserved.
+
+If two mods use the same seed for different materials, the material derived
+from that seed will be the same in both mods (seeds are deterministic). Do not
+rely on seed space to uniquely identify your materials across mods — use the
+classification entry's `name` field for that.
+
+### Do not overlap classification ranges
+
+Material classification uses the first matching entry. If your mod defines a
+classification entry whose (density × thermal_resistance) range overlaps an
+existing base game entry, the order of loading determines which name the
+player sees. To avoid this:
+- Choose ranges that are clearly distinct from base game entries.
+- Document your chosen ranges in your README.
+
+### Use additive content where possible
+
+Adding new biomes, new classification entries, and new deposit types is always
+safer than replacing existing ones. Additions do not require knowledge of what
+other mods are doing. Replacements (providing a file at the same path as a
+base game file) will override the entire file — not just the entry you wanted
+to change — which can break other mods that expected the base content to be
+present.
+
+Resolution order for path conflicts is deferred to Epic 23. For now, treat
+mods as additive-only.
+
+---
+
+## Versioning
+
+### Semantic version your mod
+
+Use semver in `mod.toml`:
+- **Patch** (`0.1.0` → `0.1.1`): bug fixes, typo corrections, tuning tweaks
+  that do not change how the mod functions.
+- **Minor** (`0.1.0` → `0.2.0`): new content added (new biome, new
+  classification, new deposit type). Existing content unchanged.
+- **Major** (`0.1.0` → `1.0.0`): breaking changes — removes content,
+  changes an existing entry's behavior, or requires a new `game_version_min`.
+
+### Update game_version_min when you use new features
+
+If a new game version adds a field or asset domain that your mod depends on,
+update `game_version_min` to that version. The game will warn players running
+older versions rather than silently loading a partially broken mod.
+
+### Never change a material seed's meaning once published
+
+If players have a saved game that uses your mod's seed 9042 as "Viridite",
+and you change seed 9042 to "Ashite" in a new version, those saved games will
+mis-classify their existing materials. Treat seed assignments as permanent. To
+add a new material type, pick a new seed.
+
+---
+
+## Testing
+
+### Run the asset validator
+
+The game ships an integration test that walks every file in `assets/` and
+`mods/` through the same validation logic used at load time:
+
+```bash
+cargo test --test asset_validation
+```
+
+Run this against your mod files before distributing. It catches malformed
+TOML, out-of-range values, and missing required fields without launching the
+full game.
+
+### Use hot-reload during development
+
+In debug builds (`cargo run` without `--release`), the game watches asset
+files for changes and reloads them in place. Edit your TOML file, save it,
+and the game picks up the change without a restart.
+
+What hot-reloads:
+- Classification entries (journal queries update immediately)
+- Biome configuration (new chunks use updated biomes)
+- Combination rules (next combination uses the updated rule)
+- Carry tuning
+- Confidence parameters
+- Knowledge graph thresholds
+- Scene configuration (re-initializes affected entities)
+
+What does not hot-reload without a restart:
+- World generation seed (restart required for a fresh planet)
+- Orbital configuration (restart required)
+
+### Test with a clean save
+
+Many of the game's systems build state from seed derivation at startup. If
+you are testing changes to biome palettes or deposit configurations, delete
+your save file and restart the game so the world generates from scratch with
+your updated data.
+
+### Verify determinism
+
+The game is deterministic: the same seed with the same data always produces
+the same world. If your mod changes the selection weights of biomes or deposit
+types, the same planet seed will now produce a different world layout. This is
+expected — but document which version of your mod produced which world layout,
+because players may not be able to reproduce an earlier run after a mod update.
+
+---
+
+## Compliance
+
+### The monetization parity rule
+
+If you distribute your mod on any paid platform (paid download, paid DLC,
+etc.), you must also provide an identical free version. The `mod.toml`
+`free_distribution_url` field is where you record that URL.
+
+This is a structural commitment — validation against the URL is not automated
+in the current release. Epic 23 will add enforcement. Mods that shipped
+without a valid `free_distribution_url` before Epic 23 will need a manifest
+update.
+
+Empty string means "not monetized." That is the safe default.
+
+### Licensing
+
+Set `spdx_license` to a valid SPDX identifier. For content mods,
+`CC-BY-4.0` (attribution required, free to share and adapt) is a good
+default. For fully open work, `CC0-1.0` (public domain dedication) is the
+most permissive. Use `LicenseRef-proprietary` if you are keeping the mod
+source private, but note that this conflicts with the free-distribution
+requirement for any paid mod.

--- a/docs/modding/data-formats.md
+++ b/docs/modding/data-formats.md
@@ -1,0 +1,393 @@
+# Data File Formats
+
+All moddable game data lives in `.toml` files under `assets/`. Every file must
+begin with `schema_version = N`. The loader reads this first and migrates older
+files forward automatically — you never need to re-ship files just because the
+schema version incremented.
+
+## Universal rules
+
+1. Every file starts with `schema_version = N` as the absolute first field.
+2. Fields are `snake_case`.
+3. No version numbers in filenames — the version lives inside the file.
+4. TOML for all human-editable data. RON for serialized Bevy asset types.
+5. All numeric ranges are inclusive (`min` ≤ value ≤ `max`).
+
+---
+
+## assets/materials/classifications.toml
+
+Controls how observed material properties map to display names (e.g. "Ferrite",
+"Calcium"). Classification is never stored on an entity — it is computed at
+query time by comparing the player's revealed property values to these ranges.
+
+```toml
+schema_version = 1
+
+[[classification]]
+name         = "my_material"      # internal key, snake_case
+display_name = "My Material"      # shown in the journal
+
+[classification.density]
+min = 0.30    # inclusive lower bound
+max = 0.45    # inclusive upper bound
+
+[classification.thermal_resistance]
+min = 0.50
+max = 0.70
+```
+
+### Property reference
+
+| Property | Range | Description |
+|---|---|---|
+| `density` | 0.0–1.0 | Derived from the material seed. Drives weight perception. |
+| `thermal_resistance` | 0.0–1.0 | Resistance to heat. Revealed by heat exposure. |
+| `reactivity` | 0.0–1.0 | How aggressively the material reacts. Reserved. |
+| `conductivity` | 0.0–1.0 | Heat/electrical conductivity. Reserved. |
+| `toxicity` | 0.0–1.0 | Toxicity. Reserved. |
+
+**Warning:** Ranges must not overlap between two classification entries for
+the same (density × thermal_resistance) region. The journal classifies using
+the first matching entry — overlapping ranges produce non-deterministic results
+depending on file load order.
+
+---
+
+## assets/config/biomes.toml
+
+Defines biome regions in temperature × moisture space and the material palette
+for each biome.
+
+```toml
+schema_version = 1
+
+# How many chunks fit in one period of the biome noise field.
+# Larger = bigger biome regions.
+noise_scale_chunks = 12.0
+
+# Sub-channel constants for independent temperature and moisture noise fields.
+# Keep these non-zero and distinct.
+temperature_noise_channel = 0xB10E_0001_0000_0001
+moisture_noise_channel    = 0xB10E_0001_0000_0002
+
+# Biome used when no range matches the chunk's (temperature, moisture) pair.
+fallback_biome_type = "mineral_steppe"
+
+[[biomes]]
+biome_type = "my_biome"   # snake_case identifier
+
+# Normalized temperature range [0, 1]. 0 = cold, 1 = hot.
+temperature_min = 0.5
+temperature_max = 0.8
+
+# Absolute temperature bounds in Kelvin (used for environment derivation).
+temperature_abs_min_k = 280.0
+temperature_abs_max_k = 420.0
+
+# Normalized moisture range [0, 1]. 0 = dry, 1 = wet.
+moisture_min = 0.2
+moisture_max = 0.6
+
+# RGB ground color. Values in [0, 1].
+ground_color = [0.4, 0.35, 0.25]
+
+# Multiplier on surface deposit density. 1.0 = baseline.
+density_modifier = 1.1
+
+# Material palette: which materials appear in this biome and how often.
+# material_seed references the seed used to derive a specific material.
+[[biomes.material_palette]]
+material_seed    = 1001    # Ferrite
+selection_weight = 3.0     # Higher = more common
+
+[[biomes.material_palette]]
+material_seed    = 1003    # Sulfurite
+selection_weight = 1.5
+```
+
+### Well-known material seeds
+
+These seeds ship in the base game. Your mod can reference them in palettes and
+combination rules without redefining the materials.
+
+| Seed | Name |
+|---|---|
+| 1001 | Ferrite |
+| 1002 | Calcium |
+| 1003 | Sulfurite |
+| 1004 | Prismate |
+| 1005 | Verdant |
+| 1006 | Osmium |
+| 1007 | Volatite |
+| 1008 | Cobaltine |
+| 1009 | Silite |
+| 1010 | Phosphite |
+
+To add a new material type, choose a seed value above 9000 (the base game uses
+1001–1999 and reserves 2000–8999 for future use). Add a classification entry
+and reference the seed in any biome palette or combination rule.
+
+---
+
+## assets/config/combinations.toml
+
+Defines how two materials interact when combined at the fabricator. Missing
+pairs fall back to the `default_rule` (equal-weight blend).
+
+```toml
+schema_version = 1
+
+# Default rule when no specific pair entry exists.
+[default_rule]
+type = "Blend"
+weight_a = 0.5
+weight_b = 0.5
+
+[[rules]]
+material_seed_a = 1001   # Ferrite
+material_seed_b = 1003   # Sulfurite
+
+# Per-property rules. Omit a property to use default_rule for it.
+density          = { type = "Max" }
+thermal_resistance = { type = "Catalyze", multiplier = 1.4 }
+reactivity       = { type = "Blend", weight_a = 0.7, weight_b = 0.3 }
+conductivity     = { type = "Min" }
+toxicity         = { type = "Blend", weight_a = 0.5, weight_b = 0.5 }
+```
+
+### Rule types
+
+| Type | Effect |
+|---|---|
+| `Blend { weight_a, weight_b }` | Weighted average of the two inputs. Predictable. |
+| `Max` | Takes the higher of the two values. Predictable. |
+| `Min` | Takes the lower of the two values. Predictable. |
+| `Catalyze { multiplier }` | `max(a, b) * multiplier`. Can exceed either input. Emergent. |
+| `Inert` | All output properties set to 0.1 — produces waste material. |
+
+Order of `material_seed_a` / `material_seed_b` does not matter.
+
+---
+
+## assets/config/world_generation.toml
+
+Controls world and planet generation parameters.
+
+```toml
+schema_version = 1
+
+# Direct planet seed override. Comment out to use system-derived mode.
+planet_seed = 20260408
+
+# System-derived mode: provide solar_system_seed + planet_index instead.
+# solar_system_seed = 20261225
+# planet_index = 2
+
+# Exterior chunk size in Bevy world units.
+chunk_size_world_units = 45.0
+
+# Active neighborhood radius around the player's current chunk.
+# 1 = 3x3 block of chunks.
+active_chunk_radius = 1
+
+# Cell size for spatial overlap detection when merging player additions.
+building_cell_size = 1.0
+
+# Planet surface size bounds in chunks.
+planet_radius_min_chunks = 8
+planet_radius_max_chunks = 24
+```
+
+---
+
+## assets/config/star_types.toml
+
+Defines the statistical properties of star types used in solar system generation.
+
+```toml
+schema_version = 1
+
+[[star_types]]
+star_type       = "my_star_type"    # snake_case identifier
+luminosity_min  = 0.5
+luminosity_max  = 2.0
+temperature_min = 4000              # Kelvin
+temperature_max = 7000              # Kelvin
+mass_min        = 0.7               # Solar masses
+mass_max        = 1.5               # Solar masses
+weight          = 1.0               # Selection weight (higher = more common)
+```
+
+---
+
+## assets/config/orbital_config.toml
+
+Controls how many planets a solar system can have and where they orbit.
+
+```toml
+schema_version = 1
+
+planet_count_min   = 2
+planet_count_max   = 8
+inner_orbit_au     = 0.3    # Minimum orbital distance in AU
+outer_orbit_au     = 50.0   # Maximum orbital distance in AU
+min_separation_au  = 0.5    # Minimum gap between adjacent orbits
+```
+
+---
+
+## assets/config/carry.toml
+
+Tunes the player's carrying capacity, stamina behavior, and weight feedback cues.
+
+```toml
+schema_version = 1
+
+active_profile       = "default"
+starting_capacity    = 5.0
+starting_strength    = 1.0
+growth_rate          = 0.02
+
+# Optional: tie carry capacity to an inventory item.
+# carry_device_item_key = "satchel_basic"
+# grant_starting_device = true
+
+[growth_curve]
+kind         = "asymptotic"
+max_strength = 8.0
+
+# Weight description strings shown diegetically (no UI text — these feed
+# in-world feedback mechanisms, not overlay text).
+[[weight_descriptions]]
+max_ratio = 0.3
+text      = "Light enough to carry easily"
+
+# [profiles.default] and [profiles.relaxed] control stamina and speed curves.
+[profiles.default]
+stamina_cost_multiplier = 1.4
+hard_limit_enabled      = true
+
+[profiles.default.speed_curve]
+kind            = "linear"
+min_multiplier  = 0.45
+exponent        = 1.35
+```
+
+---
+
+## assets/config/confidence.toml
+
+Controls how player confidence in material property observations evolves through
+use and degrades through death.
+
+```toml
+schema_version = 1
+
+# Fraction of confidence retained on death (0.0 = total loss, 1.0 = no loss).
+death_degradation_factor = 0.6
+
+# Minimum confidence after death (prevents total knowledge erasure).
+death_floor = 0.2
+
+# Recovery multiplier when re-engaging the domain that caused death.
+domain_recovery_multiplier = 2.0
+
+# Recovery multiplier for unrelated domains.
+passive_recovery_multiplier = 0.7
+
+# Evidence strength for a single observation.
+base_observation_weight = 0.2
+```
+
+---
+
+## assets/config/knowledge_graph.toml
+
+Controls the similarity thresholds that govern when the journal surfaces
+cross-material connections.
+
+```toml
+schema_version = 1
+
+# Minimum cosine similarity (0.0–1.0) to create a SimilarTo edge.
+# Typical range: 0.7–0.95
+similarity_score_threshold = 0.85
+
+# Minimum confidence on both nodes before SimilarTo edge is created.
+# Typical range: 0.2–0.5
+similarity_confidence_threshold = 0.3
+```
+
+---
+
+## assets/exterior/surface_mineral_deposits.toml
+
+Controls how surface mineral deposit clusters are placed across chunks.
+
+```toml
+schema_version = 1
+
+# Distance between deposit-site candidate cells inside each chunk.
+site_spacing_world_units = 8.5
+
+# Scale of the continuous site-density noise field.
+site_density_field_scale_world_units = 24.0
+
+# Minimum field value for a site candidate to become a visible deposit.
+site_spawn_threshold = 0.42
+
+# Maximum jitter as a fraction of site_spacing_world_units.
+site_jitter_fraction = 0.28
+
+# Minimum air gap between separate deposit sites (meters).
+site_min_gap_world_units = 1.5
+
+[[deposits]]
+key               = "my_deposit_type"   # snake_case identifier
+selection_weight  = 1.0
+scale_min         = 0.9
+scale_max         = 1.2
+deposit_radius_min = 2.4
+deposit_radius_max = 3.8
+child_count_min   = 7
+child_count_max   = 11
+cluster_compactness = 0.75   # 0 = loose, 1 = tight
+```
+
+---
+
+## assets/config/scene.toml
+
+Tunes room geometry, furniture placement, lighting, and player spawn. Most
+useful for level-design mods.
+
+```toml
+schema_version = 1
+
+[room]
+half_extent_x    = 4.0   # Room half-width in meters
+half_extent_z    = 4.0
+wall_height      = 3.0
+wall_thickness   = 0.2
+boundary_margin  = 0.12  # Player AABB clamp inset from wall
+
+[player]
+eye_height  = 1.7
+spawn_x     = 0.0
+spawn_z     = 2.0
+move_speed  = 5.0
+step_up_tolerance = 0.5  # Max step height in meters
+drop_surface_reach = 1.5 # Drop-item surface search height
+
+[lighting]
+ambient_brightness        = 14.0
+directional_illuminance   = 1100.0
+directional_shadows       = true
+spot_intensity            = 280_000.0   # lumens (PBR)
+spot_range                = 12.0
+spot_inner_angle          = 0.28
+spot_outer_angle          = 0.48
+spot_height               = 2.75
+spot_target_y             = 0.45
+```

--- a/docs/modding/extensibility-points.md
+++ b/docs/modding/extensibility-points.md
@@ -1,0 +1,231 @@
+# Extensibility Points
+
+This document maps each moddable system to what it controls, how the data
+flows into the game, and what a mod can do with it.
+
+## How mods integrate with the game
+
+Every data file — base game or mod — goes through the same Bevy `AssetServer`
+pipeline. The loader:
+1. Reads the file.
+2. Checks `schema_version` and migrates forward if needed.
+3. Validates ranges and required fields.
+4. Emits `AssetEvent::Added` / `AssetEvent::Modified`.
+5. Systems reacting to those events populate the relevant registry.
+
+Registries (`MaterialRegistry`, `KnowledgeGraph`, etc.) are
+**source-agnostic** — they do not care whether an asset came from `assets/`
+or `mods/author.slug/assets/`. This is the core mod-compatibility invariant.
+Any system that feeds a registry is automatically moddable.
+
+---
+
+## Material classification
+
+**File:** `assets/materials/classifications.toml`
+**Registry:** `MaterialRegistry`
+**What it controls:** How the player's journal groups observed materials into
+named types. Classification is query-time only — it is never stored.
+
+A mod can:
+- Add new classification entries (new material types with distinct property
+  ranges).
+- NOT override existing base-game entries — duplicate range coverage produces
+  undefined ordering. If your mod needs to reclassify a range, coordinate
+  ranges to avoid overlap.
+
+The `MaterialPlugin` populates `MaterialRegistry` by reacting to
+`AssetEvent::Added` for classification assets. Each entry is inserted as a
+named classification rule with its property ranges. The `KnowledgePlugin`
+queries these rules at journal-render time to label observed instances.
+
+---
+
+## Biomes
+
+**File:** `assets/config/biomes.toml`
+**Registry:** `WorldGenerationPlugin` region generation
+**What it controls:** How temperature × moisture space is partitioned into
+named biomes, which materials appear in each biome, and surface visual color.
+
+A mod can:
+- Add new biome entries (new biome types for temperature/moisture regions not
+  covered by base game entries).
+- Add to or override existing entries (override wins if your mod's entry
+  appears first in file order when the same temperature/moisture region is
+  covered).
+- Change the material palette for any biome by providing an entry with the
+  same `biome_type`.
+
+Hot-reload: biome changes propagate at runtime in debug builds without
+restarting the game. Newly generated chunks pick up updated biome definitions.
+Already-generated chunks are not retroactively updated.
+
+---
+
+## Material combinations
+
+**File:** `assets/config/combinations.toml`
+**What it controls:** What happens when two specific materials are combined at
+the fabricator. Missing pairs use the default_rule (equal-weight blend).
+
+A mod can:
+- Add `[[rules]]` entries for any pair of seed values.
+- Override the `[default_rule]` if the whole defaults feel wrong for your mod.
+- Define rules for new material seeds (above 9000 — see Data Formats).
+
+The `CombinationPlugin` reads combination rules at startup and on hot-reload.
+Rules are applied when the `TryCombine` intent event fires with two material
+entity IDs. The output material's property values are computed according to
+the matching rule.
+
+---
+
+## World and planet generation
+
+**File:** `assets/config/world_generation.toml`
+**What it controls:** Planet seed, chunk size, active neighborhood radius,
+and planet surface size bounds.
+
+A mod can:
+- Change the `planet_seed` to set a fixed planet for your scenario.
+- Switch between override mode (`planet_seed`) and system-derived mode
+  (`solar_system_seed` + `planet_index`).
+- Change `chunk_size_world_units` to scale the playable area.
+- Adjust `planet_radius_min_chunks` / `planet_radius_max_chunks` to
+  constrain how large planets can be.
+
+**Warning:** Changing `chunk_size_world_units` after a world has been
+explored will produce alignment mismatches with saved chunk data.
+
+---
+
+## Star types
+
+**File:** `assets/config/star_types.toml`
+**What it controls:** The statistical distribution of star types in solar
+system generation. Each entry defines a named star type with luminosity,
+temperature, mass, and selection weight.
+
+A mod can:
+- Add new star types.
+- Change selection weights to make certain star types more or less common.
+- Adjust property ranges for existing types.
+
+Star type is sampled from the distribution using the `solar_system_seed` at
+system generation time. The same seed always produces the same star type
+because the selection is deterministic.
+
+---
+
+## Orbital layout
+
+**File:** `assets/config/orbital_config.toml`
+**What it controls:** How many planets a system can have and the allowed
+orbital distance range.
+
+A mod can:
+- Adjust `planet_count_min` / `planet_count_max`.
+- Expand or constrain the orbital distance range (`inner_orbit_au`,
+  `outer_orbit_au`).
+- Change `min_separation_au` to allow closer or more spread-out orbits.
+
+---
+
+## Surface mineral deposits
+
+**File:** `assets/exterior/surface_mineral_deposits.toml`
+**What it controls:** The density, clustering, and visual shape of surface
+mineral deposit groups.
+
+A mod can:
+- Add new deposit types (`[[deposits]]` entries) with distinct keys and
+  cluster parameters.
+- Adjust global density (`site_spawn_threshold`, `site_spacing_world_units`).
+- Change clustering behavior (`cluster_compactness`, `child_count_min/max`).
+
+Deposit types are sampled at generation time using chunk seed + deposit
+selection weights. Adding a new type increases the total weight pool, which
+proportionally reduces the frequency of all existing types.
+
+---
+
+## Carry and inventory
+
+**File:** `assets/config/carry.toml`
+**What it controls:** Starting carry capacity, growth curves, stamina cost,
+and weight-feedback cues (footstep cadence, breathing triggers).
+
+A mod can:
+- Change the starting capacity and max strength to adjust progression rate.
+- Swap the speed curve kind (`linear`, `asymptotic`, etc.).
+- Adjust or add profiles (`default`, `relaxed`, `creative`) that the game
+  may select based on difficulty or player settings.
+- Retune the weight cues to match a different fiction (alien creature, heavy
+  suit, etc.).
+
+**Note:** The `weight_descriptions` array feeds diegetic feedback mechanisms,
+not overlay text. Entries must respect the diegetic-only principle — the
+strings are used in in-world output, not HUD labels.
+
+---
+
+## Player knowledge confidence
+
+**File:** `assets/config/confidence.toml`
+**What it controls:** How quickly players gain confidence in observed
+material properties and how much confidence they lose on death.
+
+A mod can:
+- Increase `death_degradation_factor` toward 1.0 to soften death's knowledge
+  cost (permissive difficulty).
+- Decrease it toward 0.0 for a survival-roguelike feel.
+- Adjust `base_observation_weight` to make knowledge accumulate faster or
+  slower.
+- Tune `domain_recovery_multiplier` to encourage or discourage players from
+  retrying what killed them.
+
+---
+
+## Knowledge graph similarity
+
+**File:** `assets/config/knowledge_graph.toml`
+**What it controls:** When the journal draws connections between two observed
+materials.
+
+A mod can:
+- Raise `similarity_score_threshold` to require materials to be very similar
+  before the journal links them (sparser associative web).
+- Lower it to create a denser, more connected knowledge graph.
+- Adjust `similarity_confidence_threshold` to control how much the player
+  must observe before links appear.
+
+---
+
+## Scene geometry and lighting
+
+**File:** `assets/config/scene.toml`
+**What it controls:** Room dimensions, player spawn position, lighting, and
+furniture placement.
+
+This is the primary hook for level-design mods. A mod can:
+- Resize the room.
+- Reposition the workbench, shelves, and heat source.
+- Change ambient and spot lighting to set a different visual tone.
+- Adjust player eye height and movement speed to change the feel.
+
+The scene configuration is loaded once at startup. Hot-reload works in debug
+builds; reloading the config re-initializes affected scene entities.
+
+---
+
+## What is not moddable today (Epic 23)
+
+| Feature | Status |
+|---|---|
+| Compiled Bevy plugins (new systems, new components) | Deferred to Epic 23 |
+| WASM mod logic | Deferred to Epic 23 |
+| Mod load order and override resolution | Deferred to Epic 23 |
+| Workshop integration | Deferred to Epic 23 |
+| Monetization enforcement | Deferred to Epic 23 |
+| Adding new asset domains without code changes | Not possible today |

--- a/docs/modding/manifest-schema.md
+++ b/docs/modding/manifest-schema.md
@@ -1,0 +1,267 @@
+# Mod Manifest Schema Reference
+
+Every Apeiron Cipher mod ships a `mod.toml` file at the root of its mod
+directory. This document is the authoritative schema reference for that file.
+
+For a guided tour of the full directory layout and practical examples, see
+[mod-structure.md](./mod-structure.md).
+
+---
+
+## File location
+
+```
+mods/
+└── author.my-mod/
+    └── mod.toml   ← schema documented here
+```
+
+The mod directory name **must exactly match** the `mod.id` field. The loader
+validates this at startup and skips any mod whose directory name doesn't match.
+
+---
+
+## Schema version
+
+```toml
+schema_version = 1
+```
+
+`schema_version` must be the **first field** in every `mod.toml`. Always `1`
+for the current format. Future schema versions will increment this integer; the
+loader will use it to select a migration path. Omitting it or placing it after
+other fields is a parse error.
+
+---
+
+## `[mod]` table — identity and metadata
+
+```toml
+[mod]
+id               = "author.my-mod"
+name             = "My Mod"
+version          = "0.1.0"
+description      = "A short human-readable summary."
+author           = "Author Name"
+dependencies     = []
+game_version_min = "0.1.0"
+```
+
+### `id` — string, **required**
+
+Globally unique reverse-domain identifier. Format rules:
+
+- Lowercase only
+- Hyphens and dots allowed, no spaces or other special characters
+- Pattern: `yourname.mod-slug` — the author segment before the dot, the mod
+  slug after
+- Must exactly match the directory name
+
+Valid examples: `nora.iron-expanse`, `community.vanilla-plus`, `lab42.deep-biomes`
+
+### `name` — string, **required**
+
+Human-readable display name shown in mod listings and the in-world terminal.
+No length limit, but keep it concise enough for a UI listing.
+
+### `version` — string, **required**
+
+Semantic version string, e.g. `"0.1.0"`, `"1.2.3"`. Follow [SemVer](https://semver.org/):
+`MAJOR.MINOR.PATCH`.
+
+### `description` — string, optional (default: `""`)
+
+Short summary shown alongside the mod name in listings. Plain text; no
+markdown. Multiline TOML string syntax is fine for longer descriptions:
+
+```toml
+description = """
+A gestural light-language spoken by the Veth, a bioluminescent deep-sea \
+species. Adds vocabulary, grammar rules, and a full phonological inventory."""
+```
+
+### `author` — string, optional (default: `""`)
+
+Mod author or team name. Displayed in listings and attribution contexts. Plain
+text.
+
+### `dependencies` — array of strings, optional (default: `[]`)
+
+Ordered list of `mod.id` values this mod requires. The loader:
+
+1. Verifies every listed id is present in the `mods/` directory.
+2. Performs a topological sort so dependencies load before dependents.
+3. Uses alphabetical tie-breaking within the same dependency level for
+   determinism (Core Principle 4).
+4. Returns a hard error for circular dependency cycles and skips all mods in
+   the cycle.
+
+Leave empty for standalone mods:
+```toml
+dependencies = []
+```
+
+Declare one or more dependencies:
+```toml
+dependencies = ["example.deep-sign"]
+```
+
+### `game_version_min` — string, **required**
+
+Minimum Apeiron Cipher version this mod targets, as a semver string. The game
+logs a warning (but still loads) if the running version is below this value.
+
+---
+
+## `[licensing]` table — distribution metadata
+
+```toml
+[licensing]
+spdx_license          = "CC-BY-4.0"
+free_distribution_url = ""
+```
+
+### `spdx_license` — string, **required**
+
+SPDX license identifier for the mod's content. Required for workshop
+discoverability. Common choices:
+
+| License | Identifier | Use case |
+|---|---|---|
+| Creative Commons Attribution 4.0 | `CC-BY-4.0` | Permissive content mods |
+| Creative Commons Attribution-ShareAlike 4.0 | `CC-BY-SA-4.0` | Copyleft content mods |
+| MIT | `MIT` | Code-heavy mods |
+| All rights reserved | `LicenseRef-custom` | Proprietary/closed-source |
+
+### `free_distribution_url` — string, **required** (empty = not monetized)
+
+Monetization parity declaration. If your mod is sold on any paid platform, you
+must also provide an identical free version and enter its download URL here.
+
+- Not monetizing: `free_distribution_url = ""`
+- Monetizing: `free_distribution_url = "https://example.com/my-mod/free"`
+
+This is a structural commitment. Validation enforcement is deferred to Epic 23.
+
+---
+
+## Complete field reference
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `schema_version` | integer | yes | — | Always `1`. Must be the first field. |
+| `mod.id` | string | yes | — | Reverse-domain unique ID matching the directory name. |
+| `mod.name` | string | yes | — | Display name shown in UI. |
+| `mod.version` | string | yes | — | SemVer string, e.g. `"1.0.0"`. |
+| `mod.description` | string | no | `""` | Short human-readable summary for listings. |
+| `mod.author` | string | no | `""` | Author or team name. |
+| `mod.dependencies` | string[] | no | `[]` | Mod IDs that must be loaded before this mod. |
+| `mod.game_version_min` | string | yes | — | Minimum game version. Game warns if not met. |
+| `licensing.spdx_license` | string | yes | — | SPDX identifier for distribution. |
+| `licensing.free_distribution_url` | string | yes | `""` | Free-version URL if monetized; else `""`. |
+
+---
+
+## Validation rules enforced by the loader
+
+The `ModManifestPlugin` runs at `PreStartup` and enforces the following at
+load time. Mods that fail validation are **skipped** (not a hard crash):
+
+1. `mod.toml` must parse as valid TOML.
+2. `schema_version` must be `1`.
+3. `mod.id` must exactly match the directory name.
+4. All entries in `mod.dependencies` must be present in `mods/` — missing
+   dependencies cause the dependent mod to be skipped.
+5. Dependency graph must be acyclic — cycles are logged as `error!` and all
+   mods in the cycle are skipped.
+
+Warnings (mod still loads):
+
+- Running game version is below `game_version_min`.
+
+---
+
+## Minimal valid manifest
+
+```toml
+schema_version = 1
+
+[mod]
+id               = "author.slug"
+name             = "My Mod"
+version          = "0.1.0"
+game_version_min = "0.1.0"
+
+[licensing]
+spdx_license = "CC-BY-4.0"
+```
+
+Optional fields (`description`, `author`, `dependencies`,
+`free_distribution_url`) default to empty values and may be omitted.
+
+---
+
+## Full example — standalone mod
+
+```toml
+# mod.toml — place at the root of your mod directory.
+# schema_version must always be the first field.
+schema_version = 1
+
+[mod]
+id               = "nora.iron-expanse"
+name             = "Iron Expanse"
+version          = "1.0.0"
+description      = "Adds iron-rich asteroid belts and new smelting recipes."
+author           = "Nora"
+dependencies     = []
+game_version_min = "0.1.0"
+
+[licensing]
+spdx_license          = "CC-BY-4.0"
+free_distribution_url = ""
+```
+
+---
+
+## Full example — mod with dependency
+
+```toml
+# mod.toml — Extended vocabulary pack that requires the base language mod.
+schema_version = 1
+
+[mod]
+id               = "example.deep-sign-extended"
+name             = "Deep Sign: Extended Vocabulary"
+version          = "0.1.0"
+description      = "Adds 20 advanced vocabulary entries to the Deep Sign language mod. Requires the base Deep Sign mod."
+author           = "Nous Research (reference mod)"
+dependencies     = ["example.deep-sign"]
+game_version_min = "0.1.0"
+
+[licensing]
+spdx_license          = "CC-BY-4.0"
+free_distribution_url = ""
+```
+
+---
+
+## Directory layout alongside the manifest
+
+```
+mods/
+└── author.my-mod/
+    ├── mod.toml          ← this schema
+    ├── README.md         ← optional, shown in community tools
+    └── assets/           ← mirrors the base game's assets/ layout
+        ├── config/       ← game-wide tuning overrides
+        ├── materials/    ← material classification additions
+        ├── biomes/       ← biome additions or replacements
+        ├── exterior/     ← surface deposit configuration
+        └── ...           ← any other domain directory
+```
+
+Only `mod.toml` is required. All other files and directories are optional —
+include only what your mod adds or changes. See
+[data-formats.md](./data-formats.md) for the TOML format of each `assets/`
+subdomain.

--- a/docs/modding/mod-structure.md
+++ b/docs/modding/mod-structure.md
@@ -1,0 +1,89 @@
+# Mod Structure
+
+A mod is a named, versioned directory. The game loads all mods it finds in the
+`mods/` directory alongside base game assets.
+
+## Directory layout
+
+```
+mods/
+└── author-name.my-mod/         <- directory name must match mod.id exactly
+    ├── mod.toml                <- required manifest (see below)
+    ├── README.md               <- optional, shown in community tools
+    └── assets/                 <- mirrors the base game's assets/ layout
+        ├── config/             <- game-wide tuning overrides
+        ├── materials/          <- material classification additions
+        ├── biomes/             <- biome additions or replacements
+        ├── exterior/           <- surface deposit configuration
+        └── ...                 <- any other domain directory
+```
+
+The `assets/` subtree inside your mod mirrors the base game's `assets/`
+structure exactly. The game discovers files in both trees via the same
+`AssetServer` pipeline. You only need to include the files you are adding
+or changing — you do not ship a full copy of every base game file.
+
+## Mod manifest — `mod.toml`
+
+Every mod directory must contain `mod.toml` at its root.
+
+```toml
+# mod.toml — place this at the root of your mod directory.
+# schema_version must always be the first field.
+schema_version = 1
+
+[mod]
+# Globally unique identifier. Use reverse-domain style: author.slug
+# The mod directory name must match this value.
+id        = "author-name.my-mod"
+
+# Human-readable display name.
+name      = "My Mod"
+
+# Semantic version string.
+version   = "0.1.0"
+
+# Minimum Apeiron Cipher version this mod targets.
+# The game logs a warning (but still loads) if the running version is lower.
+game_version_min = "0.1.0"
+
+[licensing]
+# SPDX license identifier. Required for workshop discoverability.
+# Use CC-BY-4.0 for permissive content mods.
+spdx_license = "CC-BY-4.0"
+
+# Monetization parity rule: if your mod is sold on any paid platform,
+# you must also provide an identical free version. Set this field to
+# the URL of the free download. Leave empty if you are not monetizing.
+# This is a structural commitment — enforcement is deferred to Epic 23.
+free_distribution_url = ""
+```
+
+### Field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `schema_version` | yes | Always `1` for current mods. First field in file. |
+| `mod.id` | yes | Reverse-domain unique ID. Must match the directory name. |
+| `mod.name` | yes | Display name shown in UI. |
+| `mod.version` | yes | Semver string, e.g. `"1.0.0"`. |
+| `mod.game_version_min` | yes | Minimum game version. The game warns if this is not met. |
+| `licensing.spdx_license` | yes | SPDX identifier for distribution. |
+| `licensing.free_distribution_url` | yes | URL of free version if monetized, else `""`. |
+
+## Naming rules
+
+- The `mod.id` field uses a dot-separated, all-lowercase, hyphens-ok format:
+  `yourname.mod-slug`. No spaces, no uppercase, no special characters other
+  than hyphens and dots.
+- The mod directory name must be identical to `mod.id`.
+- Examples of valid ids: `nora.iron-expanse`, `community.vanilla-plus`,
+  `lab42.deep-biomes`
+
+## The monetization parity rule
+
+The GDD requires that any mod sold on a paid platform must also be available
+as a free download. The `free_distribution_url` field is where you declare
+compliance. Empty means "not monetized." Non-empty means "also free at this
+URL." Validation is automated in Epic 23; for now the field is a
+structural commitment.


### PR DESCRIPTION
## Summary

Adds `docs/modding/` with six documents covering the full modding surface for Apeiron Cipher.

**Primary deliverable:** `docs/modding/manifest-schema.md` — the authoritative field reference for `mod.toml`, which is the schema enforced by `ModManifestPlugin` in `src/mod_manifest.rs`.

## Documents

| File | Purpose |
|---|---|
| `README.md` | Guide index and quick-start |
| `mod-structure.md` | Directory layout and manifest overview |
| `manifest-schema.md` | Complete `mod.toml` field reference with validation rules and examples |
| `data-formats.md` | TOML schema for all moddable asset domains |
| `extensibility-points.md` | Per-system modding surface and registry integration |
| `best-practices.md` | Compatibility, versioning, testing, and compliance |

## manifest-schema.md covers

- All fields (`schema_version`, `mod.id`, `mod.name`, `mod.version`, `mod.description`, `mod.author`, `mod.dependencies`, `mod.game_version_min`, `licensing.spdx_license`, `licensing.free_distribution_url`)
- Required vs optional fields with defaults
- Validation rules enforced at runtime by `ModManifestPlugin`
- Minimal valid manifest example
- Full example with and without dependencies

Closes kanban task t_04f3e339.