### PR TITLE
docs: add comment explaining #[allow(dead_code)] for deprecated level() method

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1145,6 +1145,8 @@ impl ConfidenceTracker {
         since = "0.1.0",
         note = "Use Confidence in journal observations instead of ConfidenceLevel"
     )]
+    // Retained for backward compatibility during migration to journal-based confidence tracking.
+    // Remove once all call-sites have been updated to use Confidence values from journal observations.
     #[allow(dead_code)]
     pub fn level(&self, seed: u64, property: PropertyName) -> ConfidenceLevel {
         ConfidenceLevel::from_count(self.count(seed, property))


### PR DESCRIPTION
## Summary

Adds an explanatory comment above the `#[allow(dead_code)]` attribute on `ConfidenceTracker::level()` in `src/observation.rs`.

The comment clarifies that the suppression is intentional: the deprecated `level()` method is retained for backward compatibility during migration to journal-based confidence tracking, and will be removed once all call-sites have been updated.

## Change

```rust
// Retained for backward compatibility during migration to journal-based confidence tracking.
// Remove once all call-sites have been updated to use Confidence values from journal observations.
#[allow(dead_code)]
pub fn level(&self, seed: u64, property: PropertyName) -> ConfidenceLevel {
```

## Test Plan
- `make check` passes (707 unit tests, clippy, fmt, build)

Closes kanban task t_2937c9b4