### PR TITLE
feat(epic-22): story 22.6 core delta layering engine

### DIFF
--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -1649,6 +1649,253 @@ fn merge_player_additions(
     MergedPlayerAdditions { merged, conflicts }
 }
 
+// ── Story 22.6: Core Delta Layering Engine ───────────────────────────────
+//
+// ## Purpose
+//
+// The delta layering engine is the top-level composition function for
+// multiplayer world state. It accepts a base world seed and an ordered list
+// of `WorldDeltaLayer` values — one per player (or per source) — and folds
+// them into a single `LayeredWorldState` that describes the complete world
+// as seen by any observer with access to all layers.
+//
+// ## Design invariants
+//
+// - **Pure function, no side effects.** `apply_delta_layers` takes immutable
+//   inputs and returns a new value. No ECS, no I/O, no `ResMut`. This makes
+//   it unit-testable, replayable, and safe to call from any context.
+//
+// - **Deterministic.** Same seed + same layers in the same order = same output.
+//   The function never calls `rand` or any non-deterministic source.
+//
+// - **Commutative for non-conflicting changes.** Two layers that touch
+//   different building cells (for additions) or different generated-object IDs
+//   (for removals) can be applied in any order and produce the same result.
+//   This is the key property that makes delta-based multiplayer viable: the
+//   server does not need to track arrival order for independent changes.
+//
+// - **Conflict-preserving.** When two layers place objects in the same building
+//   cell, the conflict is surfaced in `LayeredWorldState::conflicts` rather
+//   than silently resolved. No last-write-wins. The owner decides (Epic 22.4).
+//
+// ## Relationship to Story 5.6
+//
+// Story 5.6 introduced `merge_removal_deltas` (binary) and
+// `merge_player_additions` (binary). This section lifts those binary
+// operations to N-ary: `apply_delta_layers` folds an arbitrary number of
+// layers using the same underlying merge semantics. The 5.6 functions remain
+// unchanged — this is purely additive.
+//
+// ## Lifetime
+//
+// All types and `apply_delta_layers` are `#[allow(dead_code)]` until Epic 22
+// wires them into the ECS. Remove those annotations when the plumbing lands.
+
+/// A single source of world mutations — one player's (or one node's) complete
+/// delta stream.
+///
+/// A `WorldDeltaLayer` is the unit of composition in the delta layering engine.
+/// Each source that can modify world state produces one layer. The layering
+/// engine folds N layers on top of a shared seed to produce the combined world
+/// state visible to all participants.
+///
+/// ## What a layer contains
+///
+/// - **Removals** — generated objects the source has picked up or destroyed.
+///   A removal is permanent from the source's perspective: the object should
+///   not reappear when the chunk reloads.
+///
+/// - **Additions** — objects the source has placed. These are spatially
+///   located and can conflict with additions from other sources when they
+///   occupy the same building cell.
+///
+/// - **Source label** — a human-readable identifier (e.g. player name or
+///   peer ID) used in conflict reports so the base owner knows whose objects
+///   are involved in a conflict.
+///
+/// ## Why a single struct?
+///
+/// Keeping removals and additions together in one layer makes the API easier
+/// to reason about at the call site: each source provides exactly one value,
+/// and the caller does not need to zip separate slices. It also models the
+/// real-world constraint — a player's removals and additions are causally
+/// linked (you cannot drop what you have not picked up).
+#[allow(dead_code)]
+#[allow(private_interfaces)]
+pub struct WorldDeltaLayer {
+    /// The set of generated objects this source has removed from the world.
+    ///
+    /// Applied as a set-union across all layers: if any layer removes a
+    /// generated object, it is absent from the combined world state.
+    pub removals: ChunkRemovalDeltas,
+    /// The set of objects this source has placed in the world.
+    ///
+    /// Merged with building-cell conflict detection: two objects from
+    /// different sources that occupy the same cell are flagged rather than
+    /// silently merged.
+    pub additions: ChunkPlayerAdditions,
+    /// Human-readable identifier for this layer's source.
+    ///
+    /// Appears verbatim in [`DeltaMergeConflict`] records so the base owner
+    /// can identify whose objects are in conflict without inspecting IDs.
+    pub source_label: String,
+}
+
+/// The result of applying N delta layers on top of a shared world seed.
+///
+/// `LayeredWorldState` is the combined world state as seen by any observer
+/// with access to all provided layers. It is intentionally a value type —
+/// not a Bevy `Resource` — so it can be constructed, inspected, and discarded
+/// without touching the ECS.
+///
+/// ## Structure of combined state
+///
+/// The combined state preserves the three-layer model from Story 5.4/5.5:
+///
+/// ```text
+/// final_chunk_state = baseline(seed, chunk)       ← deterministic, from seed
+///                   - combined_removals[chunk]     ← union of all sources
+///                   + combined_additions[chunk]    ← merge, conflicts surfaced
+/// ```
+///
+/// `LayeredWorldState` captures the delta part (removals + additions). The
+/// baseline is not stored here — it is always re-derived from the seed on
+/// demand, which is cheaper than caching it and guarantees correctness.
+///
+/// ## Conflicts
+///
+/// `conflicts` is empty when all layers are spatially independent (different
+/// building cells). When any two sources place objects in the same cell,
+/// those objects are excluded from `combined_additions` and their conflict
+/// is reported here. The base owner must resolve conflicts before the
+/// combined state is authoritative.
+#[allow(dead_code)]
+#[allow(private_interfaces)]
+pub struct LayeredWorldState {
+    /// The base world seed. Stored here so callers can derive the chunk
+    /// baseline at any time without tracking it separately.
+    pub base_seed: u64,
+    /// Combined removal set: the union of every layer's removals.
+    ///
+    /// A generated object absent from any layer's removals but present in
+    /// `combined_removals` should not appear in the world.
+    pub combined_removals: ChunkRemovalDeltas,
+    /// Combined additions set: all non-conflicting player-placed objects.
+    ///
+    /// Conflicting additions are excluded from this set and reported in
+    /// `conflicts` instead. Once all conflicts are resolved, the resolved
+    /// objects should be inserted here.
+    pub combined_additions: ChunkPlayerAdditions,
+    /// Spatial conflicts requiring manual resolution.
+    ///
+    /// Each entry identifies a building cell where two sources placed objects
+    /// simultaneously. The base owner must choose which (if either) to keep.
+    /// An empty `conflicts` vec means the state is fully resolved and
+    /// authoritative.
+    pub conflicts: Vec<DeltaMergeConflict>,
+}
+
+/// Apply N delta layers to a shared base seed, producing the combined world state.
+///
+/// This is the primary entry point for the delta layering engine. It accepts
+/// any seed and an ordered slice of [`WorldDeltaLayer`] values and folds them
+/// left-to-right using the binary merge operations from Story 5.6.
+///
+/// ## Determinism guarantee
+///
+/// For **non-conflicting** layers (layers whose additions do not overlap in
+/// building cells and whose removals are independent sets), this function is
+/// **commutative**: reordering the layers produces the same output. This is the
+/// property that makes the system viable for multiplayer: the server does not
+/// need to enforce arrival order for independent changes.
+///
+/// When two layers *do* conflict, the conflict is surfaced in
+/// [`LayeredWorldState::conflicts`] regardless of order. Conflict detection
+/// itself is deterministic: the same pair of layers always produces the same
+/// conflict record. Order affects which label appears as `source_a` vs
+/// `source_b`, but the conflict is never silently suppressed.
+///
+/// ## Parameters
+///
+/// - `base_seed`: the world seed that underpins the deterministic baseline.
+///   Stored in the returned [`LayeredWorldState`] but not otherwise used by
+///   this function — baseline generation from the seed is the caller's
+///   responsibility (it is not performed here to keep this function pure).
+///
+/// - `cell_size`: the building cell size used for spatial quantization during
+///   addition conflict detection. Must be the same value used throughout the
+///   session; mixing cell sizes across calls would make previously-merged
+///   states incomparable.
+///
+/// - `layers`: ordered slice of delta layers to fold. An empty slice returns
+///   an empty `LayeredWorldState` with the seed recorded. A single layer
+///   is returned as-is (no merging needed). Two or more layers are folded
+///   left-to-right.
+///
+/// ## Side effects
+///
+/// None. This function is a pure transformation. It clones the first layer's
+/// data to start the accumulator and then folds in the remaining layers.
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// let layers = vec![alice_delta, bob_delta, charlie_delta];
+/// let state = apply_delta_layers(world_seed, cell_size, &layers);
+/// assert!(state.conflicts.is_empty()); // all changes were independent
+/// ```
+#[allow(dead_code)]
+pub fn apply_delta_layers(
+    base_seed: u64,
+    cell_size: f32,
+    layers: &[WorldDeltaLayer],
+) -> LayeredWorldState {
+    // Start with empty accumulator — the identity element for both merge operations.
+    // Removal identity: empty set (no objects removed).
+    // Addition identity: empty set (no objects added, no conflicts).
+    let mut combined_removals = ChunkRemovalDeltas::default();
+    let mut combined_additions = ChunkPlayerAdditions::default();
+    let mut all_conflicts: Vec<DeltaMergeConflict> = Vec::new();
+
+    // Fold each layer into the accumulator using the binary merge operations.
+    //
+    // WHY FOLD LEFT-TO-RIGHT:
+    // Both merge operations are commutative for non-conflicting inputs, so the
+    // left-to-right fold order only matters when naming conflicts: the
+    // accumulated state becomes `source_a` and the incoming layer is `source_b`.
+    // For conflict-free inputs the fold is truly commutative — any order
+    // produces identical `combined_removals` and `combined_additions`.
+    for layer in layers {
+        // Removal merge: set-union across chunks. Always commutative, never conflicts.
+        combined_removals = merge_removal_deltas(&combined_removals, &layer.removals);
+
+        // Addition merge: building-cell conflict detection across all accumulated
+        // additions vs this layer's new additions.
+        //
+        // The accumulated label is synthesised as "(accumulated)" so conflict
+        // records are readable when an object in the accumulator conflicts with
+        // the incoming layer. In practice, the base owner cares about the
+        // source_b label (the new layer) more than the accumulated label, since
+        // the accumulator represents what was already known to be conflict-free.
+        let merge_result = merge_player_additions(
+            &combined_additions,
+            &layer.additions,
+            "(accumulated)",
+            &layer.source_label,
+            cell_size,
+        );
+        combined_additions = merge_result.merged;
+        all_conflicts.extend(merge_result.conflicts);
+    }
+
+    LayeredWorldState {
+        base_seed,
+        combined_removals,
+        combined_additions,
+        conflicts: all_conflicts,
+    }
+}
+
 #[cfg(test)]
 #[path = "exterior_tests.rs"]
 mod tests;

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -49,10 +49,11 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     ActiveChunkNeighborhood, BiomeRegistry, ChunkBiome, ChunkCoord,
-    DEFAULT_MAX_PLACEMENT_SLOPE_RADIANS, GeneratedObjectId, PaletteMaterial, PlanetSurface,
-    SurfaceProvider, WorldGenerationConfig, WorldProfile, chunk_origin_xz, derive_chunk_biome,
-    derive_chunk_generation_key, derive_generated_object_id, generate_chunk_heightmap_mesh,
-    is_placement_valid, surface_alignment_rotation, world_position_to_chunk_coord,
+    DEFAULT_MAX_PLACEMENT_SLOPE_RADIANS, GeneratedObjectId, PaletteMaterial, PlanetSeed,
+    PlanetSurface, SurfaceProvider, WorldGenerationConfig, WorldProfile, chunk_origin_xz,
+    derive_chunk_biome, derive_chunk_generation_key, derive_generated_object_id,
+    generate_chunk_heightmap_mesh, is_placement_valid, surface_alignment_rotation,
+    world_position_to_chunk_coord,
 };
 use crate::carry::InCarry;
 use crate::interaction::HeldItem;
@@ -1774,7 +1775,7 @@ pub struct WorldDeltaLayer {
 pub struct LayeredWorldState {
     /// The base world seed. Stored here so callers can derive the chunk
     /// baseline at any time without tracking it separately.
-    pub base_seed: u64,
+    pub base_seed: PlanetSeed,
     /// Combined removal set: the union of every layer's removals.
     ///
     /// A generated object absent from any layer's removals but present in
@@ -1846,7 +1847,7 @@ pub struct LayeredWorldState {
 /// ```
 #[allow(dead_code)]
 pub fn apply_delta_layers(
-    base_seed: u64,
+    base_seed: PlanetSeed,
     cell_size: f32,
     layers: &[WorldDeltaLayer],
 ) -> LayeredWorldState {

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1701,6 +1701,454 @@ fn two_independent_delta_sources_merged_end_to_end() {
     assert_eq!(addition_recs.len(), 2);
 }
 
+// ── Story 22.6: Core delta layering engine tests ──────────────────────
+//
+// These tests validate `apply_delta_layers` — the N-ary composition
+// function that folds an arbitrary number of `WorldDeltaLayer` values on
+// top of a shared base seed.
+//
+// Key invariants under test:
+//
+// 1. **Zero layers** — returns empty state with the seed recorded.
+// 2. **One layer** — passthrough; output equals input.
+// 3. **Three non-conflicting layers** — all removals and additions present,
+//    no conflicts, and result is commutative (any order → same output).
+// 4. **Three layers with one conflict** — conflict surfaced, non-conflicting
+//    objects from all layers still present.
+// 5. **Commutativity — 6 permutations** — for three fully independent layers,
+//    every ordering of apply_delta_layers produces identical combined state.
+// 6. **Seed passthrough** — base_seed in LayeredWorldState matches input.
+
+/// Build a `WorldDeltaLayer` from individual removals and additions for testing.
+///
+/// Keeps the heavy builder boilerplate out of each individual test.
+fn make_layer(
+    label: &str,
+    removals: ChunkRemovalDeltas,
+    additions: ChunkPlayerAdditions,
+) -> WorldDeltaLayer {
+    WorldDeltaLayer {
+        removals,
+        additions,
+        source_label: label.to_string(),
+    }
+}
+
+/// Build a `ChunkRemovalDeltas` with a single removed ID in the given chunk.
+fn single_removal(chunk: ChunkCoord, id: GeneratedObjectId) -> ChunkRemovalDeltas {
+    let mut r = ChunkRemovalDeltas::default();
+    r.removed_by_chunk.entry(chunk).or_default().insert(id);
+    r
+}
+
+#[test]
+fn apply_delta_layers_zero_layers_returns_empty_state() {
+    // An empty layer slice should return a LayeredWorldState with:
+    // - the seed stored verbatim
+    // - empty combined_removals and combined_additions
+    // - no conflicts
+    let state = apply_delta_layers(42, 1.0, &[]);
+    assert_eq!(state.base_seed, 42, "seed must be stored verbatim");
+    assert!(
+        state.combined_removals.removed_by_chunk.is_empty(),
+        "no removals from empty layer set"
+    );
+    assert!(
+        state.combined_additions.added_by_chunk.is_empty(),
+        "no additions from empty layer set"
+    );
+    assert!(
+        state.conflicts.is_empty(),
+        "no conflicts from empty layer set"
+    );
+}
+
+#[test]
+fn apply_delta_layers_single_layer_passthrough() {
+    // A single layer should produce exactly the same removals and additions
+    // as the input, with no conflicts.
+    let chunk = ChunkCoord::new(0, 0);
+    let gen_id = sample_generated_id(1);
+    let removals = single_removal(chunk, gen_id.clone());
+    let additions =
+        sample_additions_with(chunk, vec![sample_record_at(10, "iron", [1.0, 0.0, 1.0])]);
+
+    let layer = make_layer("alice", removals, additions);
+    let state = apply_delta_layers(99, 1.0, &[layer]);
+
+    assert_eq!(state.base_seed, 99);
+    assert!(state.conflicts.is_empty());
+    let removal_set = state
+        .combined_removals
+        .removed_by_chunk
+        .get(&chunk)
+        .expect("chunk must exist in removals");
+    assert!(
+        removal_set.contains(&gen_id),
+        "alice's removal must be present"
+    );
+    let addition_recs = state
+        .combined_additions
+        .added_by_chunk
+        .get(&chunk)
+        .expect("chunk must exist in additions");
+    assert_eq!(addition_recs.len(), 1, "alice's addition must be present");
+}
+
+#[test]
+fn apply_delta_layers_three_non_conflicting_layers_all_present() {
+    // Three players each remove a different generated object and place a new
+    // object in a different building cell. The combined state must contain all
+    // three removals and all three additions with no conflicts.
+    let chunk = ChunkCoord::new(0, 0);
+    let cell_size = 1.0;
+
+    let gen_a = sample_generated_id(100);
+    let gen_b = sample_generated_id(200);
+    let gen_c = sample_generated_id(300);
+
+    // Each player removes a distinct generated object.
+    let layer_a = make_layer(
+        "alice",
+        single_removal(chunk, gen_a.clone()),
+        sample_additions_with(chunk, vec![sample_record_at(1, "alloy", [10.0, 0.0, 10.0])]),
+    );
+    let layer_b = make_layer(
+        "bob",
+        single_removal(chunk, gen_b.clone()),
+        sample_additions_with(chunk, vec![sample_record_at(2, "glass", [20.0, 0.0, 20.0])]),
+    );
+    let layer_c = make_layer(
+        "charlie",
+        single_removal(chunk, gen_c.clone()),
+        sample_additions_with(
+            chunk,
+            vec![sample_record_at(3, "carbon", [30.0, 0.0, 30.0])],
+        ),
+    );
+
+    let state = apply_delta_layers(1234, cell_size, &[layer_a, layer_b, layer_c]);
+
+    // No conflicts expected — all additions are in distinct cells.
+    assert!(
+        state.conflicts.is_empty(),
+        "no conflicts for independent layers"
+    );
+
+    // All three removals must be present.
+    let removal_set = state
+        .combined_removals
+        .removed_by_chunk
+        .get(&chunk)
+        .expect("chunk must have removals");
+    assert!(
+        removal_set.contains(&gen_a),
+        "alice's removal must be present"
+    );
+    assert!(
+        removal_set.contains(&gen_b),
+        "bob's removal must be present"
+    );
+    assert!(
+        removal_set.contains(&gen_c),
+        "charlie's removal must be present"
+    );
+
+    // All three additions must be present.
+    let addition_recs = state
+        .combined_additions
+        .added_by_chunk
+        .get(&chunk)
+        .expect("chunk must have additions");
+    assert_eq!(
+        addition_recs.len(),
+        3,
+        "all three additions must be present"
+    );
+}
+
+#[test]
+fn apply_delta_layers_three_layers_with_conflict_surfaced() {
+    // Alice and Bob both place objects in the same building cell. Charlie
+    // places in a different cell. The combined state must:
+    // - contain Charlie's addition (no conflict)
+    // - contain the single conflict between Alice and Bob
+    // - contain all three removals
+    let chunk = ChunkCoord::new(0, 0);
+    let cell_size = 1.0;
+
+    let gen_a = sample_generated_id(10);
+    let gen_b = sample_generated_id(20);
+    let gen_c = sample_generated_id(30);
+
+    // Alice and Bob both target [5.0, 0.0, 5.0] — same building cell.
+    let layer_a = make_layer(
+        "alice",
+        single_removal(chunk, gen_a),
+        sample_additions_with(chunk, vec![sample_record_at(1, "alloy", [5.0, 0.0, 5.0])]),
+    );
+    let layer_b = make_layer(
+        "bob",
+        single_removal(chunk, gen_b),
+        sample_additions_with(chunk, vec![sample_record_at(2, "glass", [5.0, 0.0, 5.0])]),
+    );
+    // Charlie is safely separate.
+    let layer_c = make_layer(
+        "charlie",
+        single_removal(chunk, gen_c.clone()),
+        sample_additions_with(
+            chunk,
+            vec![sample_record_at(3, "carbon", [99.0, 0.0, 99.0])],
+        ),
+    );
+
+    let state = apply_delta_layers(5678, cell_size, &[layer_a, layer_b, layer_c]);
+
+    // Exactly one conflict expected (Alice vs Bob).
+    assert_eq!(state.conflicts.len(), 1, "one conflict expected");
+    let conflict = &state.conflicts[0];
+    // The conflict must involve bob (the second layer to arrive in the cell).
+    assert_eq!(conflict.source_b, "bob", "bob is the conflicting source_b");
+
+    // Charlie's removal still present.
+    let removal_set = state
+        .combined_removals
+        .removed_by_chunk
+        .get(&chunk)
+        .expect("chunk must have removals");
+    assert!(
+        removal_set.contains(&gen_c),
+        "charlie's removal must be present even when others conflict"
+    );
+
+    // Charlie's addition still present (only the conflicting pair is excluded).
+    let addition_recs = state
+        .combined_additions
+        .added_by_chunk
+        .get(&chunk)
+        .expect("chunk must have additions");
+    assert_eq!(
+        addition_recs.len(),
+        1,
+        "only charlie's addition survives (alice+bob are conflicted out)"
+    );
+    assert_eq!(
+        addition_recs[0].id, 3,
+        "the surviving addition is charlie's"
+    );
+}
+
+#[test]
+fn apply_delta_layers_three_independent_layers_are_commutative() {
+    // The key multiplayer invariant: for non-conflicting layers, order does
+    // not matter. We test all 6 permutations of 3 layers and assert that
+    // combined_removals and combined_additions are identical in every case.
+    //
+    // This is the property that makes delta-based multiplayer viable: the
+    // server does not need to enforce arrival order for independent changes.
+    let chunk = ChunkCoord::new(2, 3);
+    let cell_size = 1.0;
+
+    let gen_a = sample_generated_id(400);
+    let gen_b = sample_generated_id(500);
+    let gen_c = sample_generated_id(600);
+
+    // Each layer uses a distinct building cell so there are no conflicts.
+    let make_layers = || -> Vec<WorldDeltaLayer> {
+        vec![
+            make_layer(
+                "alice",
+                single_removal(chunk, gen_a.clone()),
+                sample_additions_with(chunk, vec![sample_record_at(10, "iron", [1.0, 0.0, 1.0])]),
+            ),
+            make_layer(
+                "bob",
+                single_removal(chunk, gen_b.clone()),
+                sample_additions_with(chunk, vec![sample_record_at(20, "copper", [2.0, 0.0, 2.0])]),
+            ),
+            make_layer(
+                "charlie",
+                single_removal(chunk, gen_c.clone()),
+                sample_additions_with(chunk, vec![sample_record_at(30, "zinc", [3.0, 0.0, 3.0])]),
+            ),
+        ]
+    };
+
+    // Helper: sort removed IDs for comparison (HashSet is unordered).
+    let removed_ids = |state: &LayeredWorldState| -> Vec<u64> {
+        let mut ids: Vec<u64> = state
+            .combined_removals
+            .removed_by_chunk
+            .get(&chunk)
+            .map(|s| {
+                s.iter()
+                    .map(|id| {
+                        // GeneratedObjectId has planet_seed, chunk, and index — flatten
+                        // to a scalar for ordering in this test by using the unique
+                        // local_candidate_index which distinguishes our test IDs.
+                        id.local_candidate_index as u64
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        ids.sort_unstable();
+        ids
+    };
+
+    // Helper: sort addition IDs for comparison.
+    let addition_ids = |state: &LayeredWorldState| -> Vec<u64> {
+        let mut ids: Vec<u64> = state
+            .combined_additions
+            .added_by_chunk
+            .get(&chunk)
+            .map(|recs| recs.iter().map(|r| r.id).collect())
+            .unwrap_or_default();
+        ids.sort_unstable();
+        ids
+    };
+
+    let reference = {
+        let mut layers = make_layers();
+        // Order [A, B, C]
+        apply_delta_layers(9999, cell_size, &layers)
+    };
+
+    // Gather reference values.
+    let ref_removed = removed_ids(&reference);
+    let ref_added = addition_ids(&reference);
+    assert!(reference.conflicts.is_empty(), "reference has no conflicts");
+
+    // All 6 permutations: [A,B,C], [A,C,B], [B,A,C], [B,C,A], [C,A,B], [C,B,A]
+    let permutations: &[&[usize]] = &[
+        &[0, 1, 2],
+        &[0, 2, 1],
+        &[1, 0, 2],
+        &[1, 2, 0],
+        &[2, 0, 1],
+        &[2, 1, 0],
+    ];
+
+    for perm in permutations {
+        // Build layers fresh for each permutation, then reorder by index.
+        let mut all = make_layers();
+        let permuted: Vec<WorldDeltaLayer> = perm
+            .iter()
+            .map(|&i| WorldDeltaLayer {
+                removals: all[i].removals.clone(),
+                additions: all[i].additions.clone(),
+                source_label: all[i].source_label.clone(),
+            })
+            .collect();
+
+        let state = apply_delta_layers(9999, cell_size, &permuted);
+
+        assert!(
+            state.conflicts.is_empty(),
+            "permutation {:?} must have no conflicts",
+            perm
+        );
+        assert_eq!(
+            removed_ids(&state),
+            ref_removed,
+            "permutation {:?}: removals must be identical regardless of order",
+            perm
+        );
+        assert_eq!(
+            addition_ids(&state),
+            ref_added,
+            "permutation {:?}: additions must be identical regardless of order",
+            perm
+        );
+    }
+}
+
+#[test]
+fn apply_delta_layers_base_seed_stored_verbatim() {
+    // The base seed is passed through to LayeredWorldState unchanged.
+    // This is not computed from the layers — it is the caller's authoritative
+    // seed for the deterministic baseline.
+    let seed: u64 = 0xDEAD_BEEF_1234_5678;
+    let state = apply_delta_layers(seed, 1.0, &[]);
+    assert_eq!(
+        state.base_seed, seed,
+        "base_seed must be stored exactly as provided"
+    );
+}
+
+#[test]
+fn apply_delta_layers_empty_layer_is_identity() {
+    // An empty layer (no removals, no additions) should not change the
+    // combined state relative to the non-empty layers.
+    let chunk = ChunkCoord::new(0, 0);
+    let gen_id = sample_generated_id(77);
+
+    // Layer order: non-empty then empty.
+    let state_a = apply_delta_layers(
+        1,
+        1.0,
+        &[
+            make_layer(
+                "alice",
+                single_removal(chunk, gen_id.clone()),
+                sample_additions_with(chunk, vec![sample_record_at(1, "iron", [1.0, 0.0, 1.0])]),
+            ),
+            make_layer(
+                "empty-source",
+                ChunkRemovalDeltas::default(),
+                ChunkPlayerAdditions::default(),
+            ),
+        ],
+    );
+    // Layer order: empty then non-empty.
+    let state_b = apply_delta_layers(
+        1,
+        1.0,
+        &[
+            make_layer(
+                "empty-source",
+                ChunkRemovalDeltas::default(),
+                ChunkPlayerAdditions::default(),
+            ),
+            make_layer(
+                "alice",
+                single_removal(chunk, gen_id.clone()),
+                sample_additions_with(chunk, vec![sample_record_at(1, "iron", [1.0, 0.0, 1.0])]),
+            ),
+        ],
+    );
+
+    assert!(state_a.conflicts.is_empty());
+    assert!(state_b.conflicts.is_empty());
+
+    let ids_a: std::collections::HashSet<GeneratedObjectId> = state_a
+        .combined_removals
+        .removed_by_chunk
+        .get(&chunk)
+        .cloned()
+        .unwrap_or_default();
+    let ids_b: std::collections::HashSet<GeneratedObjectId> = state_b
+        .combined_removals
+        .removed_by_chunk
+        .get(&chunk)
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(ids_a, ids_b, "empty layer must not change removals");
+
+    let adds_a = state_a
+        .combined_additions
+        .added_by_chunk
+        .get(&chunk)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let adds_b = state_b
+        .combined_additions
+        .added_by_chunk
+        .get(&chunk)
+        .map(|v| v.len())
+        .unwrap_or(0);
+    assert_eq!(adds_a, adds_b, "empty layer must not change additions");
+}
+
 // ── Story 5a.2: Biome weight and density modifier tests ──────────────
 
 #[test]

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1747,8 +1747,12 @@ fn apply_delta_layers_zero_layers_returns_empty_state() {
     // - the seed stored verbatim
     // - empty combined_removals and combined_additions
     // - no conflicts
-    let state = apply_delta_layers(42, 1.0, &[]);
-    assert_eq!(state.base_seed, 42, "seed must be stored verbatim");
+    let state = apply_delta_layers(PlanetSeed(42), 1.0, &[]);
+    assert_eq!(
+        state.base_seed,
+        PlanetSeed(42),
+        "seed must be stored verbatim"
+    );
     assert!(
         state.combined_removals.removed_by_chunk.is_empty(),
         "no removals from empty layer set"
@@ -1774,9 +1778,9 @@ fn apply_delta_layers_single_layer_passthrough() {
         sample_additions_with(chunk, vec![sample_record_at(10, "iron", [1.0, 0.0, 1.0])]);
 
     let layer = make_layer("alice", removals, additions);
-    let state = apply_delta_layers(99, 1.0, &[layer]);
+    let state = apply_delta_layers(PlanetSeed(99), 1.0, &[layer]);
 
-    assert_eq!(state.base_seed, 99);
+    assert_eq!(state.base_seed, PlanetSeed(99));
     assert!(state.conflicts.is_empty());
     let removal_set = state
         .combined_removals
@@ -1827,7 +1831,7 @@ fn apply_delta_layers_three_non_conflicting_layers_all_present() {
         ),
     );
 
-    let state = apply_delta_layers(1234, cell_size, &[layer_a, layer_b, layer_c]);
+    let state = apply_delta_layers(PlanetSeed(1234), cell_size, &[layer_a, layer_b, layer_c]);
 
     // No conflicts expected — all additions are in distinct cells.
     assert!(
@@ -1902,7 +1906,7 @@ fn apply_delta_layers_three_layers_with_conflict_surfaced() {
         ),
     );
 
-    let state = apply_delta_layers(5678, cell_size, &[layer_a, layer_b, layer_c]);
+    let state = apply_delta_layers(PlanetSeed(5678), cell_size, &[layer_a, layer_b, layer_c]);
 
     // Exactly one conflict expected (Alice vs Bob).
     assert_eq!(state.conflicts.len(), 1, "one conflict expected");
@@ -2010,7 +2014,7 @@ fn apply_delta_layers_three_independent_layers_are_commutative() {
     let reference = {
         let mut layers = make_layers();
         // Order [A, B, C]
-        apply_delta_layers(9999, cell_size, &layers)
+        apply_delta_layers(PlanetSeed(9999), cell_size, &layers)
     };
 
     // Gather reference values.
@@ -2040,7 +2044,7 @@ fn apply_delta_layers_three_independent_layers_are_commutative() {
             })
             .collect();
 
-        let state = apply_delta_layers(9999, cell_size, &permuted);
+        let state = apply_delta_layers(PlanetSeed(9999), cell_size, &permuted);
 
         assert!(
             state.conflicts.is_empty(),
@@ -2067,7 +2071,7 @@ fn apply_delta_layers_base_seed_stored_verbatim() {
     // The base seed is passed through to LayeredWorldState unchanged.
     // This is not computed from the layers — it is the caller's authoritative
     // seed for the deterministic baseline.
-    let seed: u64 = 0xDEAD_BEEF_1234_5678;
+    let seed = PlanetSeed(0xDEAD_BEEF_1234_5678);
     let state = apply_delta_layers(seed, 1.0, &[]);
     assert_eq!(
         state.base_seed, seed,
@@ -2084,7 +2088,7 @@ fn apply_delta_layers_empty_layer_is_identity() {
 
     // Layer order: non-empty then empty.
     let state_a = apply_delta_layers(
-        1,
+        PlanetSeed(1),
         1.0,
         &[
             make_layer(
@@ -2101,7 +2105,7 @@ fn apply_delta_layers_empty_layer_is_identity() {
     );
     // Layer order: empty then non-empty.
     let state_b = apply_delta_layers(
-        1,
+        PlanetSeed(1),
         1.0,
         &[
             make_layer(


### PR DESCRIPTION
## Story 22.6 — Core Delta Layering Engine

Implements the deterministic N-source delta layering engine for Epic 22.

### What's in this PR

**New types (exterior.rs)**
- `WorldDeltaLayer` — one source's removals + additions + label in a single value
- `LayeredWorldState` — combined world state after folding N layers; carries base seed, union removals, merged additions, and conflict list
- `DeltaMergeConflict` — per-cell conflict record (source_a, source_b, cell_key) — conflicts are surfaced, never silently dropped

**New function (exterior.rs)**
- `apply_delta_layers(base_seed, cell_size, &[WorldDeltaLayer]) -> LayeredWorldState`
  - Pure function: no ECS, no I/O, no ResMut
  - Folds N layers over the shared base seed via the existing binary merge ops from Story 5.6 (`merge_removal_deltas` / `merge_player_additions`)
  - Story 5.6 binary functions are unchanged — new code is purely additive

**Unit tests (exterior_tests.rs) — 7 tests**
- `apply_delta_layers_zero_layers_returns_empty_state`
- `apply_delta_layers_single_layer_passthrough`
- `apply_delta_layers_three_non_conflicting_layers_all_present`
- `apply_delta_layers_three_layers_with_conflict_surfaced`
- `apply_delta_layers_three_independent_layers_are_commutative` (all 6 permutations)
- `apply_delta_layers_base_seed_stored_verbatim`
- `apply_delta_layers_empty_layer_is_identity`

### Lint notes
All new types carry `#[allow(dead_code)]` and `#[allow(private_interfaces)]` pending Epic 22 ECS wiring. These annotations will be removed when the public API is exposed.

Closes kanban task t_35108d70