### PR TITLE
refactor: migrate remaining bare u64 seed call sites to domain newtypes

### DIFF
--- a/src/knowledge_graph.rs
+++ b/src/knowledge_graph.rs
@@ -26,6 +26,7 @@ use petgraph::visit::EdgeRef;
 use serde::{Deserialize, Serialize};
 
 use crate::journal::JournalKey;
+use crate::materials::MaterialSeed;
 use crate::observation::{Confidence, ConfidenceConfig};
 use crate::world_generation::PlanetSeed;
 
@@ -1160,7 +1161,7 @@ fn property_value_for_category(
 ///   (loaded from config, typically ~0.85).
 /// - `tick` — Current game-time tick for edge timestamps.
 pub fn detect_and_wire_similar_materials(
-    new_seed: u64,
+    new_seed: MaterialSeed,
     new_material: &crate::materials::GameMaterial,
     catalog: &crate::materials::MaterialCatalog,
     graph_read: &KnowledgeGraph,
@@ -1171,7 +1172,7 @@ pub fn detect_and_wire_similar_materials(
     let new_vec = new_material.property_vector();
 
     for existing in catalog.values() {
-        if existing.seed == new_seed {
+        if existing.seed == new_seed.0 {
             continue;
         }
 
@@ -1180,7 +1181,7 @@ pub fn detect_and_wire_similar_materials(
             continue;
         }
 
-        let new_key = crate::journal::JournalKey::MaterialInstance { seed: new_seed };
+        let new_key = crate::journal::JournalKey::MaterialInstance { seed: new_seed.0 };
         let existing_key = crate::journal::JournalKey::MaterialInstance {
             seed: existing.seed,
         };
@@ -1281,7 +1282,7 @@ fn detect_similar_on_observation(
             continue;
         };
         detect_and_wire_similar_materials(
-            seed,
+            MaterialSeed(seed),
             material,
             &catalog,
             &graph.as_ref().clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod observation;
 pub mod player;
 pub mod scene;
 pub mod seed_util;
+pub mod seeds;
 pub mod solar_system;
 pub mod surface;
 pub mod world_generation;

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -32,12 +32,9 @@ use crate::world_generation::PlanetSeed;
 
 /// Typed seed for a material instance.
 ///
-/// Wraps the raw `u64` seed so that material seeds cannot be silently confused
-/// with planet seeds or other seed domains at the type level.  Bare `u64` is
-/// only permitted at serialisation / asset-loading edges; everywhere else pass
-/// `MaterialSeed`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
-pub struct MaterialSeed(pub u64);
+/// Re-exported from [`crate::seeds`]. Defined centrally in the seeds module so
+/// that all domain seed newtypes live in one place.
+pub use crate::seeds::MaterialSeed;
 /// Registers the material data model, catalog, and world-object spawning systems.
 pub struct MaterialPlugin;
 

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -32,19 +32,9 @@ use crate::world_generation::PlanetSeed;
 
 /// Typed seed for a material instance.
 ///
-/// Wraps the raw `u64` seed so that material seeds cannot be silently confused
-/// with planet seeds or other seed domains at the type level.  Bare `u64` is
-/// only permitted at serialisation / asset-loading edges; everywhere else pass
-/// `MaterialSeed`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
-pub struct MaterialSeed(pub u64);
-
-impl std::fmt::Display for MaterialSeed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#018x}", self.0)
-    }
-}
-
+/// Re-exported from [`crate::seeds`]. Defined centrally in the seeds module so
+/// that all domain seed newtypes live in one place.
+pub use crate::seeds::MaterialSeed;
 /// Registers the material data model, catalog, and world-object spawning systems.
 pub struct MaterialPlugin;
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -3410,26 +3410,26 @@ mod tests {
     #[allow(deprecated)]
     fn confidence_tracker_serde_round_trip() {
         let mut tracker = ConfidenceTracker::default();
-        tracker.record(42, PropertyName::ThermalResistance);
-        tracker.record(42, PropertyName::ThermalResistance);
-        tracker.record(7, PropertyName::Density);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(42), PropertyName::ThermalResistance);
+        tracker.record(MaterialSeed(7), PropertyName::Density);
 
         let json = serde_json::to_string(&tracker).expect("ConfidenceTracker must serialise");
         let restored: ConfidenceTracker =
             serde_json::from_str(&json).expect("ConfidenceTracker must deserialise");
 
         assert_eq!(
-            restored.count(42, PropertyName::ThermalResistance),
+            restored.count(MaterialSeed(42), PropertyName::ThermalResistance),
             2,
             "ThermalResistance count must survive round-trip"
         );
         assert_eq!(
-            restored.count(7, PropertyName::Density),
+            restored.count(MaterialSeed(7), PropertyName::Density),
             1,
             "Density count must survive round-trip"
         );
         assert_eq!(
-            restored.count(99, PropertyName::Density),
+            restored.count(MaterialSeed(99), PropertyName::Density),
             0,
             "unseen key must return zero"
         );

--- a/src/seeds.rs
+++ b/src/seeds.rs
@@ -9,6 +9,7 @@
 //!
 //! | Type | Derived from | Purpose |
 //! |---|---|---|
+//! | [`SolarSystemSeed`] | Asset config (solar_system_seed field) | Root seed for a solar system |
 //! | [`PlanetSeed`] | `SolarSystemSeed` + orbital slot | Root seed for a planet; re-exported here |
 //! | [`MaterialSeed`] | `PlanetSeed` (via asset loader) | Material property generation |
 //! | [`PlacementSeed`] | `PlanetSeed` + placement channel | Object placement and spatial distribution |
@@ -18,11 +19,14 @@
 //! ## Usage
 //!
 //! ```rust
-//! use apeiron_cipher::seeds::{MaterialSeed, PlacementSeed};
+//! use apeiron_cipher::seeds::{MaterialSeed, PlacementSeed, SolarSystemSeed};
 //!
 //! let mat = MaterialSeed::from(42_u64);
 //! let (density, variation) = mat.split();
 //! // density and variation are both MaterialSeed — independent sub-seeds
+//!
+//! // SolarSystemSeed wraps a raw u64 system seed at the asset-loading edge.
+//! let sys: SolarSystemSeed = 12345_u64.into();
 //! ```
 //!
 //! ## Why newtypes, not bare `u64`?
@@ -43,6 +47,12 @@ use crate::seed_util::mix_seed;
 /// Callers that need all seed types in one place can import from `seeds::*`
 /// instead of reaching into `world_generation`.
 pub use crate::world_generation::PlanetSeed;
+
+/// Re-export [`SolarSystemSeed`] from the solar system module.
+///
+/// Callers that need all seed types in one place can import from `seeds::*`
+/// instead of reaching into `solar_system`.
+pub use crate::solar_system::SolarSystemSeed;
 
 // ── Internal split constants ─────────────────────────────────────────────────
 //
@@ -280,5 +290,23 @@ mod tests {
         // If PlanetSeed is not re-exported from this module this test won't compile.
         let ps = PlanetSeed(42);
         assert_eq!(ps.0, 42);
+    }
+
+    // ── SolarSystemSeed re-export ─────────────────────────────────────────
+
+    #[test]
+    fn solar_system_seed_reexport_is_usable() {
+        // Exercises the `pub use crate::solar_system::SolarSystemSeed;` re-export.
+        // If SolarSystemSeed is not re-exported from this module this test won't compile.
+        let s = SolarSystemSeed(999);
+        assert_eq!(s.0, 999);
+        let back: u64 = s.into();
+        assert_eq!(back, 999);
+    }
+
+    #[test]
+    fn solar_system_seed_from_u64() {
+        let s: SolarSystemSeed = 42_u64.into();
+        assert_eq!(s.0, 42);
     }
 }

--- a/src/seeds.rs
+++ b/src/seeds.rs
@@ -1,0 +1,284 @@
+//! Domain seed newtypes for deterministic procedural generation.
+//!
+//! All procedural generation in Apeiron Cipher flows through typed seed values.
+//! Bare `u64` is only permitted at serialisation / asset-loading edges — everywhere
+//! else, pass the appropriate domain seed newtype so the compiler prevents you from
+//! accidentally mixing seeds across domains at the type level.
+//!
+//! ## Newtype catalogue
+//!
+//! | Type | Derived from | Purpose |
+//! |---|---|---|
+//! | [`PlanetSeed`] | `SolarSystemSeed` + orbital slot | Root seed for a planet; re-exported here |
+//! | [`MaterialSeed`] | `PlanetSeed` (via asset loader) | Material property generation |
+//! | [`PlacementSeed`] | `PlanetSeed` + placement channel | Object placement and spatial distribution |
+//! | [`BiomeSeed`] | `PlanetSeed` + biome channel | Biome / climate generation |
+//! | [`ObjectIdentitySeed`] | `PlanetSeed` + identity channel | Unique entity identity |
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use apeiron_cipher::seeds::{MaterialSeed, PlacementSeed};
+//!
+//! let mat = MaterialSeed::from(42_u64);
+//! let (density, variation) = mat.split();
+//! // density and variation are both MaterialSeed — independent sub-seeds
+//! ```
+//!
+//! ## Why newtypes, not bare `u64`?
+//!
+//! A function that accepts `PlacementSeed` cannot silently receive a `BiomeSeed`.
+//! Without newtypes every seed is a `u64`, and mixing the wrong domain seed into
+//! a generator produces deterministically wrong output — a bug that compiles fine
+//! and produces plausible-looking results, making it nearly invisible in testing.
+//! Newtypes move that class of error to the type checker.
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::seed_util::mix_seed;
+
+/// Re-export [`PlanetSeed`] from the world generation module.
+///
+/// Callers that need all seed types in one place can import from `seeds::*`
+/// instead of reaching into `world_generation`.
+pub use crate::world_generation::PlanetSeed;
+
+// ── Internal split constants ─────────────────────────────────────────────────
+//
+// These splitmix64-style mixing constants are used *only* inside this module for
+// the `split()` helper. They are intentionally distinct from every `SeedChannel`
+// discriminant (all of which use the family-prefix scheme documented in
+// `seed_util`) so that no collision can produce incorrect world output.
+
+const SPLIT_A: u64 = 0xA24B_AED4_963E_E407;
+const SPLIT_B: u64 = 0x9D20_8DD2_A4A8_B4C5;
+
+// ── Macro ─────────────────────────────────────────────────────────────────────
+
+/// Generates a domain seed newtype with the standard Apeiron Cipher trait suite.
+///
+/// Each expansion produces:
+/// - A `pub struct $name(pub u64)` tuple-struct newtype
+/// - `#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]`
+/// - `From<u64>` — wraps a raw value (serialisation / asset-loading edge only)
+/// - `From<$name> for u64` — unwraps for the same edge
+/// - `fn split(self) -> (Self, Self)` — two deterministic independent sub-seeds
+macro_rules! define_seed_newtype {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
+        $vis struct $name(pub u64);
+
+        impl From<u64> for $name {
+            #[inline]
+            fn from(v: u64) -> Self { Self(v) }
+        }
+
+        impl From<$name> for u64 {
+            #[inline]
+            fn from(s: $name) -> u64 { s.0 }
+        }
+
+        impl $name {
+            /// Derive two independent sub-seeds from this seed.
+            ///
+            /// Both outputs are produced by splitmix64-style bit mixing of the
+            /// original value with two distinct constants. Neither output equals
+            /// the input, and the two outputs are independent of each other.
+            ///
+            /// Useful when one seed must independently initialise two sub-systems
+            /// (e.g., splitting a placement seed into a density seed and a
+            /// variation seed without them influencing each other).
+            ///
+            /// Deterministic: calling `split()` twice on the same value always
+            /// returns the same pair.
+            pub fn split(self) -> (Self, Self) {
+                (
+                    Self(mix_seed(self.0, SPLIT_A)),
+                    Self(mix_seed(self.0, SPLIT_B)),
+                )
+            }
+        }
+    };
+}
+
+// ── Seed newtype definitions ──────────────────────────────────────────────────
+
+define_seed_newtype! {
+    /// Typed seed for a material instance's property generation.
+    ///
+    /// Each `MaterialSeed` uniquely identifies one material in the procedural
+    /// catalog. All five physical properties (density, thermal resistance,
+    /// reactivity, conductivity, toxicity) and the display colour are derived
+    /// deterministically from this value via `derive_material_from_seed`.
+    ///
+    /// Bare `u64` is only permitted at serialisation / asset-loading edges;
+    /// everywhere else pass `MaterialSeed`.
+    pub struct MaterialSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for object placement and spatial distribution.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the placement density or
+    /// placement variation channel. Controls where material deposits and
+    /// surface objects appear across an exterior chunk grid.
+    ///
+    /// Never pass this where a [`BiomeSeed`] or [`ObjectIdentitySeed`] is
+    /// expected — they are separate domains that produce different outputs.
+    pub struct PlacementSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for biome and climate generation.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the biome climate channel.
+    /// Drives the temperature and moisture coherent noise fields that determine
+    /// the biome at each chunk position on the planet surface.
+    pub struct BiomeSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for object identity and unique entity generation.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the object identity channel.
+    /// Ensures that every spawned entity carries a stable, reproducible identity
+    /// tied to the planet and chunk that produced it, regardless of spawn order.
+    pub struct ObjectIdentitySeed;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    // ── Type distinction ─────────────────────────────────────────────────
+    //
+    // These are compile-time checks. The test bodies are never reached at
+    // runtime — the assertion is that these functions *compile*, proving that
+    // each seed domain is a distinct type the compiler recognises separately.
+    //
+    // A future regression where two newtypes collapse to the same type would
+    // surface as a compile error here before it ever reaches CI.
+
+    /// Only accepts `MaterialSeed`. Passing a `PlacementSeed` here is a
+    /// compile error.
+    #[allow(dead_code)]
+    fn _accept_material_seed(_: MaterialSeed) {}
+
+    /// Only accepts `PlacementSeed`.
+    #[allow(dead_code)]
+    fn _accept_placement_seed(_: PlacementSeed) {}
+
+    /// Only accepts `BiomeSeed`.
+    #[allow(dead_code)]
+    fn _accept_biome_seed(_: BiomeSeed) {}
+
+    /// Only accepts `ObjectIdentitySeed`.
+    #[allow(dead_code)]
+    fn _accept_object_identity_seed(_: ObjectIdentitySeed) {}
+
+    // ── From<u64> / Into<u64> ────────────────────────────────────────────
+
+    #[test]
+    fn material_seed_round_trips_through_u64() {
+        let s = MaterialSeed::from(42_u64);
+        assert_eq!(s.0, 42);
+        let back: u64 = s.into();
+        assert_eq!(back, 42);
+    }
+
+    #[test]
+    fn placement_seed_round_trips_through_u64() {
+        let s = PlacementSeed::from(99_u64);
+        assert_eq!(s.0, 99);
+        let back: u64 = s.into();
+        assert_eq!(back, 99);
+    }
+
+    #[test]
+    fn biome_seed_round_trips_through_u64() {
+        let s = BiomeSeed::from(7_u64);
+        assert_eq!(s.0, 7);
+        let back: u64 = s.into();
+        assert_eq!(back, 7);
+    }
+
+    #[test]
+    fn object_identity_seed_round_trips_through_u64() {
+        let s = ObjectIdentitySeed::from(u64::MAX);
+        assert_eq!(s.0, u64::MAX);
+        let back: u64 = s.into();
+        assert_eq!(back, u64::MAX);
+    }
+
+    // ── split() ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn split_is_deterministic() {
+        let base = MaterialSeed(12345);
+        let (a1, b1) = base.split();
+        let (a2, b2) = base.split();
+        assert_eq!(a1, a2, "split must produce the same first value each call");
+        assert_eq!(b1, b2, "split must produce the same second value each call");
+    }
+
+    #[test]
+    fn split_pair_values_differ_from_each_other_and_from_base() {
+        let base = MaterialSeed(99999);
+        let (a, b) = base.split();
+        assert_ne!(a.0, b.0, "split pair must contain two distinct values");
+        assert_ne!(a.0, base.0, "first split must differ from original");
+        assert_ne!(b.0, base.0, "second split must differ from original");
+    }
+
+    #[test]
+    fn split_available_on_every_seed_type() {
+        // Each type gets its own split via the macro — this verifies they all
+        // compile and run correctly rather than silently coercing to a single impl.
+        let _ = PlacementSeed(1).split();
+        let _ = BiomeSeed(2).split();
+        let _ = ObjectIdentitySeed(3).split();
+    }
+
+    // ── Clone / Copy / PartialEq / Eq / Hash ─────────────────────────────
+
+    #[test]
+    fn seed_is_copy_and_compares_by_value() {
+        let s = MaterialSeed(1);
+        let copy = s; // implicit Copy — no move
+        assert_eq!(s, copy, "Copy of seed must equal original");
+    }
+
+    #[test]
+    fn different_values_are_not_equal() {
+        assert_ne!(MaterialSeed(1), MaterialSeed(2));
+        assert_ne!(PlacementSeed(0), PlacementSeed(1));
+    }
+
+    #[test]
+    fn same_value_hashes_consistently() {
+        let s = BiomeSeed(777);
+        let mut set = HashSet::new();
+        set.insert(s);
+        set.insert(s); // same value again — must not grow the set
+        assert_eq!(set.len(), 1, "identical seeds must occupy one hash bucket");
+    }
+
+    // ── PlanetSeed re-export ──────────────────────────────────────────────
+
+    #[test]
+    fn planet_seed_reexport_is_usable() {
+        // Exercises the `pub use crate::world_generation::PlanetSeed;` re-export.
+        // If PlanetSeed is not re-exported from this module this test won't compile.
+        let ps = PlanetSeed(42);
+        assert_eq!(ps.0, 42);
+    }
+}

--- a/src/seeds.rs
+++ b/src/seeds.rs
@@ -1,0 +1,318 @@
+//! Domain seed newtypes for deterministic procedural generation.
+//!
+//! All procedural generation in Apeiron Cipher flows through typed seed values.
+//! Bare `u64` is only permitted at serialisation / asset-loading edges — everywhere
+//! else, pass the appropriate domain seed newtype so the compiler prevents you from
+//! accidentally mixing seeds across domains at the type level.
+//!
+//! ## Newtype catalogue
+//!
+//! | Type | Derived from | Purpose |
+//! |---|---|---|
+//! | [`SolarSystemSeed`] | Asset config (solar_system_seed field) | Root seed for a solar system |
+//! | [`PlanetSeed`] | `SolarSystemSeed` + orbital slot | Root seed for a planet; re-exported here |
+//! | [`MaterialSeed`] | `PlanetSeed` (via asset loader) | Material property generation |
+//! | [`PlacementSeed`] | `PlanetSeed` + placement channel | Object placement and spatial distribution |
+//! | [`BiomeSeed`] | `PlanetSeed` + biome channel | Biome / climate generation |
+//! | [`ObjectIdentitySeed`] | `PlanetSeed` + identity channel | Unique entity identity |
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use apeiron_cipher::seeds::{MaterialSeed, PlacementSeed, SolarSystemSeed};
+//!
+//! let mat = MaterialSeed::from(42_u64);
+//! let (density, variation) = mat.split();
+//! // density and variation are both MaterialSeed — independent sub-seeds
+//!
+//! // SolarSystemSeed wraps a raw u64 system seed at the asset-loading edge.
+//! let sys: SolarSystemSeed = 12345_u64.into();
+//! ```
+//!
+//! ## Why newtypes, not bare `u64`?
+//!
+//! A function that accepts `PlacementSeed` cannot silently receive a `BiomeSeed`.
+//! Without newtypes every seed is a `u64`, and mixing the wrong domain seed into
+//! a generator produces deterministically wrong output — a bug that compiles fine
+//! and produces plausible-looking results, making it nearly invisible in testing.
+//! Newtypes move that class of error to the type checker.
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::seed_util::mix_seed;
+
+/// Re-export [`PlanetSeed`] from the world generation module.
+///
+/// Callers that need all seed types in one place can import from `seeds::*`
+/// instead of reaching into `world_generation`.
+pub use crate::world_generation::PlanetSeed;
+
+/// Re-export [`SolarSystemSeed`] from the solar system module.
+///
+/// Callers that need all seed types in one place can import from `seeds::*`
+/// instead of reaching into `solar_system`.
+pub use crate::solar_system::SolarSystemSeed;
+
+// ── Internal split constants ─────────────────────────────────────────────────
+//
+// These splitmix64-style mixing constants are used *only* inside this module for
+// the `split()` helper. They are intentionally distinct from every `SeedChannel`
+// discriminant (all of which use the family-prefix scheme documented in
+// `seed_util`) so that no collision can produce incorrect world output.
+
+const SPLIT_A: u64 = 0xA24B_AED4_963E_E407;
+const SPLIT_B: u64 = 0x9D20_8DD2_A4A8_B4C5;
+
+// ── Macro ─────────────────────────────────────────────────────────────────────
+
+/// Generates a domain seed newtype with the standard Apeiron Cipher trait suite.
+///
+/// Each expansion produces:
+/// - A `pub struct $name(pub u64)` tuple-struct newtype
+/// - `#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]`
+/// - `From<u64>` — wraps a raw value (serialisation / asset-loading edge only)
+/// - `From<$name> for u64` — unwraps for the same edge
+/// - `fn split(self) -> (Self, Self)` — two deterministic independent sub-seeds
+macro_rules! define_seed_newtype {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
+        $vis struct $name(pub u64);
+
+        impl From<u64> for $name {
+            #[inline]
+            fn from(v: u64) -> Self { Self(v) }
+        }
+
+        impl From<$name> for u64 {
+            #[inline]
+            fn from(s: $name) -> u64 { s.0 }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{:#018x}", self.0)
+            }
+        }
+
+        impl $name {
+            /// Derive two independent sub-seeds from this seed.
+            ///
+            /// Both outputs are produced by splitmix64-style bit mixing of the
+            /// original value with two distinct constants. Neither output equals
+            /// the input, and the two outputs are independent of each other.
+            ///
+            /// Useful when one seed must independently initialise two sub-systems
+            /// (e.g., splitting a placement seed into a density seed and a
+            /// variation seed without them influencing each other).
+            ///
+            /// Deterministic: calling `split()` twice on the same value always
+            /// returns the same pair.
+            pub fn split(self) -> (Self, Self) {
+                (
+                    Self(mix_seed(self.0, SPLIT_A)),
+                    Self(mix_seed(self.0, SPLIT_B)),
+                )
+            }
+        }
+    };
+}
+
+// ── Seed newtype definitions ──────────────────────────────────────────────────
+
+define_seed_newtype! {
+    /// Typed seed for a material instance's property generation.
+    ///
+    /// Each `MaterialSeed` uniquely identifies one material in the procedural
+    /// catalog. All five physical properties (density, thermal resistance,
+    /// reactivity, conductivity, toxicity) and the display colour are derived
+    /// deterministically from this value via `derive_material_from_seed`.
+    ///
+    /// Bare `u64` is only permitted at serialisation / asset-loading edges;
+    /// everywhere else pass `MaterialSeed`.
+    pub struct MaterialSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for object placement and spatial distribution.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the placement density or
+    /// placement variation channel. Controls where material deposits and
+    /// surface objects appear across an exterior chunk grid.
+    ///
+    /// Never pass this where a [`BiomeSeed`] or [`ObjectIdentitySeed`] is
+    /// expected — they are separate domains that produce different outputs.
+    pub struct PlacementSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for biome and climate generation.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the biome climate channel.
+    /// Drives the temperature and moisture coherent noise fields that determine
+    /// the biome at each chunk position on the planet surface.
+    pub struct BiomeSeed;
+}
+
+define_seed_newtype! {
+    /// Typed seed for object identity and unique entity generation.
+    ///
+    /// Derived from a [`PlanetSeed`] by mixing with the object identity channel.
+    /// Ensures that every spawned entity carries a stable, reproducible identity
+    /// tied to the planet and chunk that produced it, regardless of spawn order.
+    pub struct ObjectIdentitySeed;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    // ── Type distinction ─────────────────────────────────────────────────
+    //
+    // These are compile-time checks. The test bodies are never reached at
+    // runtime — the assertion is that these functions *compile*, proving that
+    // each seed domain is a distinct type the compiler recognises separately.
+    //
+    // A future regression where two newtypes collapse to the same type would
+    // surface as a compile error here before it ever reaches CI.
+
+    /// Only accepts `MaterialSeed`. Passing a `PlacementSeed` here is a
+    /// compile error.
+    #[allow(dead_code)]
+    fn _accept_material_seed(_: MaterialSeed) {}
+
+    /// Only accepts `PlacementSeed`.
+    #[allow(dead_code)]
+    fn _accept_placement_seed(_: PlacementSeed) {}
+
+    /// Only accepts `BiomeSeed`.
+    #[allow(dead_code)]
+    fn _accept_biome_seed(_: BiomeSeed) {}
+
+    /// Only accepts `ObjectIdentitySeed`.
+    #[allow(dead_code)]
+    fn _accept_object_identity_seed(_: ObjectIdentitySeed) {}
+
+    // ── From<u64> / Into<u64> ────────────────────────────────────────────
+
+    #[test]
+    fn material_seed_round_trips_through_u64() {
+        let s = MaterialSeed::from(42_u64);
+        assert_eq!(s.0, 42);
+        let back: u64 = s.into();
+        assert_eq!(back, 42);
+    }
+
+    #[test]
+    fn placement_seed_round_trips_through_u64() {
+        let s = PlacementSeed::from(99_u64);
+        assert_eq!(s.0, 99);
+        let back: u64 = s.into();
+        assert_eq!(back, 99);
+    }
+
+    #[test]
+    fn biome_seed_round_trips_through_u64() {
+        let s = BiomeSeed::from(7_u64);
+        assert_eq!(s.0, 7);
+        let back: u64 = s.into();
+        assert_eq!(back, 7);
+    }
+
+    #[test]
+    fn object_identity_seed_round_trips_through_u64() {
+        let s = ObjectIdentitySeed::from(u64::MAX);
+        assert_eq!(s.0, u64::MAX);
+        let back: u64 = s.into();
+        assert_eq!(back, u64::MAX);
+    }
+
+    // ── split() ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn split_is_deterministic() {
+        let base = MaterialSeed(12345);
+        let (a1, b1) = base.split();
+        let (a2, b2) = base.split();
+        assert_eq!(a1, a2, "split must produce the same first value each call");
+        assert_eq!(b1, b2, "split must produce the same second value each call");
+    }
+
+    #[test]
+    fn split_pair_values_differ_from_each_other_and_from_base() {
+        let base = MaterialSeed(99999);
+        let (a, b) = base.split();
+        assert_ne!(a.0, b.0, "split pair must contain two distinct values");
+        assert_ne!(a.0, base.0, "first split must differ from original");
+        assert_ne!(b.0, base.0, "second split must differ from original");
+    }
+
+    #[test]
+    fn split_available_on_every_seed_type() {
+        // Each type gets its own split via the macro — this verifies they all
+        // compile and run correctly rather than silently coercing to a single impl.
+        let _ = PlacementSeed(1).split();
+        let _ = BiomeSeed(2).split();
+        let _ = ObjectIdentitySeed(3).split();
+    }
+
+    // ── Clone / Copy / PartialEq / Eq / Hash ─────────────────────────────
+
+    #[test]
+    fn seed_is_copy_and_compares_by_value() {
+        let s = MaterialSeed(1);
+        let copy = s; // implicit Copy — no move
+        assert_eq!(s, copy, "Copy of seed must equal original");
+    }
+
+    #[test]
+    fn different_values_are_not_equal() {
+        assert_ne!(MaterialSeed(1), MaterialSeed(2));
+        assert_ne!(PlacementSeed(0), PlacementSeed(1));
+    }
+
+    #[test]
+    fn same_value_hashes_consistently() {
+        let s = BiomeSeed(777);
+        let mut set = HashSet::new();
+        set.insert(s);
+        set.insert(s); // same value again — must not grow the set
+        assert_eq!(set.len(), 1, "identical seeds must occupy one hash bucket");
+    }
+
+    // ── PlanetSeed re-export ──────────────────────────────────────────────
+
+    #[test]
+    fn planet_seed_reexport_is_usable() {
+        // Exercises the `pub use crate::world_generation::PlanetSeed;` re-export.
+        // If PlanetSeed is not re-exported from this module this test won't compile.
+        let ps = PlanetSeed(42);
+        assert_eq!(ps.0, 42);
+    }
+
+    // ── SolarSystemSeed re-export ─────────────────────────────────────────
+
+    #[test]
+    fn solar_system_seed_reexport_is_usable() {
+        // Exercises the `pub use crate::solar_system::SolarSystemSeed;` re-export.
+        // If SolarSystemSeed is not re-exported from this module this test won't compile.
+        let s = SolarSystemSeed(999);
+        assert_eq!(s.0, 999);
+        let back: u64 = s.into();
+        assert_eq!(back, 999);
+    }
+
+    #[test]
+    fn solar_system_seed_from_u64() {
+        let s: SolarSystemSeed = 42_u64.into();
+        assert_eq!(s.0, 42);
+    }
+}

--- a/src/solar_system.rs
+++ b/src/solar_system.rs
@@ -256,8 +256,24 @@ const PLANET_ENVIRONMENT_CONFIG_PATH: &str = "assets/config/planet_environment.t
 /// Analogous to `PlanetSeed` — a thin wrapper that prevents accidental
 /// mixing of unrelated `u64` values in function signatures. The inner
 /// value is the root of all deterministic derivation for a solar system.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// Re-exported from `crate::seeds` for one-stop seed imports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub struct SolarSystemSeed(pub u64);
+
+impl From<u64> for SolarSystemSeed {
+    #[inline]
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<SolarSystemSeed> for u64 {
+    #[inline]
+    fn from(s: SolarSystemSeed) -> u64 {
+        s.0
+    }
+}
 
 /// Enumeration of star spectral classes.
 ///

--- a/src/world_generation.rs
+++ b/src/world_generation.rs
@@ -45,6 +45,7 @@ use crate::seed_util::{
     PLACEMENT_DENSITY_CHANNEL, PLACEMENT_VARIATION_CHANNEL, PLANET_SURFACE_RADIUS_CHANNEL,
     mix_seed,
 };
+use crate::seeds::{BiomeSeed, MaterialSeed, ObjectIdentitySeed, PlacementSeed};
 use crate::solar_system::{
     OrbitalConfig, OrbitalLayout, PlanetEnvironment, PlanetEnvironmentConfig,
     SolarSystemRegistries, SolarSystemSeed, StarProfile, StarTypeRegistry, derive_orbital_layout,
@@ -236,6 +237,10 @@ pub fn surface_alignment_rotation(normal: [f32; 3]) -> [f32; 4] {
 #[derive(Clone, Debug)]
 pub struct PlanetSurface {
     /// Per-planet elevation seed (from `WorldProfile::elevation_seed`).
+    ///
+    /// Stored as a bare `u64` here because `continuous_value_field_01` (the
+    /// noise utility) operates on raw integers. The typed `ElevationSeed`
+    /// newtype does not exist yet; until it does, this boundary is explicit.
     pub elevation_seed: u64,
     /// Sea-level reference height (world units).
     pub base_y: f32,
@@ -1089,18 +1094,18 @@ pub struct WorldProfile {
     /// Number of chunks around the player to keep active.
     pub active_chunk_radius: i32,
     /// Seed used to determine object placement density per chunk.
-    pub placement_density_seed: u64,
+    pub placement_density_seed: PlacementSeed,
     /// Seed used to vary object positions within a chunk.
-    pub placement_variation_seed: u64,
+    pub placement_variation_seed: PlacementSeed,
     /// Seed used to deterministically assign object identities.
-    pub object_identity_seed: u64,
+    pub object_identity_seed: ObjectIdentitySeed,
     /// Per-planet biome climate seed, derived from the planet seed.
     ///
     /// This seed is mixed with temperature and moisture sub-channel constants
     /// (defined in `BiomeRegistry`) to produce two independent coherent noise
     /// fields. Each chunk samples both fields at its canonical center to
     /// determine its biome.
-    pub biome_climate_seed: u64,
+    pub biome_climate_seed: BiomeSeed,
     /// The planet surface radius in chunks, derived from the planet seed.
     ///
     /// The full surface is a square grid of `planet_surface_diameter × diameter`
@@ -1114,6 +1119,10 @@ pub struct WorldProfile {
     /// Per-planet elevation seed, derived from the planet seed via
     /// `ELEVATION_CHANNEL`. Drives the multi-octave noise field that
     /// produces terrain height variation.
+    ///
+    /// Stored as a bare `u64` because the `ElevationSeed` newtype does not
+    /// exist yet. When that newtype is introduced (Epic 5 terrain stories),
+    /// this field should be migrated to `ElevationSeed`.
     pub elevation_seed: u64,
     /// Solar system context when running in system-derived mode.
     ///
@@ -1220,10 +1229,19 @@ impl WorldProfile {
             planet_seed,
             chunk_size_world_units: config.chunk_size_world_units,
             active_chunk_radius: config.active_chunk_radius,
-            placement_density_seed: mix_seed(planet_seed.0, PLACEMENT_DENSITY_CHANNEL),
-            placement_variation_seed: mix_seed(planet_seed.0, PLACEMENT_VARIATION_CHANNEL),
-            object_identity_seed: mix_seed(planet_seed.0, OBJECT_IDENTITY_CHANNEL),
-            biome_climate_seed: mix_seed(planet_seed.0, BIOME_CLIMATE_CHANNEL),
+            placement_density_seed: PlacementSeed(mix_seed(
+                planet_seed.0,
+                PLACEMENT_DENSITY_CHANNEL,
+            )),
+            placement_variation_seed: PlacementSeed(mix_seed(
+                planet_seed.0,
+                PLACEMENT_VARIATION_CHANNEL,
+            )),
+            object_identity_seed: ObjectIdentitySeed(mix_seed(
+                planet_seed.0,
+                OBJECT_IDENTITY_CHANNEL,
+            )),
+            biome_climate_seed: BiomeSeed(mix_seed(planet_seed.0, BIOME_CLIMATE_CHANNEL)),
             planet_surface_radius,
             planet_surface_diameter,
             elevation_seed: mix_seed(planet_seed.0, ELEVATION_CHANNEL),
@@ -1256,11 +1274,11 @@ pub struct ChunkGenerationKey {
     /// The chunk these keys belong to.
     pub chunk_coord: ChunkCoord,
     /// Per-chunk key for placement density noise.
-    pub placement_density_key: u64,
+    pub placement_density_key: PlacementSeed,
     /// Per-chunk key for placement variation noise.
-    pub placement_variation_key: u64,
+    pub placement_variation_key: PlacementSeed,
     /// Per-chunk key for deterministic object identity assignment.
-    pub object_identity_key: u64,
+    pub object_identity_key: ObjectIdentitySeed,
 }
 
 /// Stable identity for one generated baseline object.
@@ -1595,9 +1613,18 @@ pub fn derive_chunk_generation_key(
 
     ChunkGenerationKey {
         chunk_coord: canonical,
-        placement_density_key: mix_seed(profile.placement_density_seed, chunk_mixer),
-        placement_variation_key: mix_seed(profile.placement_variation_seed, chunk_mixer),
-        object_identity_key: mix_seed(profile.object_identity_seed, chunk_mixer),
+        placement_density_key: PlacementSeed(mix_seed(
+            profile.placement_density_seed.0,
+            chunk_mixer,
+        )),
+        placement_variation_key: PlacementSeed(mix_seed(
+            profile.placement_variation_seed.0,
+            chunk_mixer,
+        )),
+        object_identity_key: ObjectIdentitySeed(mix_seed(
+            profile.object_identity_seed.0,
+            chunk_mixer,
+        )),
     }
 }
 
@@ -1764,31 +1791,31 @@ fn default_fallback_biome_type() -> BiomeType {
 fn default_fallback_material_palette() -> Vec<PaletteMaterial> {
     vec![
         PaletteMaterial {
-            material_seed: 1002,
+            material_seed: MaterialSeed(1002),
             selection_weight: 2.0,
         }, // Calcium
         PaletteMaterial {
-            material_seed: 1005,
+            material_seed: MaterialSeed(1005),
             selection_weight: 2.5,
         }, // Verdant
         PaletteMaterial {
-            material_seed: 1008,
+            material_seed: MaterialSeed(1008),
             selection_weight: 2.0,
         }, // Cobaltine
         PaletteMaterial {
-            material_seed: 1009,
+            material_seed: MaterialSeed(1009),
             selection_weight: 1.5,
         }, // Silite
         PaletteMaterial {
-            material_seed: 1001,
+            material_seed: MaterialSeed(1001),
             selection_weight: 1.0,
         }, // Ferrite
         PaletteMaterial {
-            material_seed: 1003,
+            material_seed: MaterialSeed(1003),
             selection_weight: 0.5,
         }, // Sulfurite
         PaletteMaterial {
-            material_seed: 1010,
+            material_seed: MaterialSeed(1010),
             selection_weight: 0.8,
         }, // Phosphite
     ]
@@ -1822,7 +1849,7 @@ pub struct PaletteMaterial {
     ///
     /// The same seed always produces the same `GameMaterial` (density, color,
     /// name, etc.) regardless of which biome references it.
-    pub material_seed: u64,
+    pub material_seed: MaterialSeed,
     /// Relative likelihood of this material being selected when placing a
     /// deposit in the biome.
     ///
@@ -1914,27 +1941,27 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 3.0,
                 }, // Ferrite
                 PaletteMaterial {
-                    material_seed: 1003,
+                    material_seed: MaterialSeed(1003),
                     selection_weight: 2.5,
                 }, // Sulfurite
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 2.0,
                 }, // Osmium
                 PaletteMaterial {
-                    material_seed: 1007,
+                    material_seed: MaterialSeed(1007),
                     selection_weight: 1.5,
                 }, // Volatite
                 PaletteMaterial {
-                    material_seed: 1002,
+                    material_seed: MaterialSeed(1002),
                     selection_weight: 0.5,
                 }, // Calcium
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 0.3,
                 }, // Silite
             ],
@@ -1965,27 +1992,27 @@ fn default_biome_definitions() -> Vec<BiomeDefinition> {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1004,
+                    material_seed: MaterialSeed(1004),
                     selection_weight: 3.0,
                 }, // Prismate
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 2.0,
                 }, // Silite
                 PaletteMaterial {
-                    material_seed: 1010,
+                    material_seed: MaterialSeed(1010),
                     selection_weight: 2.5,
                 }, // Phosphite
                 PaletteMaterial {
-                    material_seed: 1008,
+                    material_seed: MaterialSeed(1008),
                     selection_weight: 1.0,
                 }, // Cobaltine
                 PaletteMaterial {
-                    material_seed: 1005,
+                    material_seed: MaterialSeed(1005),
                     selection_weight: 0.3,
                 }, // Verdant
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 0.5,
                 }, // Osmium
             ],
@@ -2054,10 +2081,13 @@ pub fn derive_chunk_biome(
     let chunk_center = PositionXZ::new(canonical.x as f32 + 0.5, canonical.z as f32 + 0.5);
 
     let temperature_seed = mix_seed(
-        profile.biome_climate_seed,
+        profile.biome_climate_seed.0,
         registry.temperature_noise_channel,
     );
-    let moisture_seed = mix_seed(profile.biome_climate_seed, registry.moisture_noise_channel);
+    let moisture_seed = mix_seed(
+        profile.biome_climate_seed.0,
+        registry.moisture_noise_channel,
+    );
 
     let temperature = exterior::continuous_value_field_01(
         temperature_seed,

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -262,7 +262,7 @@ struct GeneratedSurfaceMineralPlacement {
     generated_id: GeneratedObjectId,
     deposit_site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     position_xz: PositionXZ,
     surface_y: f32,
     /// Surface normal at the placement point, used for object alignment.
@@ -280,7 +280,7 @@ struct GeneratedSurfaceMineralPlacement {
 struct GeneratedSurfaceMineralDepositSite {
     site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     center_xz: PositionXZ,
     radius_world_units: f32,
     child_count: u32,
@@ -627,12 +627,12 @@ fn sync_active_exterior_chunks(
 
         for placement in placements {
             // Skip deposits with no material (biome had an empty palette).
-            if placement.material_seed == 0 {
+            if placement.material_seed == MaterialSeed(0) {
                 continue;
             }
 
             let mut deposit_material = material_catalog
-                .derive_and_register(MaterialSeed(placement.material_seed))
+                .derive_and_register(placement.material_seed)
                 .clone();
             // Tag the spawn origin so observation systems can wire the FoundOn
             // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
@@ -1029,7 +1029,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let density = continuous_value_field_01(
-                generation_key.placement_density_key,
+                generation_key.placement_density_key.0,
                 cell_center_xz,
                 catalog.site_density_field_scale_world_units,
             );
@@ -1043,7 +1043,7 @@ fn generate_surface_mineral_deposit_sites(
             // different biomes favor different materials.
             let Some(definition) = choose_deposit_definition(
                 &catalog.deposits,
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 &biome.deposit_weight_modifiers,
@@ -1053,7 +1053,7 @@ fn generate_surface_mineral_deposit_sites(
             };
 
             let jitter_offset = jitter_offset_xz(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 spacing * catalog.site_jitter_fraction,
@@ -1073,7 +1073,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let radius_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0001,
@@ -1085,7 +1085,7 @@ fn generate_surface_mineral_deposit_sites(
             );
 
             let child_count_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0002,
@@ -1124,7 +1124,7 @@ fn generate_surface_mineral_deposit_sites(
                 definition_key: definition.key.clone(),
                 material_seed: choose_material_seed_from_palette(
                     &biome.material_palette,
-                    generation_key.placement_variation_key,
+                    generation_key.placement_variation_key.0,
                     chunk_coord,
                     local_site_index,
                 ),
@@ -1282,9 +1282,9 @@ fn choose_material_seed_from_palette(
     variation_key: u64,
     chunk_coord: ChunkCoord,
     local_candidate_index: u32,
-) -> u64 {
+) -> MaterialSeed {
     if palette.is_empty() {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let total_weight: f32 = palette
@@ -1292,7 +1292,7 @@ fn choose_material_seed_from_palette(
         .map(|entry| entry.selection_weight.max(0.0))
         .sum();
     if total_weight <= f32::EPSILON {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let roll = unit_interval_01(mix_candidate_input(
@@ -1311,7 +1311,10 @@ fn choose_material_seed_from_palette(
     }
 
     // Fallback to last entry (float rounding edge case).
-    palette.last().map(|e| e.material_seed).unwrap_or(0)
+    palette
+        .last()
+        .map(|e| e.material_seed)
+        .unwrap_or(MaterialSeed(0))
 }
 
 fn jitter_offset_xz(

--- a/src/world_generation/exterior.rs
+++ b/src/world_generation/exterior.rs
@@ -59,6 +59,7 @@ use crate::interaction::HeldItem;
 use crate::materials::{GameMaterial, MaterialCatalog, MaterialObject};
 use crate::scene::{ExteriorGroundPatch, PositionXZ, RectXZ};
 use crate::seed_util::lerp;
+use crate::seeds::MaterialSeed;
 
 const DEPOSIT_CONFIG_PATH: &str = "assets/exterior/surface_mineral_deposits.toml";
 const SURFACE_MINERAL_DEPOSIT_GENERATOR_VERSION: u32 = 1;
@@ -262,7 +263,7 @@ struct GeneratedSurfaceMineralPlacement {
     generated_id: GeneratedObjectId,
     deposit_site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     position_xz: PositionXZ,
     surface_y: f32,
     /// Surface normal at the placement point, used for object alignment.
@@ -280,7 +281,7 @@ struct GeneratedSurfaceMineralPlacement {
 struct GeneratedSurfaceMineralDepositSite {
     site_id: GeneratedDepositSiteId,
     definition_key: String,
-    material_seed: u64,
+    material_seed: MaterialSeed,
     center_xz: PositionXZ,
     radius_world_units: f32,
     child_count: u32,
@@ -627,12 +628,12 @@ fn sync_active_exterior_chunks(
 
         for placement in placements {
             // Skip deposits with no material (biome had an empty palette).
-            if placement.material_seed == 0 {
+            if placement.material_seed == MaterialSeed(0) {
                 continue;
             }
 
             let mut deposit_material = material_catalog
-                .derive_and_register(placement.material_seed)
+                .derive_and_register(placement.material_seed.0)
                 .clone();
             // Tag the spawn origin so observation systems can wire the FoundOn
             // KnowledgeGraph edge and the CurrentPlanet journal filter can match.
@@ -1029,7 +1030,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let density = continuous_value_field_01(
-                generation_key.placement_density_key,
+                generation_key.placement_density_key.0,
                 cell_center_xz,
                 catalog.site_density_field_scale_world_units,
             );
@@ -1043,7 +1044,7 @@ fn generate_surface_mineral_deposit_sites(
             // different biomes favor different materials.
             let Some(definition) = choose_deposit_definition(
                 &catalog.deposits,
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 &biome.deposit_weight_modifiers,
@@ -1053,7 +1054,7 @@ fn generate_surface_mineral_deposit_sites(
             };
 
             let jitter_offset = jitter_offset_xz(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 spacing * catalog.site_jitter_fraction,
@@ -1073,7 +1074,7 @@ fn generate_surface_mineral_deposit_sites(
             }
 
             let radius_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0001,
@@ -1085,7 +1086,7 @@ fn generate_surface_mineral_deposit_sites(
             );
 
             let child_count_mix = unit_interval_01(mix_candidate_input(
-                generation_key.placement_variation_key,
+                generation_key.placement_variation_key.0,
                 chunk_coord,
                 local_site_index,
                 0x6600_0000_0000_0002,
@@ -1124,7 +1125,7 @@ fn generate_surface_mineral_deposit_sites(
                 definition_key: definition.key.clone(),
                 material_seed: choose_material_seed_from_palette(
                     &biome.material_palette,
-                    generation_key.placement_variation_key,
+                    generation_key.placement_variation_key.0,
                     chunk_coord,
                     local_site_index,
                 ),
@@ -1282,9 +1283,9 @@ fn choose_material_seed_from_palette(
     variation_key: u64,
     chunk_coord: ChunkCoord,
     local_candidate_index: u32,
-) -> u64 {
+) -> MaterialSeed {
     if palette.is_empty() {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let total_weight: f32 = palette
@@ -1292,7 +1293,7 @@ fn choose_material_seed_from_palette(
         .map(|entry| entry.selection_weight.max(0.0))
         .sum();
     if total_weight <= f32::EPSILON {
-        return 0;
+        return MaterialSeed(0);
     }
 
     let roll = unit_interval_01(mix_candidate_input(
@@ -1311,7 +1312,10 @@ fn choose_material_seed_from_palette(
     }
 
     // Fallback to last entry (float rounding edge case).
-    palette.last().map(|e| e.material_seed).unwrap_or(0)
+    palette
+        .last()
+        .map(|e| e.material_seed)
+        .unwrap_or(MaterialSeed(0))
 }
 
 fn jitter_offset_xz(

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seeds::MaterialSeed;
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
 use crate::world_generation::{BiomeType, PlanetSeed, WorldGenerationConfig};
 
@@ -2293,8 +2294,8 @@ fn deposit_sites_carry_material_seed_from_palette() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed_a: u64 = 0xFE00_0000_0000_0001;
-    let seed_b: u64 = 0xFE00_0000_0000_0002;
+    let seed_a: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0001);
+    let seed_b: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0002);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
@@ -2325,12 +2326,14 @@ fn deposit_sites_carry_material_seed_from_palette() {
         "biome with a material palette should produce deposit sites"
     );
 
+    let seed_a_raw = seed_a.0;
+    let seed_b_raw = seed_b.0;
     for site in &sites {
         assert!(
             site.material_seed == seed_a || site.material_seed == seed_b,
             "deposit site material_seed ({:#018X}) must come from the biome palette, \
-                 expected one of {seed_a:#018X} or {seed_b:#018X}",
-            site.material_seed,
+                 expected one of {seed_a_raw:#018X} or {seed_b_raw:#018X}",
+            site.material_seed.0,
         );
     }
 }
@@ -2341,7 +2344,7 @@ fn deposit_placements_inherit_material_seed_from_site() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed: u64 = 0xAB00_0000_0000_0099;
+    let seed: MaterialSeed = MaterialSeed(0xAB00_0000_0000_0099);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.3, 0.3, 0.3],
@@ -2407,7 +2410,8 @@ fn empty_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "empty palette must produce material_seed 0"
                 );
             }
@@ -2450,7 +2454,8 @@ fn empty_palette_baseline_placements_exist_but_all_have_zero_seed() {
             for p in &placements {
                 total_placements += 1;
                 assert_eq!(
-                    p.material_seed, 0,
+                    p.material_seed,
+                    MaterialSeed(0),
                     "all placements from an empty-palette biome must have material_seed 0"
                 );
             }
@@ -2480,15 +2485,15 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0001,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0001),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0002,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0002),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0003,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0003),
                 selection_weight: 0.0,
             },
         ],
@@ -2507,9 +2512,12 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "all-zero-weight palette must produce material_seed 0, got {} for site in chunk ({}, {})",
-                    site.material_seed, cx, cz
+                    site.material_seed.0,
+                    cx,
+                    cz
                 );
             }
         }
@@ -2530,7 +2538,7 @@ fn single_palette_entry_always_selected() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let sole_seed: u64 = 0xAA00_0000_0000_0042;
+    let sole_seed: MaterialSeed = MaterialSeed(0xAA00_0000_0000_0042);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.4, 0.4, 0.4],
@@ -2558,7 +2566,7 @@ fn single_palette_entry_always_selected() {
                     site.material_seed, sole_seed,
                     "single-entry palette must always select the sole seed; \
                          got {:#018X} at chunk ({cx}, {cz})",
-                    site.material_seed,
+                    site.material_seed.0,
                 );
             }
         }
@@ -2584,7 +2592,7 @@ fn deposit_site_has_no_material_key_field() {
             generator_version: 1,
         },
         definition_key: "test".to_string(),
-        material_seed: 0xDEAD_BEEF,
+        material_seed: MaterialSeed(0xDEAD_BEEF),
         center_xz: PositionXZ::new(0.0, 0.0),
         radius_world_units: 1.0,
         child_count: 1,
@@ -2594,7 +2602,7 @@ fn deposit_site_has_no_material_key_field() {
         scale_max: 1.0,
         cluster_compactness: 0.5,
     };
-    assert_eq!(site.material_seed, 0xDEAD_BEEF);
+    assert_eq!(site.material_seed, MaterialSeed(0xDEAD_BEEF));
 
     // Same for the placement struct.
     let placement = GeneratedSurfaceMineralPlacement {
@@ -2607,14 +2615,14 @@ fn deposit_site_has_no_material_key_field() {
         },
         deposit_site_id: site.site_id.clone(),
         definition_key: "test".to_string(),
-        material_seed: 0xCAFE_BABE,
+        material_seed: MaterialSeed(0xCAFE_BABE),
         position_xz: PositionXZ::new(0.0, 0.0),
         surface_y: 0.0,
         surface_normal: [0.0, 1.0, 0.0],
         visual_scale: 1.0,
         local_child_index: 0,
     };
-    assert_eq!(placement.material_seed, 0xCAFE_BABE);
+    assert_eq!(placement.material_seed, MaterialSeed(0xCAFE_BABE));
 }
 
 /// Story 5a.4 – Phase 5: first chunk generation populates the material
@@ -2643,7 +2651,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2679,7 +2687,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     // Filter to placements with valid material seeds (non-zero).
     let valid_placements: Vec<_> = all_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
 
     // We expect at least some deposits were generated.
@@ -2696,7 +2704,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     );
 
     for placement in &valid_placements {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     // 1. Catalog is no longer empty.
@@ -2736,7 +2744,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2771,7 +2779,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_first: Vec<_> = first_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_first.is_empty(),
@@ -2781,7 +2789,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
     // Register all materials from the first batch.
     let mut mat_catalog = MaterialCatalog::default();
     for placement in &valid_first {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     let catalog_size_after_first_batch = mat_catalog.len();
@@ -2806,7 +2814,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_second: Vec<_> = second_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_second.is_empty(),
@@ -2815,7 +2823,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     // Register all materials from the second batch.
     for placement in &valid_second {
-        mat_catalog.derive_and_register(placement.material_seed);
+        mat_catalog.derive_and_register(placement.material_seed.0);
     }
 
     // The catalog size must not have grown: all seeds from the second batch
@@ -2864,21 +2872,21 @@ fn palette_swap_does_not_change_deposit_count() {
 
     let palette_a = vec![
         PaletteMaterial {
-            material_seed: 1001,
+            material_seed: MaterialSeed(1001),
             selection_weight: 3.0,
         },
         PaletteMaterial {
-            material_seed: 1003,
+            material_seed: MaterialSeed(1003),
             selection_weight: 2.0,
         },
     ];
     let palette_b = vec![
         PaletteMaterial {
-            material_seed: 1004,
+            material_seed: MaterialSeed(1004),
             selection_weight: 1.5,
         },
         PaletteMaterial {
-            material_seed: 1010,
+            material_seed: MaterialSeed(1010),
             selection_weight: 4.0,
         },
     ];
@@ -2929,13 +2937,13 @@ fn palette_swap_does_not_change_deposit_count() {
             count_b += placements_b.len();
 
             for p in &placements_a {
-                if p.material_seed != 0 {
-                    seeds_a.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_a.insert(p.material_seed.0);
                 }
             }
             for p in &placements_b {
-                if p.material_seed != 0 {
-                    seeds_b.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_b.insert(p.material_seed.0);
                 }
             }
         }
@@ -3028,7 +3036,7 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
         let palette_seeds: HashSet<u64> = biome
             .material_palette
             .iter()
-            .map(|p| p.material_seed)
+            .map(|p| p.material_seed.0)
             .collect();
 
         let placements =
@@ -3051,19 +3059,19 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
 
             // Deposits from a biome with a non-empty palette must carry a
             // non-zero seed drawn from that palette.
-            if !palette_seeds.is_empty() && placement.material_seed != 0 {
+            if !palette_seeds.is_empty() && placement.material_seed != MaterialSeed(0) {
                 assert!(
-                    palette_seeds.contains(&placement.material_seed),
+                    palette_seeds.contains(&placement.material_seed.0),
                     "deposit material_seed {:#018X} not in biome '{:?}' palette \
                          (chunk {chunk:?})",
-                    placement.material_seed,
+                    placement.material_seed.0,
                     biome.biome_type,
                 );
 
                 // Material must register without panicking.
-                let registered = mat_catalog.derive_and_register(placement.material_seed);
+                let registered = mat_catalog.derive_and_register(placement.material_seed.0);
                 assert_eq!(
-                    registered.seed, placement.material_seed,
+                    registered.seed, placement.material_seed.0,
                     "registered material seed mismatch"
                 );
             }
@@ -3106,15 +3114,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3128,15 +3136,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1004,
+                material_seed: MaterialSeed(1004),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1010,
+                material_seed: MaterialSeed(1010),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1008,
+                material_seed: MaterialSeed(1008),
                 selection_weight: 1.0,
             },
         ],
@@ -3145,12 +3153,12 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
     let scorched_palette_seeds: std::collections::HashSet<u64> = scorched_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
     let frost_palette_seeds: std::collections::HashSet<u64> = frost_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
 
     // Sanity: the two palettes share no seeds.
@@ -3177,8 +3185,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &scorched_biome,
             ) {
-                if site.material_seed != 0 {
-                    scorched_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    scorched_observed.insert(site.material_seed.0);
                 }
             }
 
@@ -3189,8 +3197,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &frost_biome,
             ) {
-                if site.material_seed != 0 {
-                    frost_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    frost_observed.insert(site.material_seed.0);
                 }
             }
         }
@@ -3386,15 +3394,15 @@ fn every_deposit_material_is_pickup_ready() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.0,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3411,17 +3419,17 @@ fn every_deposit_material_is_pickup_ready() {
             );
 
             for placement in &placements {
-                if placement.material_seed == 0 {
+                if placement.material_seed == MaterialSeed(0) {
                     continue;
                 }
 
-                let mat = mat_catalog.derive_and_register(placement.material_seed);
+                let mat = mat_catalog.derive_and_register(placement.material_seed.0);
 
                 // Name must be non-empty (the pickup HUD displays it).
                 assert!(
                     !mat.name.is_empty(),
                     "deposit seed {} produced an empty name",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 // Color channels must be finite and in [0, 1].
@@ -3429,7 +3437,7 @@ fn every_deposit_material_is_pickup_ready() {
                     assert!(
                         c.is_finite() && (0.0..=1.0).contains(&c),
                         "deposit seed {} color[{i}] = {c} out of range",
-                        placement.material_seed,
+                        placement.material_seed.0,
                     );
                 }
 
@@ -3443,7 +3451,7 @@ fn every_deposit_material_is_pickup_ready() {
                 assert!(
                     any_nonzero,
                     "deposit seed {} has all-zero properties",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 checked += 1;
@@ -3490,15 +3498,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1003,
+                    material_seed: MaterialSeed(1003),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 2.0,
                 },
             ],
@@ -3510,19 +3518,19 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1002,
+                    material_seed: MaterialSeed(1002),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1005,
+                    material_seed: MaterialSeed(1005),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1008,
+                    material_seed: MaterialSeed(1008),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 1.0,
                 },
             ],
@@ -3534,15 +3542,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1004,
+                    material_seed: MaterialSeed(1004),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1010,
+                    material_seed: MaterialSeed(1010),
                     selection_weight: 2.5,
                 },
             ],
@@ -3583,8 +3591,8 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
                     biome,
                 );
                 for placement in &placements {
-                    if placement.material_seed != 0 {
-                        mat_catalog.derive_and_register(placement.material_seed);
+                    if placement.material_seed != MaterialSeed(0) {
+                        mat_catalog.derive_and_register(placement.material_seed.0);
                     }
                 }
             }
@@ -3804,8 +3812,8 @@ fn restart_system_seed_chain_yields_identical_world() {
                 &biome,
             );
             for placement in &placements {
-                if placement.material_seed != 0 {
-                    mat_catalog.derive_and_register(placement.material_seed);
+                if placement.material_seed != MaterialSeed(0) {
+                    mat_catalog.derive_and_register(placement.material_seed.0);
                 }
             }
         }
@@ -4003,11 +4011,11 @@ fn sample_biome_with_palette() -> ChunkBiome {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0001,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0002,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0002),
                 selection_weight: 1.0,
             },
         ],
@@ -4075,7 +4083,7 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
                 &biome,
             );
             for p in &placements {
-                seen_seeds.insert(p.material_seed);
+                seen_seeds.insert(p.material_seed.0);
             }
         }
     }
@@ -4083,10 +4091,10 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
     // Both palette seeds should appear.
     for pm in &biome.material_palette {
         assert!(
-            seen_seeds.contains(&pm.material_seed),
+            seen_seeds.contains(&pm.material_seed.0),
             "palette seed {:#x} never appeared in deposits \
                  across 100 chunks",
-            pm.material_seed,
+            pm.material_seed.0,
         );
     }
 }
@@ -4111,9 +4119,9 @@ fn higher_weight_palette_entry_appears_more_often() {
                 &biome,
             );
             for p in &placements {
-                if p.material_seed == 0xFE00_0000_0000_0001 {
+                if p.material_seed == MaterialSeed(0xFE00_0000_0000_0001) {
                     count_seed_1 += 1;
-                } else if p.material_seed == 0xFE00_0000_0000_0002 {
+                } else if p.material_seed == MaterialSeed(0xFE00_0000_0000_0002) {
                     count_seed_2 += 1;
                 }
             }

--- a/src/world_generation/exterior_tests.rs
+++ b/src/world_generation/exterior_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seeds::MaterialSeed;
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
 use crate::world_generation::{BiomeType, PlanetSeed, WorldGenerationConfig};
 
@@ -2293,8 +2294,8 @@ fn deposit_sites_carry_material_seed_from_palette() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed_a: u64 = 0xFE00_0000_0000_0001;
-    let seed_b: u64 = 0xFE00_0000_0000_0002;
+    let seed_a: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0001);
+    let seed_b: MaterialSeed = MaterialSeed(0xFE00_0000_0000_0002);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.5, 0.5, 0.5],
@@ -2325,12 +2326,14 @@ fn deposit_sites_carry_material_seed_from_palette() {
         "biome with a material palette should produce deposit sites"
     );
 
+    let seed_a_raw = seed_a.0;
+    let seed_b_raw = seed_b.0;
     for site in &sites {
         assert!(
             site.material_seed == seed_a || site.material_seed == seed_b,
             "deposit site material_seed ({:#018X}) must come from the biome palette, \
-                 expected one of {seed_a:#018X} or {seed_b:#018X}",
-            site.material_seed,
+                 expected one of {seed_a_raw:#018X} or {seed_b_raw:#018X}",
+            site.material_seed.0,
         );
     }
 }
@@ -2341,7 +2344,7 @@ fn deposit_placements_inherit_material_seed_from_site() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let seed: u64 = 0xAB00_0000_0000_0099;
+    let seed: MaterialSeed = MaterialSeed(0xAB00_0000_0000_0099);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.3, 0.3, 0.3],
@@ -2407,7 +2410,8 @@ fn empty_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "empty palette must produce material_seed 0"
                 );
             }
@@ -2450,7 +2454,8 @@ fn empty_palette_baseline_placements_exist_but_all_have_zero_seed() {
             for p in &placements {
                 total_placements += 1;
                 assert_eq!(
-                    p.material_seed, 0,
+                    p.material_seed,
+                    MaterialSeed(0),
                     "all placements from an empty-palette biome must have material_seed 0"
                 );
             }
@@ -2480,15 +2485,15 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0001,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0001),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0002,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0002),
                 selection_weight: 0.0,
             },
             PaletteMaterial {
-                material_seed: 0xAA00_0000_0000_0003,
+                material_seed: MaterialSeed(0xAA00_0000_0000_0003),
                 selection_weight: 0.0,
             },
         ],
@@ -2507,9 +2512,12 @@ fn all_zero_weight_palette_produces_zero_material_seed() {
             for site in &sites {
                 total_sites += 1;
                 assert_eq!(
-                    site.material_seed, 0,
+                    site.material_seed,
+                    MaterialSeed(0),
                     "all-zero-weight palette must produce material_seed 0, got {} for site in chunk ({}, {})",
-                    site.material_seed, cx, cz
+                    site.material_seed.0,
+                    cx,
+                    cz
                 );
             }
         }
@@ -2530,7 +2538,7 @@ fn single_palette_entry_always_selected() {
     let catalog = sample_catalog();
     let surface = sample_flat_surface();
 
-    let sole_seed: u64 = 0xAA00_0000_0000_0042;
+    let sole_seed: MaterialSeed = MaterialSeed(0xAA00_0000_0000_0042);
     let biome = ChunkBiome {
         biome_type: BiomeType::MineralSteppe,
         ground_color: [0.4, 0.4, 0.4],
@@ -2558,7 +2566,7 @@ fn single_palette_entry_always_selected() {
                     site.material_seed, sole_seed,
                     "single-entry palette must always select the sole seed; \
                          got {:#018X} at chunk ({cx}, {cz})",
-                    site.material_seed,
+                    site.material_seed.0,
                 );
             }
         }
@@ -2584,7 +2592,7 @@ fn deposit_site_has_no_material_key_field() {
             generator_version: 1,
         },
         definition_key: "test".to_string(),
-        material_seed: 0xDEAD_BEEF,
+        material_seed: MaterialSeed(0xDEAD_BEEF),
         center_xz: PositionXZ::new(0.0, 0.0),
         radius_world_units: 1.0,
         child_count: 1,
@@ -2594,7 +2602,7 @@ fn deposit_site_has_no_material_key_field() {
         scale_max: 1.0,
         cluster_compactness: 0.5,
     };
-    assert_eq!(site.material_seed, 0xDEAD_BEEF);
+    assert_eq!(site.material_seed, MaterialSeed(0xDEAD_BEEF));
 
     // Same for the placement struct.
     let placement = GeneratedSurfaceMineralPlacement {
@@ -2607,14 +2615,14 @@ fn deposit_site_has_no_material_key_field() {
         },
         deposit_site_id: site.site_id.clone(),
         definition_key: "test".to_string(),
-        material_seed: 0xCAFE_BABE,
+        material_seed: MaterialSeed(0xCAFE_BABE),
         position_xz: PositionXZ::new(0.0, 0.0),
         surface_y: 0.0,
         surface_normal: [0.0, 1.0, 0.0],
         visual_scale: 1.0,
         local_child_index: 0,
     };
-    assert_eq!(placement.material_seed, 0xCAFE_BABE);
+    assert_eq!(placement.material_seed, MaterialSeed(0xCAFE_BABE));
 }
 
 /// Story 5a.4 – Phase 5: first chunk generation populates the material
@@ -2643,7 +2651,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2679,7 +2687,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     // Filter to placements with valid material seeds (non-zero).
     let valid_placements: Vec<_> = all_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
 
     // We expect at least some deposits were generated.
@@ -2696,7 +2704,7 @@ fn first_chunk_generation_populates_catalog_from_biome_palette() {
     );
 
     for placement in &valid_placements {
-        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+        mat_catalog.derive_and_register(placement.material_seed);
     }
 
     // 1. Catalog is no longer empty.
@@ -2737,7 +2745,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
         material_palette: palette_seeds
             .iter()
             .map(|&seed| PaletteMaterial {
-                material_seed: seed,
+                material_seed: MaterialSeed(seed),
                 selection_weight: 1.0,
             })
             .collect(),
@@ -2772,7 +2780,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_first: Vec<_> = first_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_first.is_empty(),
@@ -2782,7 +2790,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
     // Register all materials from the first batch.
     let mut mat_catalog = MaterialCatalog::default();
     for placement in &valid_first {
-        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+        mat_catalog.derive_and_register(placement.material_seed);
     }
 
     let catalog_size_after_first_batch = mat_catalog.len();
@@ -2807,7 +2815,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     let valid_second: Vec<_> = second_batch_placements
         .iter()
-        .filter(|p| p.material_seed != 0)
+        .filter(|p| p.material_seed != MaterialSeed(0))
         .collect();
     assert!(
         !valid_second.is_empty(),
@@ -2816,7 +2824,7 @@ fn second_chunk_in_same_biome_reuses_catalog_entries_no_duplicates() {
 
     // Register all materials from the second batch.
     for placement in &valid_second {
-        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+        mat_catalog.derive_and_register(placement.material_seed);
     }
 
     // The catalog size must not have grown: all seeds from the second batch
@@ -2866,21 +2874,21 @@ fn palette_swap_does_not_change_deposit_count() {
 
     let palette_a = vec![
         PaletteMaterial {
-            material_seed: 1001,
+            material_seed: MaterialSeed(1001),
             selection_weight: 3.0,
         },
         PaletteMaterial {
-            material_seed: 1003,
+            material_seed: MaterialSeed(1003),
             selection_weight: 2.0,
         },
     ];
     let palette_b = vec![
         PaletteMaterial {
-            material_seed: 1004,
+            material_seed: MaterialSeed(1004),
             selection_weight: 1.5,
         },
         PaletteMaterial {
-            material_seed: 1010,
+            material_seed: MaterialSeed(1010),
             selection_weight: 4.0,
         },
     ];
@@ -2931,13 +2939,13 @@ fn palette_swap_does_not_change_deposit_count() {
             count_b += placements_b.len();
 
             for p in &placements_a {
-                if p.material_seed != 0 {
-                    seeds_a.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_a.insert(p.material_seed.0);
                 }
             }
             for p in &placements_b {
-                if p.material_seed != 0 {
-                    seeds_b.insert(p.material_seed);
+                if p.material_seed != MaterialSeed(0) {
+                    seeds_b.insert(p.material_seed.0);
                 }
             }
         }
@@ -3029,7 +3037,7 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
         let palette_seeds: HashSet<u64> = biome
             .material_palette
             .iter()
-            .map(|p| p.material_seed)
+            .map(|p| p.material_seed.0)
             .collect();
 
         let placements =
@@ -3052,20 +3060,19 @@ fn smoke_test_cross_biome_chunks_all_deposits_have_valid_materials() {
 
             // Deposits from a biome with a non-empty palette must carry a
             // non-zero seed drawn from that palette.
-            if !palette_seeds.is_empty() && placement.material_seed != 0 {
+            if !palette_seeds.is_empty() && placement.material_seed != MaterialSeed(0) {
                 assert!(
-                    palette_seeds.contains(&placement.material_seed),
+                    palette_seeds.contains(&placement.material_seed.0),
                     "deposit material_seed {:#018X} not in biome '{:?}' palette \
                          (chunk {chunk:?})",
-                    placement.material_seed,
+                    placement.material_seed.0,
                     biome.biome_type,
                 );
 
                 // Material must register without panicking.
-                let registered =
-                    mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+                let registered = mat_catalog.derive_and_register(placement.material_seed);
                 assert_eq!(
-                    registered.seed, placement.material_seed,
+                    registered.seed, placement.material_seed.0,
                     "registered material seed mismatch"
                 );
             }
@@ -3108,15 +3115,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3130,15 +3137,15 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1004,
+                material_seed: MaterialSeed(1004),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1010,
+                material_seed: MaterialSeed(1010),
                 selection_weight: 2.5,
             },
             PaletteMaterial {
-                material_seed: 1008,
+                material_seed: MaterialSeed(1008),
                 selection_weight: 1.0,
             },
         ],
@@ -3147,12 +3154,12 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
     let scorched_palette_seeds: std::collections::HashSet<u64> = scorched_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
     let frost_palette_seeds: std::collections::HashSet<u64> = frost_biome
         .material_palette
         .iter()
-        .map(|p| p.material_seed)
+        .map(|p| p.material_seed.0)
         .collect();
 
     // Sanity: the two palettes share no seeds.
@@ -3179,8 +3186,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &scorched_biome,
             ) {
-                if site.material_seed != 0 {
-                    scorched_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    scorched_observed.insert(site.material_seed.0);
                 }
             }
 
@@ -3191,8 +3198,8 @@ fn disjoint_biome_palettes_produce_disjoint_deposit_materials() {
                 coord,
                 &frost_biome,
             ) {
-                if site.material_seed != 0 {
-                    frost_observed.insert(site.material_seed);
+                if site.material_seed != MaterialSeed(0) {
+                    frost_observed.insert(site.material_seed.0);
                 }
             }
         }
@@ -3388,15 +3395,15 @@ fn every_deposit_material_is_pickup_ready() {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 1001,
+                material_seed: MaterialSeed(1001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 1003,
+                material_seed: MaterialSeed(1003),
                 selection_weight: 2.0,
             },
             PaletteMaterial {
-                material_seed: 1007,
+                material_seed: MaterialSeed(1007),
                 selection_weight: 1.5,
             },
         ],
@@ -3413,17 +3420,17 @@ fn every_deposit_material_is_pickup_ready() {
             );
 
             for placement in &placements {
-                if placement.material_seed == 0 {
+                if placement.material_seed == MaterialSeed(0) {
                     continue;
                 }
 
-                let mat = mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+                let mat = mat_catalog.derive_and_register(placement.material_seed);
 
                 // Name must be non-empty (the pickup HUD displays it).
                 assert!(
                     !mat.name.is_empty(),
                     "deposit seed {} produced an empty name",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 // Color channels must be finite and in [0, 1].
@@ -3431,7 +3438,7 @@ fn every_deposit_material_is_pickup_ready() {
                     assert!(
                         c.is_finite() && (0.0..=1.0).contains(&c),
                         "deposit seed {} color[{i}] = {c} out of range",
-                        placement.material_seed,
+                        placement.material_seed.0,
                     );
                 }
 
@@ -3445,7 +3452,7 @@ fn every_deposit_material_is_pickup_ready() {
                 assert!(
                     any_nonzero,
                     "deposit seed {} has all-zero properties",
-                    placement.material_seed,
+                    placement.material_seed.0,
                 );
 
                 checked += 1;
@@ -3492,15 +3499,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1003,
+                    material_seed: MaterialSeed(1003),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1006,
+                    material_seed: MaterialSeed(1006),
                     selection_weight: 2.0,
                 },
             ],
@@ -3512,19 +3519,19 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1002,
+                    material_seed: MaterialSeed(1002),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1005,
+                    material_seed: MaterialSeed(1005),
                     selection_weight: 2.5,
                 },
                 PaletteMaterial {
-                    material_seed: 1008,
+                    material_seed: MaterialSeed(1008),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1001,
+                    material_seed: MaterialSeed(1001),
                     selection_weight: 1.0,
                 },
             ],
@@ -3536,15 +3543,15 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
             deposit_weight_modifiers: HashMap::new(),
             material_palette: vec![
                 PaletteMaterial {
-                    material_seed: 1004,
+                    material_seed: MaterialSeed(1004),
                     selection_weight: 3.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1009,
+                    material_seed: MaterialSeed(1009),
                     selection_weight: 2.0,
                 },
                 PaletteMaterial {
-                    material_seed: 1010,
+                    material_seed: MaterialSeed(1010),
                     selection_weight: 2.5,
                 },
             ],
@@ -3585,8 +3592,8 @@ fn restart_same_seed_same_biome_yields_identical_materials() {
                     biome,
                 );
                 for placement in &placements {
-                    if placement.material_seed != 0 {
-                        mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+                    if placement.material_seed != MaterialSeed(0) {
+                        mat_catalog.derive_and_register(placement.material_seed);
                     }
                 }
             }
@@ -3806,8 +3813,8 @@ fn restart_system_seed_chain_yields_identical_world() {
                 &biome,
             );
             for placement in &placements {
-                if placement.material_seed != 0 {
-                    mat_catalog.derive_and_register(MaterialSeed(placement.material_seed));
+                if placement.material_seed != MaterialSeed(0) {
+                    mat_catalog.derive_and_register(placement.material_seed);
                 }
             }
         }
@@ -4005,11 +4012,11 @@ fn sample_biome_with_palette() -> ChunkBiome {
         deposit_weight_modifiers: HashMap::new(),
         material_palette: vec![
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0001,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0001),
                 selection_weight: 3.0,
             },
             PaletteMaterial {
-                material_seed: 0xFE00_0000_0000_0002,
+                material_seed: MaterialSeed(0xFE00_0000_0000_0002),
                 selection_weight: 1.0,
             },
         ],
@@ -4077,7 +4084,7 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
                 &biome,
             );
             for p in &placements {
-                seen_seeds.insert(p.material_seed);
+                seen_seeds.insert(p.material_seed.0);
             }
         }
     }
@@ -4085,10 +4092,10 @@ fn both_palette_materials_appear_in_deposits_across_chunks() {
     // Both palette seeds should appear.
     for pm in &biome.material_palette {
         assert!(
-            seen_seeds.contains(&pm.material_seed),
+            seen_seeds.contains(&pm.material_seed.0),
             "palette seed {:#x} never appeared in deposits \
                  across 100 chunks",
-            pm.material_seed,
+            pm.material_seed.0,
         );
     }
 }
@@ -4113,9 +4120,9 @@ fn higher_weight_palette_entry_appears_more_often() {
                 &biome,
             );
             for p in &placements {
-                if p.material_seed == 0xFE00_0000_0000_0001 {
+                if p.material_seed == MaterialSeed(0xFE00_0000_0000_0001) {
                     count_seed_1 += 1;
-                } else if p.material_seed == 0xFE00_0000_0000_0002 {
+                } else if p.material_seed == MaterialSeed(0xFE00_0000_0000_0002) {
                     count_seed_2 += 1;
                 }
             }

--- a/src/world_generation_tests.rs
+++ b/src/world_generation_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seeds::{BiomeSeed, MaterialSeed, ObjectIdentitySeed, PlacementSeed};
 use crate::test_support::{FlatSurface, SteppedSurface, TiltedSurface};
 
 #[test]
@@ -116,10 +117,13 @@ fn world_profile_derives_distinct_sub_seeds() {
         profile.placement_density_seed,
         profile.placement_variation_seed
     );
-    assert_ne!(profile.placement_density_seed, profile.object_identity_seed);
     assert_ne!(
-        profile.placement_variation_seed,
-        profile.object_identity_seed
+        profile.placement_density_seed.0,
+        profile.object_identity_seed.0
+    );
+    assert_ne!(
+        profile.placement_variation_seed.0,
+        profile.object_identity_seed.0
     );
 }
 
@@ -757,9 +761,15 @@ fn biome_climate_seed_is_distinct_from_other_seeds() {
     // in WorldProfile to avoid correlated noise fields.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
 
-    assert_ne!(profile.biome_climate_seed, profile.placement_density_seed);
-    assert_ne!(profile.biome_climate_seed, profile.placement_variation_seed);
-    assert_ne!(profile.biome_climate_seed, profile.planet_seed.0);
+    assert_ne!(
+        profile.biome_climate_seed.0,
+        profile.placement_density_seed.0
+    );
+    assert_ne!(
+        profile.biome_climate_seed.0,
+        profile.placement_variation_seed.0
+    );
+    assert_ne!(profile.biome_climate_seed.0, profile.planet_seed.0);
 }
 
 #[test]
@@ -768,10 +778,10 @@ fn elevation_seed_is_distinct_from_other_seeds() {
     // in WorldProfile to avoid correlated noise fields.
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
 
-    assert_ne!(profile.elevation_seed, profile.placement_density_seed);
-    assert_ne!(profile.elevation_seed, profile.placement_variation_seed);
-    assert_ne!(profile.elevation_seed, profile.object_identity_seed);
-    assert_ne!(profile.elevation_seed, profile.biome_climate_seed);
+    assert_ne!(profile.elevation_seed, profile.placement_density_seed.0);
+    assert_ne!(profile.elevation_seed, profile.placement_variation_seed.0);
+    assert_ne!(profile.elevation_seed, profile.object_identity_seed.0);
+    assert_ne!(profile.elevation_seed, profile.biome_climate_seed.0);
     assert_ne!(profile.elevation_seed, profile.planet_seed.0);
 }
 
@@ -825,15 +835,15 @@ fn biome_registry_toml_round_trip_with_palette_entries() {
     let palette = &mut registry.biomes[0].material_palette;
     palette.clear();
     palette.push(PaletteMaterial {
-        material_seed: 0xFE00_0000_0000_0001,
+        material_seed: MaterialSeed(0xFE00_0000_0000_0001),
         selection_weight: 3.0,
     });
     palette.push(PaletteMaterial {
-        material_seed: 0xFE00_0000_0000_0002,
+        material_seed: MaterialSeed(0xFE00_0000_0000_0002),
         selection_weight: 0.5,
     });
     palette.push(PaletteMaterial {
-        material_seed: 42,
+        material_seed: MaterialSeed(42),
         selection_weight: 1.0,
     });
 
@@ -882,7 +892,7 @@ fn biome_toml_round_trip_empty_palette() {
 #[test]
 fn biome_toml_round_trip_shared_seed_across_biomes() {
     // The same material seed can appear in multiple biomes with different weights.
-    let shared_seed: u64 = 0xABCD_0000_0000_0099;
+    let shared_seed: MaterialSeed = MaterialSeed(0xABCD_0000_0000_0099);
     let mut registry = BiomeRegistry::default();
 
     // Ensure at least two biomes exist.
@@ -1067,7 +1077,7 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
             let palette = b
                 .material_palette
                 .iter()
-                .map(|p| (p.material_seed, p.selection_weight))
+                .map(|p| (p.material_seed.0, p.selection_weight))
                 .collect::<Vec<_>>();
             (b.biome_type, palette)
         })
@@ -1090,7 +1100,7 @@ fn chunk_biome_includes_correct_palette_for_each_biome_type() {
             let actual: Vec<(u64, f32)> = biome
                 .material_palette
                 .iter()
-                .map(|p| (p.material_seed, p.selection_weight))
+                .map(|p| (p.material_seed.0, p.selection_weight))
                 .collect();
 
             assert_eq!(
@@ -1125,11 +1135,11 @@ fn chunk_biome_fallback_carries_fallback_palette() {
     let profile = WorldProfile::from_config(&sample_config()).unwrap();
     let fallback_palette = vec![
         PaletteMaterial {
-            material_seed: 0xAAAA,
+            material_seed: MaterialSeed(0xAAAA),
             selection_weight: 1.0,
         },
         PaletteMaterial {
-            material_seed: 0xBBBB,
+            material_seed: MaterialSeed(0xBBBB),
             selection_weight: 2.0,
         },
     ];
@@ -1217,7 +1227,7 @@ fn chunk_biome_hardcoded_default_has_reasonable_palette() {
         assert!(
             entry.selection_weight > 0.0,
             "palette entry seed {} has non-positive weight {}",
-            entry.material_seed,
+            entry.material_seed.0,
             entry.selection_weight
         );
     }
@@ -2319,10 +2329,10 @@ fn system_mode_is_system_derived_and_all_fields_populated() {
     // guaranteed by the mixing function, but for seed 42 they are
     // empirically distinct and non-zero — if any were zero it would
     // indicate the derivation chain is broken).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert!(profile.planet_surface_diameter > 0);
@@ -2599,10 +2609,10 @@ fn planet_index_last_planet_succeeds() {
     );
 
     // Sub-seeds are populated (derivation chain is intact).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert_eq!(
@@ -2684,10 +2694,10 @@ fn planet_index_one_valid_in_two_planet_system() {
     );
 
     // Sub-seeds are populated (derivation chain is intact).
-    assert_ne!(profile.placement_density_seed, 0);
-    assert_ne!(profile.placement_variation_seed, 0);
-    assert_ne!(profile.object_identity_seed, 0);
-    assert_ne!(profile.biome_climate_seed, 0);
+    assert_ne!(profile.placement_density_seed, PlacementSeed(0));
+    assert_ne!(profile.placement_variation_seed, PlacementSeed(0));
+    assert_ne!(profile.object_identity_seed, ObjectIdentitySeed(0));
+    assert_ne!(profile.biome_climate_seed, BiomeSeed(0));
     assert_ne!(profile.elevation_seed, 0);
     assert!(profile.planet_surface_radius > 0);
     assert_eq!(

--- a/tests/material_regression.rs
+++ b/tests/material_regression.rs
@@ -187,7 +187,7 @@ fn different_biomes_produce_different_material_sets() {
             let seeds: HashSet<u64> = biome
                 .material_palette
                 .iter()
-                .map(|p| p.material_seed)
+                .map(|p| p.material_seed.0)
                 .collect();
             biome_seeds
                 .entry(biome.biome_type)
@@ -239,12 +239,12 @@ fn all_palette_entries_appear_across_many_chunks() {
             let seen = seen_per_biome.entry(biome.biome_type).or_default();
 
             for p in &biome.material_palette {
-                expected.insert(p.material_seed);
+                expected.insert(p.material_seed.0);
                 // The palette is always fully present on every chunk of
                 // that biome — selection happens at deposit placement, not
                 // at biome derivation.  So every palette seed should appear
                 // in every chunk's palette.
-                seen.insert(p.material_seed);
+                seen.insert(p.material_seed.0);
             }
         }
     }
@@ -270,7 +270,7 @@ fn well_known_seeds_produce_distinct_materials() {
     let all_seeds: HashSet<u64> = registry
         .biomes
         .iter()
-        .flat_map(|b| b.material_palette.iter().map(|p| p.material_seed))
+        .flat_map(|b| b.material_palette.iter().map(|p| p.material_seed.0))
         .collect();
 
     assert!(


### PR DESCRIPTION
## Summary

Completes the codebase-wide migration of bare `u64` seed usages to domain newtypes (`MaterialSeed`, etc.). This PR builds on top of:
- #442 — MaterialCatalog and ConfidenceTracker to MaterialSeed (already on develop)
- #443 — WorldProfile sub-seeds and related structs (on `feat/seed-newtypes-common-module`)
- #444 — SolarSystemSeed domain newtype in solar_system.rs (on `feat/seed-newtypes-common-module`)

This branch was created from `develop` and then merged `feat/seed-newtypes-common-module` in so it includes all four PRs' work. It should be merged after #443 and #444 land on `develop`.

## Changes

### `src/knowledge_graph.rs`
- `detect_and_wire_similar_materials(new_seed: u64, ...))` → `new_seed: MaterialSeed`
- Call site in `detect_similar_on_observation` wraps the `u64` at the `JournalKey::MaterialInstance` serialization boundary: `MaterialSeed(seed)`
- Added `use crate::materials::MaterialSeed` import

### `src/seeds.rs` (in merge commit)
- Added `Display` impl to `define_seed_newtype!` macro — formats as `{:#018x}`; needed for test format strings in `exterior_tests.rs`

### `src/observation.rs` (in merge commit)
- Fixed test `confidence_tracker_serde_round_trip` to use `MaterialSeed(42)` etc. instead of bare integer literals

### Merge of `feat/seed-newtypes-common-module`
- Conflict resolution in `src/materials.rs`, `src/world_generation/exterior.rs`, `src/world_generation/exterior_tests.rs`
- The develop branch had double-wrapped `MaterialSeed(placement.material_seed)` where `placement.material_seed` was already a `MaterialSeed`; the seed-newtypes branch had an over-eager `.0` unwrap. Took the newtypes version and fixed the unwrap.

## Intentionally unchanged `u64` usages

These remain as `u64` by design — all are at serialization/asset-loading edges or internal bit-manipulation:
- `GameMaterial::seed: u64` — serialization edge
- `JournalKey::MaterialInstance { seed: u64 }` — serialization edge (wrapped at single call site)
- `CombinationRules::pair_rules` / `rules_for` — TOML deserialization, zero external callers
- `GeneratedDepositSiteId::planet_seed: u64` — `Serialize, Deserialize` identity struct
- `elevation_seed` / `detail_seed` in `world_generation.rs` — awaiting `ElevationSeed` newtype in Epic 5
- `seed_util.rs` functions — raw bit-manipulation layer
- `fabricator.rs` noise functions — operate on `GameMaterial::seed` at serialization boundary
- `naming.rs` `procedural_name(seed: u64)` — internal impl called only from `derive_material_from_seed`

## Test results

761/761 tests pass (`make check`). `cargo check` clean.