### PR TITLE
feat(kanban): backlog flat list and group-by-type modes

### DIFF
--- a/kanban/src/components/BacklogView.jsx
+++ b/kanban/src/components/BacklogView.jsx
@@ -387,15 +387,19 @@ function EpicTree({ issues, onSelect, repo }) {
 }
 
 export default function BacklogView({ repo }) {
-  const [mode, setMode] = useState("flat");
+  const backlogMode = useIssueStore((s) => s.backlogMode);
+  const setBacklogMode = useIssueStore((s) => s.setBacklogMode);
+  const hiddenColumns = useIssueStore((s) => s.hiddenColumns);
   const filteredIssues = useIssueStore((s) => s.filteredIssues());
   const selectIssue = useIssueStore((s) => s.selectIssue);
 
-  // Only show open issues in backlog
-  const openIssues = filteredIssues.filter((i) => i.state !== "closed");
+  // Only show open issues not in hidden columns
+  const openIssues = filteredIssues.filter(
+    (i) => i.state !== "closed" && !hiddenColumns.has(issueColumn(i))
+  );
 
   function renderContent() {
-    switch (mode) {
+    switch (backlogMode) {
       case "flat":
         return <FlatList issues={openIssues} onSelect={selectIssue} />;
       case "type":
@@ -407,7 +411,7 @@ export default function BacklogView({ repo }) {
       case "epic":
         return <EpicTree issues={openIssues} onSelect={selectIssue} repo={repo} />;
       default:
-        return <div style={s.placeholder}>mode: {mode}</div>;
+        return <div style={s.placeholder}>mode: {backlogMode}</div>;
     }
   }
 
@@ -420,9 +424,9 @@ export default function BacklogView({ repo }) {
             key={m.key}
             style={{
               ...s.modeBtn,
-              ...(mode === m.key ? s.modeBtnActive : {}),
+              ...(backlogMode === m.key ? s.modeBtnActive : {}),
             }}
-            onClick={() => setMode(m.key)}
+            onClick={() => setBacklogMode(m.key)}
           >
             {m.label}
           </button>

--- a/kanban/src/store/issues.js
+++ b/kanban/src/store/issues.js
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 const COLLAPSED_KEY = "gh_kanban_collapsed";
 const HIDDEN_COLUMNS_KEY = "gh_kanban_hidden_columns";
+const BACKLOG_MODE_KEY = "gh_kanban_backlog_mode";
 
 // These are populated by initColumns() before React mounts.
 // Treat as read-only after initialisation.
@@ -92,6 +93,18 @@ function saveHiddenColumns(set) {
   localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify([...set]));
 }
 
+function loadBacklogMode() {
+  try {
+    return localStorage.getItem(BACKLOG_MODE_KEY) || "flat";
+  } catch {
+    return "flat";
+  }
+}
+
+function saveBacklogMode(mode) {
+  localStorage.setItem(BACKLOG_MODE_KEY, mode);
+}
+
 export const useIssueStore = create((set, get) => ({
   issues: [],
   loading: false,
@@ -101,6 +114,7 @@ export const useIssueStore = create((set, get) => ({
   columnOrder: {},
   collapsedColumns: loadCollapsed(),
   hiddenColumns: loadHiddenColumns() ?? new Set(defaultHiddenColumns),
+  backlogMode: loadBacklogMode(),
 
   setIssues(issues) {
     const persisted = loadHiddenColumns();
@@ -154,6 +168,11 @@ export const useIssueStore = create((set, get) => ({
       saveHiddenColumns(next);
       return { hiddenColumns: next };
     });
+  },
+
+  setBacklogMode(mode) {
+    saveBacklogMode(mode);
+    set({ backlogMode: mode });
   },
 
   moveIssue(issueNumber, targetColumn) {


### PR DESCRIPTION
## Summary

Implements KB-1.3 / #254 — backlog view modes with store-level persistence.

### Changes
- **store/issues.js**: Added `backlogMode` state (default `'flat'`), `setBacklogMode(mode)` action, localStorage load/save helpers using key `gh_kanban_backlog_mode`
- **components/BacklogView.jsx**: Wired mode selector to store instead of local `useState`; added hidden-column filtering so issues in hidden columns are excluded from all backlog modes

### Acceptance Criteria
- [x] Mode selector visible in Backlog tab with Flat List and Group by Type options (+ 3 more)
- [x] Flat List shows all non-hidden-column open issues in a single list
- [x] Group by Type shows collapsible sections per type label
- [x] Mode choice persists across reloads (localStorage `gh_kanban_backlog_mode`)

### Checks
- `make kb-check`: 0 errors, 5 pre-existing warnings, build OK

Closes #254