### PR TITLE
feat(orchestrator): signaling protocol schema — TypeScript types and JSON Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt-check fmt run check clean install-hooks kb-check o-check coverage coverage-html
+.PHONY: build test lint fmt-check fmt run check clean install-hooks kb-check o-check sig-schema-check coverage coverage-html
 
 build:
 	cargo build
@@ -30,6 +30,10 @@ kb-check:
 # --- Orchestrator checks ---
 o-check:
 	cd infra/orchestrator && go vet ./... && go test ./...
+
+# --- Signaling schema checks (TypeScript types + JSON Schema validation) ---
+sig-schema-check:
+	cd infra/signaling-schema && npm install --prefer-offline && npm run check && npm run build && node dist/validate-examples.js
 
 install-hooks:
 	cp hooks/pre-commit .git/hooks/pre-commit

--- a/infra/signaling-schema/.gitignore
+++ b/infra/signaling-schema/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/infra/signaling-schema/README.md
+++ b/infra/signaling-schema/README.md
@@ -1,0 +1,132 @@
+# @apeiron-cipher/signaling-schema
+
+Shared TypeScript types and JSON Schema for the Apeiron Cipher signaling protocol.
+
+## What this is
+
+The Apeiron Cipher multiplayer architecture relies on a central **signaling server** for
+player discovery, lobby management, and WebRTC offer/answer/ICE relay. All payloads
+flow over a single WebSocket connection using a top-level `type` discriminator:
+
+```json
+{ "type": "register", "payload": { "display_name": "Alice" } }
+```
+
+This package provides:
+
+1. **TypeScript types** (`src/index.ts`) — typed `Envelope<T, P>` aliases for every message.
+2. **JSON Schema** (`src/schema.ts`) — Draft-07 schema for runtime validation (AJV-compatible).
+3. **Example payloads** (`src/examples.ts`) — typed example messages for every type.
+4. **Validation helpers** — `validateEnvelope`, `assertEnvelope`.
+
+## Wire format
+
+```
+Envelope = { type: MsgType, payload?: <type-specific object> }
+```
+
+All types:
+
+| direction        | type            | payload type           | description                          |
+|-----------------|-----------------|------------------------|--------------------------------------|
+| client → server | `register`      | `RegisterPayload`      | Claim ephemeral session              |
+| server → client | `registered`    | `RegisteredPayload`    | Session ID assigned                  |
+| client → server | `create_lobby`  | `CreateLobbyPayload`   | Create a matchmaking lobby           |
+| server → client | `lobby_created` | `LobbyCreatedPayload`  | Lobby created, id returned           |
+| client → server | `list_lobbies`  | _(empty)_              | Request current lobby list           |
+| server → client | `lobby_list`    | `LobbyListPayload`     | Current lobbies                      |
+| client → server | `join_lobby`    | `JoinLobbyPayload`     | Request to join a lobby              |
+| server → client | `lobby_joined`  | `LobbyJoinedPayload`   | Join accepted, peer list returned    |
+| server → client | `peer_joined`   | `PeerJoinedPayload`    | Another peer joined the lobby        |
+| server → client | `peer_left`     | `PeerLeftPayload`      | A peer left or disconnected          |
+| client → server | `leave`         | _(empty)_              | Leave current lobby                  |
+| client → server | `offer`         | `RelayPayload`         | Relay WebRTC SDP offer to peer       |
+| client → server | `answer`        | `RelayPayload`         | Relay WebRTC SDP answer to peer      |
+| client → server | `ice`           | `RelayPayload`         | Relay ICE candidate to peer          |
+| server → client | `relay`         | `RelayDeliveryPayload` | Delivered offer/answer/ice from peer |
+| server → client | `error`         | `ErrorPayload`         | Error response                       |
+| client → server | `ping`          | _(empty)_              | Keepalive                            |
+| server → client | `pong`          | _(empty)_              | Keepalive response                   |
+
+## Schema versioning
+
+`SCHEMA_VERSION = "1.0.0"` is exported from both `index.ts` and `schema.ts`.
+
+- **Major bump**: breaking change to the wire format (removed/renamed field or type).
+- **Minor bump**: new optional field added to an existing payload.
+- **Patch bump**: documentation or tooling only.
+
+Clients should include the schema version in telemetry. Future server versions may
+validate `X-Schema-Version` headers to reject incompatible clients.
+
+## Usage
+
+### TypeScript client
+
+```typescript
+import { makeEnvelope, parseServerMessage } from "@apeiron-cipher/signaling-schema";
+
+const ws = new WebSocket("wss://signal.apeiron-cipher.internal/ws");
+
+ws.send(JSON.stringify(makeEnvelope("register", { display_name: "Alice" })));
+
+ws.onmessage = (evt) => {
+  const env = parseServerMessage(JSON.parse(evt.data));
+  if (!env) return;
+
+  switch (env.type) {
+    case "registered":
+      console.log("Session ID:", env.payload!.session_id);
+      break;
+    case "lobby_joined":
+      console.log("Joined lobby, peers:", env.payload!.peers);
+      break;
+    case "relay":
+      // Incoming WebRTC offer/answer/ice from peer
+      handleRelay(env.payload!);
+      break;
+    case "error":
+      console.error(env.payload!.code, env.payload!.message);
+      break;
+  }
+};
+```
+
+### Runtime validation
+
+```typescript
+import Ajv from "ajv";
+import { envelopeSchema, validateEnvelope } from "@apeiron-cipher/signaling-schema/schema";
+
+const raw = JSON.parse(incomingJson);
+if (!validateEnvelope(raw)) {
+  console.error("Received malformed signaling message, dropping");
+  return;
+}
+```
+
+## Development
+
+```sh
+# Install deps
+npm install
+
+# Type-check only (no emit)
+npm run check
+
+# Build to dist/
+npm run build
+
+# Validate all example payloads against the JSON Schema
+npm run validate
+```
+
+## Relationship to Go server
+
+The Go server implementation lives in:
+```
+infra/orchestrator/internal/signaling/messages.go
+```
+
+This TypeScript package mirrors those types exactly. When the Go types change,
+this package must be updated in the same PR and `SCHEMA_VERSION` bumped appropriately.

--- a/infra/signaling-schema/package-lock.json
+++ b/infra/signaling-schema/package-lock.json
@@ -1,0 +1,294 @@
+{
+  "name": "@apeiron-cipher/signaling-schema",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@apeiron-cipher/signaling-schema",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "ajv": "^8.17.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/infra/signaling-schema/package.json
+++ b/infra/signaling-schema/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@apeiron-cipher/signaling-schema",
+  "version": "1.0.0",
+  "description": "Shared signaling protocol schema and TypeScript types for Apeiron Cipher matchmaking/WebRTC relay",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "validate": "ts-node src/validate-examples.ts",
+    "test": "node --test dist/index.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "ajv": "^8.17.1",
+    "ts-node": "^10.9.2",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/infra/signaling-schema/src/examples.ts
+++ b/infra/signaling-schema/src/examples.ts
@@ -1,0 +1,256 @@
+/**
+ * Example payloads for the Apeiron Cipher signaling protocol.
+ *
+ * These serve as:
+ *   1. Human-readable documentation of the wire format.
+ *   2. Inputs for the schema validation smoke test.
+ *   3. Fixtures for client-side integration tests.
+ *
+ * All examples are typed using the exported schema types from index.ts.
+ */
+
+import type {
+  RegisterEnvelope,
+  RegisteredEnvelope,
+  CreateLobbyEnvelope,
+  LobbyCreatedEnvelope,
+  ListLobbiesEnvelope,
+  LobbyListEnvelope,
+  JoinLobbyEnvelope,
+  LobbyJoinedEnvelope,
+  PeerJoinedEnvelope,
+  PeerLeftEnvelope,
+  LeaveEnvelope,
+  OfferEnvelope,
+  AnswerEnvelope,
+  IceEnvelope,
+  RelayDeliveryEnvelope,
+  ErrorEnvelope,
+  PingEnvelope,
+  PongEnvelope,
+} from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Registration flow
+// ---------------------------------------------------------------------------
+
+export const registerExample: RegisterEnvelope = {
+  type: "register",
+  payload: { display_name: "Alice" },
+};
+
+export const registerNoNameExample: RegisterEnvelope = {
+  type: "register",
+  // display_name is optional
+};
+
+export const registeredExample: RegisteredEnvelope = {
+  type: "registered",
+  payload: {
+    session_id: "7f3a9c21-4b8e-4d1a-9f5c-e3a8b2d60471",
+    display_name: "Alice",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Lobby management flow
+// ---------------------------------------------------------------------------
+
+export const createLobbyExample: CreateLobbyEnvelope = {
+  type: "create_lobby",
+  payload: { max_peers: 4 },
+};
+
+export const createLobbyUnlimitedExample: CreateLobbyEnvelope = {
+  type: "create_lobby",
+  // max_peers absent → unlimited
+};
+
+export const lobbyCreatedExample: LobbyCreatedEnvelope = {
+  type: "lobby_created",
+  payload: { lobby_id: "lby_a1b2c3d4" },
+};
+
+export const listLobbiesExample: ListLobbiesEnvelope = {
+  type: "list_lobbies",
+};
+
+export const lobbyListExample: LobbyListEnvelope = {
+  type: "lobby_list",
+  payload: {
+    lobbies: [
+      {
+        lobby_id: "lby_a1b2c3d4",
+        display_name: "Alice",
+        peer_count: 1,
+        max_peers: 4,
+      },
+      {
+        lobby_id: "lby_e5f6g7h8",
+        display_name: "Bob",
+        peer_count: 2,
+      },
+    ],
+  },
+};
+
+export const joinLobbyExample: JoinLobbyEnvelope = {
+  type: "join_lobby",
+  payload: { lobby_id: "lby_a1b2c3d4" },
+};
+
+export const lobbyJoinedExample: LobbyJoinedEnvelope = {
+  type: "lobby_joined",
+  payload: {
+    lobby_id: "lby_a1b2c3d4",
+    peers: [
+      {
+        session_id: "7f3a9c21-4b8e-4d1a-9f5c-e3a8b2d60471",
+        display_name: "Alice",
+      },
+    ],
+  },
+};
+
+export const peerJoinedExample: PeerJoinedEnvelope = {
+  type: "peer_joined",
+  payload: {
+    lobby_id: "lby_a1b2c3d4",
+    peer: {
+      session_id: "c2d4e6f8-1a3b-5c7d-9e0f-2a4b6c8d0e1f",
+      display_name: "Carol",
+    },
+  },
+};
+
+export const peerLeftExample: PeerLeftEnvelope = {
+  type: "peer_left",
+  payload: {
+    lobby_id: "lby_a1b2c3d4",
+    session_id: "c2d4e6f8-1a3b-5c7d-9e0f-2a4b6c8d0e1f",
+  },
+};
+
+export const leaveExample: LeaveEnvelope = {
+  type: "leave",
+};
+
+// ---------------------------------------------------------------------------
+// WebRTC relay flow
+// ---------------------------------------------------------------------------
+
+// Simulated SDP offer blob (abbreviated for readability)
+const fakeSdpOffer = {
+  type: "offer",
+  sdp: "v=0\r\no=- 46117317 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n...",
+};
+
+export const offerExample: OfferEnvelope = {
+  type: "offer",
+  payload: {
+    target_session_id: "c2d4e6f8-1a3b-5c7d-9e0f-2a4b6c8d0e1f",
+    data: fakeSdpOffer,
+  },
+};
+
+const fakeSdpAnswer = {
+  type: "answer",
+  sdp: "v=0\r\no=- 46117318 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n...",
+};
+
+export const answerExample: AnswerEnvelope = {
+  type: "answer",
+  payload: {
+    target_session_id: "7f3a9c21-4b8e-4d1a-9f5c-e3a8b2d60471",
+    data: fakeSdpAnswer,
+  },
+};
+
+const fakeIceCandidate = {
+  candidate: "candidate:1 1 udp 2130706431 192.168.1.100 50000 typ host",
+  sdpMid: "0",
+  sdpMLineIndex: 0,
+};
+
+export const iceExample: IceEnvelope = {
+  type: "ice",
+  payload: {
+    target_session_id: "c2d4e6f8-1a3b-5c7d-9e0f-2a4b6c8d0e1f",
+    data: fakeIceCandidate,
+  },
+};
+
+// What the target receives after the server routes the relay
+export const relayDeliveryOfferExample: RelayDeliveryEnvelope = {
+  type: "relay",
+  payload: {
+    from_session_id: "7f3a9c21-4b8e-4d1a-9f5c-e3a8b2d60471",
+    kind: "offer",
+    data: fakeSdpOffer,
+  },
+};
+
+export const relayDeliveryIceExample: RelayDeliveryEnvelope = {
+  type: "relay",
+  payload: {
+    from_session_id: "7f3a9c21-4b8e-4d1a-9f5c-e3a8b2d60471",
+    kind: "ice",
+    data: fakeIceCandidate,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export const errorLobbyNotFoundExample: ErrorEnvelope = {
+  type: "error",
+  payload: {
+    code: "lobby_not_found",
+    message: "No lobby with id lby_xxxxxxxx exists",
+  },
+};
+
+export const errorNotRegisteredExample: ErrorEnvelope = {
+  type: "error",
+  payload: {
+    code: "not_registered",
+    message: "You must send a 'register' message before using this endpoint",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Keepalive
+// ---------------------------------------------------------------------------
+
+export const pingExample: PingEnvelope = { type: "ping" };
+export const pongExample: PongEnvelope = { type: "pong" };
+
+// ---------------------------------------------------------------------------
+// Convenience: all examples as an array (used by validate-examples.ts)
+// ---------------------------------------------------------------------------
+
+export const ALL_EXAMPLES = [
+  registerExample,
+  registerNoNameExample,
+  registeredExample,
+  createLobbyExample,
+  createLobbyUnlimitedExample,
+  lobbyCreatedExample,
+  listLobbiesExample,
+  lobbyListExample,
+  joinLobbyExample,
+  lobbyJoinedExample,
+  peerJoinedExample,
+  peerLeftExample,
+  leaveExample,
+  offerExample,
+  answerExample,
+  iceExample,
+  relayDeliveryOfferExample,
+  relayDeliveryIceExample,
+  errorLobbyNotFoundExample,
+  errorNotRegisteredExample,
+  pingExample,
+  pongExample,
+] as const;

--- a/infra/signaling-schema/src/index.ts
+++ b/infra/signaling-schema/src/index.ts
@@ -1,0 +1,308 @@
+/**
+ * Apeiron Cipher — Signaling Protocol Schema
+ *
+ * Canonical TypeScript types and JSON Schema for the WebSocket matchmaking and
+ * WebRTC signaling protocol. Mirrors the Go wire types in
+ * infra/orchestrator/internal/signaling/messages.go.
+ *
+ * All messages share a top-level `type` discriminator so clients can dispatch
+ * on a single field without deserialising the entire payload.
+ *
+ * SCHEMA_VERSION must be incremented on any breaking change to the wire format.
+ * Non-breaking additions (new optional fields) increment the minor version only.
+ */
+
+export const SCHEMA_VERSION = "1.0.0" as const;
+
+// ---------------------------------------------------------------------------
+// Message type discriminator
+// ---------------------------------------------------------------------------
+
+/** All message types understood by the signaling protocol. */
+export type MsgType =
+  // Client → server
+  | "register"       // Claim an ephemeral session, optionally announce displayName
+  | "create_lobby"   // Create a new matchmaking lobby
+  | "list_lobbies"   // Request current lobby list
+  | "join_lobby"     // Request to join an existing lobby
+  | "leave"          // Leave current lobby (stay connected)
+  | "offer"          // WebRTC SDP offer relay (client → peer)
+  | "answer"         // WebRTC SDP answer relay (client → peer)
+  | "ice"            // ICE candidate relay (client → peer)
+  | "ping"           // Keepalive ping
+  // Server → client
+  | "registered"     // Acknowledge registration, return session ID
+  | "lobby_list"     // Current lobby list
+  | "lobby_created"  // New lobby acknowledged
+  | "lobby_joined"   // Join request accepted, includes peer info
+  | "peer_joined"    // Someone else joined the client's lobby
+  | "peer_left"      // Peer disconnected or left
+  | "relay"          // Relayed offer / answer / ice from peer
+  | "error"          // Error response
+  | "pong";          // Keepalive response
+
+/** Client-to-server message types (outbound from game client). */
+export type ClientMsgType = Extract<MsgType,
+  | "register"
+  | "create_lobby"
+  | "list_lobbies"
+  | "join_lobby"
+  | "leave"
+  | "offer"
+  | "answer"
+  | "ice"
+  | "ping"
+>;
+
+/** Server-to-client message types (inbound to game client). */
+export type ServerMsgType = Extract<MsgType,
+  | "registered"
+  | "lobby_list"
+  | "lobby_created"
+  | "lobby_joined"
+  | "peer_joined"
+  | "peer_left"
+  | "relay"
+  | "error"
+  | "pong"
+>;
+
+// ---------------------------------------------------------------------------
+// Envelope — top-level wrapper for every message
+// ---------------------------------------------------------------------------
+
+/**
+ * Every message on the wire is wrapped in an Envelope. The `type` field acts
+ * as the discriminator; `payload` contains type-specific JSON.
+ *
+ * The server keeps payload as raw bytes to allow dispatch-before-decode;
+ * clients should decode payload based on the type field.
+ */
+export interface Envelope<T extends MsgType = MsgType, P = unknown> {
+  type: T;
+  /** Type-specific payload. Absent (undefined) for payloads with no fields. */
+  payload?: P;
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/** Sent by a client to claim an ephemeral session. */
+export interface RegisterPayload {
+  /** Optional human-readable display name shown to other players. */
+  display_name?: string;
+}
+
+/** Server acknowledgement of registration. */
+export interface RegisteredPayload {
+  /** Randomly generated UUID for this session; must be passed as target_session_id in relay messages. */
+  session_id: string;
+  /** Echo of the display name (server may assign a default if omitted). */
+  display_name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Lobby management
+// ---------------------------------------------------------------------------
+
+/** Summary view of a lobby included in list responses. */
+export interface LobbyInfo {
+  lobby_id: string;
+  /** Display name of the lobby creator. */
+  display_name: string;
+  /** Current peer count including the creator. */
+  peer_count: number;
+  /** Maximum peers allowed; 0 means unlimited. */
+  max_peers?: number;
+}
+
+/** Sent by a client to create a new lobby. */
+export interface CreateLobbyPayload {
+  /** Maximum number of peers; 0 or absent means unlimited. */
+  max_peers?: number;
+}
+
+/** Server acknowledgement of lobby creation. */
+export interface LobbyCreatedPayload {
+  lobby_id: string;
+}
+
+/** No fields needed for a list request. */
+export type ListLobbiesPayload = Record<string, never>;
+
+/** Server response to list_lobbies. */
+export interface LobbyListPayload {
+  lobbies: LobbyInfo[];
+}
+
+/** Sent by a client requesting to join a lobby. */
+export interface JoinLobbyPayload {
+  lobby_id: string;
+}
+
+/** Minimal peer descriptor included in joined/peer_joined messages. */
+export interface PeerInfo {
+  session_id: string;
+  display_name: string;
+}
+
+/** Sent to the joining client on successful join. */
+export interface LobbyJoinedPayload {
+  lobby_id: string;
+  /** Existing peers in the lobby, excluding the joiner. */
+  peers: PeerInfo[];
+}
+
+/** Sent to existing lobby members when a new peer joins. */
+export interface PeerJoinedPayload {
+  lobby_id: string;
+  peer: PeerInfo;
+}
+
+/** Sent to remaining lobby members when a peer leaves or disconnects. */
+export interface PeerLeftPayload {
+  lobby_id: string;
+  session_id: string;
+}
+
+// ---------------------------------------------------------------------------
+// WebRTC relay
+// ---------------------------------------------------------------------------
+
+/** Relay types that can travel inside the `kind` field of a relay delivery. */
+export type RelayKind = "offer" | "answer" | "ice";
+
+/**
+ * Sent by a client to relay SDP offer, SDP answer, or ICE candidate to a peer.
+ * The server routes the message to `target_session_id` without inspecting `data`.
+ */
+export interface RelayPayload {
+  target_session_id: string;
+  /** Opaque SDP blob or RTCIceCandidate JSON — the server passes this through unchanged. */
+  data: unknown;
+}
+
+/** What the recipient receives — the same data, enriched with sender identity. */
+export interface RelayDeliveryPayload {
+  from_session_id: string;
+  /** Identifies whether this is an offer, answer, or ICE candidate. */
+  kind: RelayKind;
+  /** Opaque SDP or ICE data from the sender. */
+  data: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Sent by the server when a request cannot be fulfilled. */
+export interface ErrorPayload {
+  /** Machine-readable error code (e.g. "not_registered", "lobby_not_found"). */
+  code: string;
+  /** Human-readable description suitable for logging. */
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Keepalive
+// ---------------------------------------------------------------------------
+
+/** Ping has no payload — an empty or absent payload field is expected. */
+export type PingPayload = undefined;
+/** Pong has no payload. */
+export type PongPayload = undefined;
+
+// ---------------------------------------------------------------------------
+// Typed Envelope aliases — the recommended way to work with messages
+// ---------------------------------------------------------------------------
+
+export type RegisterEnvelope      = Envelope<"register",      RegisterPayload>;
+export type CreateLobbyEnvelope   = Envelope<"create_lobby",  CreateLobbyPayload>;
+export type ListLobbiesEnvelope   = Envelope<"list_lobbies",  ListLobbiesPayload | undefined>;
+export type JoinLobbyEnvelope     = Envelope<"join_lobby",    JoinLobbyPayload>;
+export type LeaveEnvelope         = Envelope<"leave",         undefined>;
+export type OfferEnvelope         = Envelope<"offer",         RelayPayload>;
+export type AnswerEnvelope        = Envelope<"answer",        RelayPayload>;
+export type IceEnvelope           = Envelope<"ice",           RelayPayload>;
+export type PingEnvelope          = Envelope<"ping",          undefined>;
+
+export type RegisteredEnvelope    = Envelope<"registered",    RegisteredPayload>;
+export type LobbyListEnvelope     = Envelope<"lobby_list",    LobbyListPayload>;
+export type LobbyCreatedEnvelope  = Envelope<"lobby_created", LobbyCreatedPayload>;
+export type LobbyJoinedEnvelope   = Envelope<"lobby_joined",  LobbyJoinedPayload>;
+export type PeerJoinedEnvelope    = Envelope<"peer_joined",   PeerJoinedPayload>;
+export type PeerLeftEnvelope      = Envelope<"peer_left",     PeerLeftPayload>;
+export type RelayDeliveryEnvelope = Envelope<"relay",         RelayDeliveryPayload>;
+export type ErrorEnvelope         = Envelope<"error",         ErrorPayload>;
+export type PongEnvelope          = Envelope<"pong",          undefined>;
+
+/** Union of all valid client-bound envelopes. */
+export type AnyServerEnvelope =
+  | RegisteredEnvelope
+  | LobbyListEnvelope
+  | LobbyCreatedEnvelope
+  | LobbyJoinedEnvelope
+  | PeerJoinedEnvelope
+  | PeerLeftEnvelope
+  | RelayDeliveryEnvelope
+  | ErrorEnvelope
+  | PongEnvelope;
+
+/** Union of all valid server-bound envelopes. */
+export type AnyClientEnvelope =
+  | RegisterEnvelope
+  | CreateLobbyEnvelope
+  | ListLobbiesEnvelope
+  | JoinLobbyEnvelope
+  | LeaveEnvelope
+  | OfferEnvelope
+  | AnswerEnvelope
+  | IceEnvelope
+  | PingEnvelope;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow an unknown value to a typed server envelope. Returns the typed
+ * envelope if `type` is a known ServerMsgType, or null otherwise.
+ *
+ * Usage:
+ *   const env = parseServerMessage(JSON.parse(rawJson));
+ *   if (env?.type === "registered") { ... env.payload.session_id ... }
+ */
+export function parseServerMessage(raw: unknown): AnyServerEnvelope | null {
+  if (
+    typeof raw !== "object" ||
+    raw === null ||
+    !("type" in raw) ||
+    typeof (raw as { type: unknown }).type !== "string"
+  ) {
+    return null;
+  }
+  const knownServerTypes: ServerMsgType[] = [
+    "registered", "lobby_list", "lobby_created", "lobby_joined",
+    "peer_joined", "peer_left", "relay", "error", "pong",
+  ];
+  const t = (raw as { type: string }).type as MsgType;
+  if (!(knownServerTypes as string[]).includes(t)) {
+    return null;
+  }
+  return raw as AnyServerEnvelope;
+}
+
+/**
+ * Build a typed Envelope for sending from client to server.
+ *
+ * Usage:
+ *   const msg = makeEnvelope("register", { display_name: "Alice" });
+ *   ws.send(JSON.stringify(msg));
+ */
+export function makeEnvelope<T extends ClientMsgType, P>(
+  type: T,
+  payload?: P,
+): Envelope<T, P> {
+  return payload !== undefined ? { type, payload } : { type };
+}

--- a/infra/signaling-schema/src/schema.ts
+++ b/infra/signaling-schema/src/schema.ts
@@ -1,0 +1,289 @@
+/**
+ * JSON Schema definitions for the Apeiron Cipher signaling protocol.
+ *
+ * These schemas mirror the TypeScript types in index.ts and the Go types in
+ * infra/orchestrator/internal/signaling/messages.go.
+ *
+ * Use with AJV (or any JSON Schema Draft-07 validator) to validate incoming
+ * or outgoing messages at runtime:
+ *
+ *   import Ajv from "ajv";
+ *   import { envelopeSchema, validateEnvelope } from "./schema";
+ *   const valid = validateEnvelope({ type: "register", payload: { display_name: "Alice" } });
+ */
+
+export const SCHEMA_VERSION = "1.0.0";
+
+// ---------------------------------------------------------------------------
+// Reusable sub-schemas
+// ---------------------------------------------------------------------------
+
+export const peerInfoSchema = {
+  type: "object",
+  required: ["session_id", "display_name"],
+  additionalProperties: false,
+  properties: {
+    session_id:   { type: "string", minLength: 1 },
+    display_name: { type: "string" },
+  },
+} as const;
+
+export const lobbyInfoSchema = {
+  type: "object",
+  required: ["lobby_id", "display_name", "peer_count"],
+  additionalProperties: false,
+  properties: {
+    lobby_id:     { type: "string", minLength: 1 },
+    display_name: { type: "string" },
+    peer_count:   { type: "integer", minimum: 0 },
+    max_peers:    { type: "integer", minimum: 0 },
+  },
+} as const;
+
+export const errorPayloadSchema = {
+  type: "object",
+  required: ["code", "message"],
+  additionalProperties: false,
+  properties: {
+    code:    { type: "string", minLength: 1 },
+    message: { type: "string" },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Per-type payload schemas
+// ---------------------------------------------------------------------------
+
+const payloadSchemas: Record<string, object> = {
+  register: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      display_name: { type: "string" },
+    },
+  },
+
+  registered: {
+    type: "object",
+    required: ["session_id", "display_name"],
+    additionalProperties: false,
+    properties: {
+      session_id:   { type: "string", minLength: 1 },
+      display_name: { type: "string" },
+    },
+  },
+
+  create_lobby: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      max_peers: { type: "integer", minimum: 0 },
+    },
+  },
+
+  lobby_created: {
+    type: "object",
+    required: ["lobby_id"],
+    additionalProperties: false,
+    properties: {
+      lobby_id: { type: "string", minLength: 1 },
+    },
+  },
+
+  list_lobbies: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+
+  lobby_list: {
+    type: "object",
+    required: ["lobbies"],
+    additionalProperties: false,
+    properties: {
+      lobbies: {
+        type: "array",
+        items: lobbyInfoSchema,
+      },
+    },
+  },
+
+  join_lobby: {
+    type: "object",
+    required: ["lobby_id"],
+    additionalProperties: false,
+    properties: {
+      lobby_id: { type: "string", minLength: 1 },
+    },
+  },
+
+  lobby_joined: {
+    type: "object",
+    required: ["lobby_id", "peers"],
+    additionalProperties: false,
+    properties: {
+      lobby_id: { type: "string", minLength: 1 },
+      peers: {
+        type: "array",
+        items: peerInfoSchema,
+      },
+    },
+  },
+
+  peer_joined: {
+    type: "object",
+    required: ["lobby_id", "peer"],
+    additionalProperties: false,
+    properties: {
+      lobby_id: { type: "string", minLength: 1 },
+      peer: peerInfoSchema,
+    },
+  },
+
+  peer_left: {
+    type: "object",
+    required: ["lobby_id", "session_id"],
+    additionalProperties: false,
+    properties: {
+      lobby_id:   { type: "string", minLength: 1 },
+      session_id: { type: "string", minLength: 1 },
+    },
+  },
+
+  leave: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+
+  offer: {
+    type: "object",
+    required: ["target_session_id", "data"],
+    additionalProperties: false,
+    properties: {
+      target_session_id: { type: "string", minLength: 1 },
+      data: {},  // opaque SDP JSON — any shape is valid
+    },
+  },
+
+  answer: {
+    type: "object",
+    required: ["target_session_id", "data"],
+    additionalProperties: false,
+    properties: {
+      target_session_id: { type: "string", minLength: 1 },
+      data: {},
+    },
+  },
+
+  ice: {
+    type: "object",
+    required: ["target_session_id", "data"],
+    additionalProperties: false,
+    properties: {
+      target_session_id: { type: "string", minLength: 1 },
+      data: {},
+    },
+  },
+
+  relay: {
+    type: "object",
+    required: ["from_session_id", "kind", "data"],
+    additionalProperties: false,
+    properties: {
+      from_session_id: { type: "string", minLength: 1 },
+      kind: { type: "string", enum: ["offer", "answer", "ice"] },
+      data: {},
+    },
+  },
+
+  error: errorPayloadSchema,
+
+  ping: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+
+  pong: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Top-level Envelope schema (dynamic — validates by type)
+// ---------------------------------------------------------------------------
+
+const allTypes = Object.keys(payloadSchemas);
+
+/**
+ * JSON Schema (Draft-07) for an Envelope object.
+ * The `payload` property is validated against the per-type schema selected by `type`.
+ */
+export const envelopeSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://apeiron-cipher.internal/signaling/envelope",
+  title: "SignalingEnvelope",
+  description: `Apeiron Cipher signaling protocol envelope (schema v${SCHEMA_VERSION})`,
+  type: "object",
+  required: ["type"],
+  additionalProperties: false,
+  properties: {
+    type: { type: "string", enum: allTypes },
+    payload: {},  // refined per type in if/then blocks below
+  },
+  // Per-type payload validation via JSON Schema if/then
+  allOf: allTypes.map((t) => ({
+    if: { properties: { type: { const: t } }, required: ["type"] },
+    then: { properties: { payload: payloadSchemas[t] } },
+  })),
+};
+
+// ---------------------------------------------------------------------------
+// AJV-based runtime validator (optional convenience export)
+// ---------------------------------------------------------------------------
+
+let _ajv: unknown | null = null;
+let _validate: ((data: unknown) => boolean) | null = null;
+
+function getValidator(): ((data: unknown) => boolean) {
+  if (_validate) return _validate;
+  try {
+    // AJV is an optional peer dep — do not throw if absent
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Ajv = require("ajv");
+    const ajv = new Ajv({ strict: false });
+    _ajv = ajv;
+    _validate = ajv.compile(envelopeSchema);
+    return _validate!;
+  } catch {
+    // AJV not installed — return a permissive stub
+    return (_data: unknown) => true;
+  }
+}
+
+/**
+ * Validate a parsed JSON object against the signaling envelope schema.
+ * Returns true if valid. Requires `ajv` package to be installed for real
+ * validation; returns true unconditionally if ajv is absent.
+ */
+export function validateEnvelope(data: unknown): boolean {
+  return getValidator()(data);
+}
+
+/**
+ * Same as validateEnvelope but throws with a descriptive error on failure.
+ */
+export function assertEnvelope(data: unknown): void {
+  const validate = getValidator();
+  if (!validate(data)) {
+    const err = (validate as unknown as { errors?: unknown[] }).errors;
+    throw new Error(
+      `Invalid signaling envelope: ${JSON.stringify(err ?? "unknown AJV error")}`,
+    );
+  }
+}
+
+export { payloadSchemas };

--- a/infra/signaling-schema/src/validate-examples.ts
+++ b/infra/signaling-schema/src/validate-examples.ts
@@ -1,0 +1,28 @@
+/**
+ * Smoke test: validate every example payload against the JSON Schema.
+ *
+ * Run with: `npm run validate` (via ts-node) or after build via `node dist/validate-examples.js`
+ */
+
+import { validateEnvelope, assertEnvelope } from "./schema.js";
+import { ALL_EXAMPLES } from "./examples.js";
+
+let passed = 0;
+let failed = 0;
+
+for (const example of ALL_EXAMPLES) {
+  try {
+    assertEnvelope(example);
+    console.log(`  PASS  ${example.type}`);
+    passed++;
+  } catch (err) {
+    console.error(`  FAIL  ${example.type}:`, err);
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/infra/signaling-schema/tsconfig.json
+++ b/infra/signaling-schema/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `infra/signaling-schema/` — the canonical shared schema module for the Apeiron Cipher WebSocket matchmaking and WebRTC signaling protocol.

## What's included

| File | Purpose |
|------|---------|
| `src/index.ts` | TypeScript interfaces + typed `Envelope<T, P>` aliases for all 18 message types (mirrors Go `messages.go` exactly) |
| `src/schema.ts` | JSON Schema Draft-07 definitions; `validateEnvelope` / `assertEnvelope` AJV-backed runtime validators |
| `src/examples.ts` | Typed example payloads for every message type (22 total) |
| `src/validate-examples.ts` | Smoke test: validates all examples against the schema |
| `README.md` | Usage guide, wire format table, versioning policy |
| `Makefile` | New `sig-schema-check` target |

## Acceptance criteria

- [x] Schema compiles (`tsc --noEmit` clean)
- [x] 22 example payloads validate against JSON Schema (`make sig-schema-check`)
- [x] Importable by server (Node.js / ts-node) and client (browser TS)
- [x] `SCHEMA_VERSION = "1.0.0"` exported from both `index.ts` and `schema.ts`

## Versioning

`SCHEMA_VERSION` follows semver:
- **Major**: breaking wire change (removed/renamed field)
- **Minor**: new optional field added
- **Patch**: docs/tooling only

## Relationship to Go server

Mirrors `infra/orchestrator/internal/signaling/messages.go` (PR #468). When Go types change, this package must be updated in the same PR with a version bump.

Closes #234 (partial — this is the schema task; PR #468 has the Go server)