### PR TITLE
feat(orchestrator): Story 22.6 — STUN/TURN ICE config and TURN credential rotation

### DIFF
--- a/infra/orchestrator/cmd/signaling/main.go
+++ b/infra/orchestrator/cmd/signaling/main.go
@@ -7,6 +7,13 @@
 //	PORT            — TCP port to listen on (default: 9090)
 //	SIGNALING_ORIGIN — comma-separated allowed origins for WebSocket upgrade
 //	                   (default: * — allow all, NOT suitable for production)
+//	STUN_SERVERS    — comma-separated STUN URLs returned to clients on register
+//	                   (e.g. "stun:stun.l.google.com:19302")
+//	TURN_SERVERS    — comma-separated TURN URLs returned to clients on register
+//	                   (e.g. "turn:turn.example.com:3478")
+//	TURN_SECRET     — shared HMAC-SHA1 secret for short-lived credential
+//	                   generation (RFC 8489 §9.2 / draft-uberti-behave-turn-rest-00)
+//	                   Compatible with Coturn --use-auth-secret mode.
 //
 // The server exposes:
 //
@@ -37,7 +44,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	hub := signaling.NewHub()
+	hub := signaling.NewHub(signaling.NewICEConfigProviderFromEnv())
 	go hub.Run(ctx)
 
 	mux := http.NewServeMux()

--- a/infra/orchestrator/internal/signaling/hub.go
+++ b/infra/orchestrator/internal/signaling/hub.go
@@ -92,11 +92,15 @@ type relayPayload struct {
 // Hub manages all signaling state and message dispatch.
 type Hub struct {
 	cmds chan cmd
+	ice  *ICEConfigProvider
 }
 
 // NewHub creates an uninitialised Hub. Call Run to start it.
-func NewHub() *Hub {
-	return &Hub{cmds: make(chan cmd, 256)}
+// ice configures ICE server list and TURN credential rotation; use
+// NewICEConfigProviderFromEnv() for production or NewICEConfigProvider() in
+// tests.
+func NewHub(ice *ICEConfigProvider) *Hub {
+	return &Hub{cmds: make(chan cmd, 256), ice: ice}
 }
 
 // Run starts the hub's event loop. It returns when ctx is cancelled.
@@ -143,9 +147,11 @@ func (h *Hub) dispatch(c cmd, sessions map[string]*session, lobbies map[string]*
 			name = "player-" + p.sessionID[:6]
 		}
 		s.displayName = name
+		iceConfig := h.ice.ConfigForSession(s.id)
 		s.conn.Send(MakeEnvelope(MsgRegistered, RegisteredPayload{
 			SessionID:   s.id,
 			DisplayName: s.displayName,
+			ICEServers:  iceConfig.ICEServers,
 		}))
 
 	case cmdCreateLobby:

--- a/infra/orchestrator/internal/signaling/hub_test.go
+++ b/infra/orchestrator/internal/signaling/hub_test.go
@@ -46,10 +46,21 @@ func drainConn(c *Conn) []Envelope {
 // hubWithContext starts a hub in a background goroutine and returns both the
 // hub and a cancel func. The hub is drained synchronously after each command
 // via a small sleep — good enough for unit tests.
+// It uses an empty ICEConfigProvider (no STUN/TURN configured) so existing
+// tests are unaffected; ICE-specific tests use hubWithICE.
 func hubWithContext(t *testing.T) (*Hub, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	h := NewHub()
+	h := NewHub(NewICEConfigProvider(nil, nil, nil))
+	go h.Run(ctx)
+	return h, cancel
+}
+
+// hubWithICE starts a hub configured with the provided ICEConfigProvider.
+func hubWithICE(t *testing.T, ice *ICEConfigProvider) (*Hub, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	h := NewHub(ice)
 	go h.Run(ctx)
 	return h, cancel
 }

--- a/infra/orchestrator/internal/signaling/ice.go
+++ b/infra/orchestrator/internal/signaling/ice.go
@@ -1,0 +1,168 @@
+// ice.go provides ICE server configuration and TURN credential rotation for
+// the Apeiron Cipher signaling server.
+//
+// # ICE Server Configuration
+//
+// The signaling server reads ICE server config from environment variables so
+// the binary stays config-file-free. Three variables are supported:
+//
+//   - STUN_SERVERS  — comma-separated STUN URLs, e.g.
+//     "stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302"
+//   - TURN_SERVERS  — comma-separated TURN URLs, e.g.
+//     "turn:turn.example.com:3478"
+//   - TURN_SECRET   — shared HMAC-SHA1 secret for short-lived credential
+//     generation (RFC 8489 §9.2 / draft-uberti-behave-turn-rest-00).
+//
+// If TURN_SECRET is empty, TURN servers are still returned in the ICE list
+// but without credentials — suitable for TURN servers that allow open access
+// (uncommon) or for configuration testing.
+//
+// # Short-lived TURN Credentials
+//
+// When TURN_SECRET is set, the server generates time-limited HMAC-SHA1
+// credentials for every new session (on "register"). The username is:
+//
+//	<expiry_unix_timestamp>:<session_id>
+//
+// The password is:
+//
+//	base64( HMAC-SHA1( TURN_SECRET, username ) )
+//
+// The credential expires after TURNCredentialTTL (default 24 h). The TURN
+// relay validates these the same way: it knows the shared secret, computes
+// the HMAC, and rejects any connection whose timestamp is in the past.
+//
+// This is the same scheme used by Coturn (--use-auth-secret), Pion's TURN
+// server, and Cloudflare Calls TURN — it is broadly interoperable.
+package signaling
+
+import (
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec // HMAC-SHA1 is mandated by draft-uberti-behave-turn-rest-00
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// TURNCredentialTTL is how long issued TURN credentials remain valid.
+// 24 hours is the Coturn default and gives plenty of time for a game session.
+const TURNCredentialTTL = 24 * time.Hour
+
+// ICEServer is the wire representation of a single ICE server entry.
+// It matches the RTCIceServer shape expected by WebRTC implementations.
+type ICEServer struct {
+	URLs       []string `json:"urls"`
+	Username   string   `json:"username,omitempty"`   // only for TURN
+	Credential string   `json:"credential,omitempty"` // only for TURN
+}
+
+// ICEConfig holds the full ICE server list returned to clients on register.
+type ICEConfig struct {
+	ICEServers []ICEServer `json:"ice_servers"`
+}
+
+// ICEConfigProvider builds ICEConfig values for new sessions. It is
+// constructed once at startup and shared across all handler goroutines; all
+// fields are immutable after construction so no locking is needed.
+type ICEConfigProvider struct {
+	stunURLs   []string // parsed from STUN_SERVERS env
+	turnURLs   []string // parsed from TURN_SERVERS env
+	turnSecret []byte   // parsed from TURN_SECRET env; nil if not set
+}
+
+// NewICEConfigProviderFromEnv reads STUN_SERVERS, TURN_SERVERS, and
+// TURN_SECRET from the environment and returns a ready-to-use provider.
+// It never returns an error — missing variables simply disable the
+// corresponding feature.
+func NewICEConfigProviderFromEnv() *ICEConfigProvider {
+	return &ICEConfigProvider{
+		stunURLs:   parseCommaSeparated(os.Getenv("STUN_SERVERS")),
+		turnURLs:   parseCommaSeparated(os.Getenv("TURN_SERVERS")),
+		turnSecret: parseSecret(os.Getenv("TURN_SECRET")),
+	}
+}
+
+// NewICEConfigProvider constructs a provider from explicit values.
+// Useful for tests and for wiring the hub without depending on env.
+func NewICEConfigProvider(stunURLs, turnURLs []string, turnSecret []byte) *ICEConfigProvider {
+	return &ICEConfigProvider{
+		stunURLs:   stunURLs,
+		turnURLs:   turnURLs,
+		turnSecret: turnSecret,
+	}
+}
+
+// IsEmpty reports whether the provider has no ICE servers configured.
+// When true the registered payload carries an empty ice_servers list.
+func (p *ICEConfigProvider) IsEmpty() bool {
+	return len(p.stunURLs) == 0 && len(p.turnURLs) == 0
+}
+
+// ConfigForSession returns an ICEConfig for the given session ID. TURN
+// credentials are generated fresh for each call (short-lived per-session).
+func (p *ICEConfigProvider) ConfigForSession(sessionID string) ICEConfig {
+	var servers []ICEServer
+
+	// STUN entries — no credentials needed.
+	if len(p.stunURLs) > 0 {
+		servers = append(servers, ICEServer{URLs: p.stunURLs})
+	}
+
+	// TURN entries — with or without HMAC credentials.
+	for _, url := range p.turnURLs {
+		entry := ICEServer{URLs: []string{url}}
+		if len(p.turnSecret) > 0 {
+			username, password := makeTURNCredential(p.turnSecret, sessionID, time.Now().Add(TURNCredentialTTL))
+			entry.Username = username
+			entry.Credential = password
+		}
+		servers = append(servers, entry)
+	}
+
+	if servers == nil {
+		servers = []ICEServer{} // always send an array, never null
+	}
+	return ICEConfig{ICEServers: servers}
+}
+
+// makeTURNCredential generates a short-lived HMAC-SHA1 TURN credential pair.
+//
+// username = "<expiry_unix>:<sessionID>"
+// password = base64( HMAC-SHA1( secret, username ) )
+//
+// This is the "REST API" scheme documented in draft-uberti-behave-turn-rest-00
+// and implemented by Coturn (--use-auth-secret flag).
+func makeTURNCredential(secret []byte, sessionID string, expiry time.Time) (username, password string) {
+	username = fmt.Sprintf("%d:%s", expiry.Unix(), sessionID)
+	mac := hmac.New(sha1.New, secret) //nolint:gosec // HMAC-SHA1, not plain SHA1
+	mac.Write([]byte(username))       //nolint:errcheck // hmac.Hash.Write never errors
+	password = base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return username, password
+}
+
+// parseCommaSeparated splits a comma-delimited env string into a trimmed,
+// non-empty string slice. Returns nil when the input is empty.
+func parseCommaSeparated(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// parseSecret converts a non-empty string to a byte slice suitable for HMAC
+// use. Returns nil when the input is empty (TURN auth disabled).
+func parseSecret(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	return []byte(s)
+}

--- a/infra/orchestrator/internal/signaling/ice_test.go
+++ b/infra/orchestrator/internal/signaling/ice_test.go
@@ -1,0 +1,280 @@
+// ice_test.go tests ICE server configuration and TURN credential rotation.
+package signaling
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec
+)
+
+// --- Unit tests for credential generation ---
+
+func TestMakeTURNCredential_Format(t *testing.T) {
+	secret := []byte("supersecret")
+	sessionID := "abc123"
+	expiry := time.Unix(9999999999, 0) // far future
+
+	username, password := makeTURNCredential(secret, sessionID, expiry)
+
+	// username must be "<expiry>:<sessionID>"
+	wantUsername := "9999999999:abc123"
+	if username != wantUsername {
+		t.Errorf("username: got %q, want %q", username, wantUsername)
+	}
+
+	// password must be base64(HMAC-SHA1(secret, username))
+	mac := hmac.New(sha1.New, secret) //nolint:gosec
+	mac.Write([]byte(username))       //nolint:errcheck
+	wantPassword := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	if password != wantPassword {
+		t.Errorf("password: got %q, want %q", password, wantPassword)
+	}
+}
+
+func TestMakeTURNCredential_DifferentSessionsDifferentPasswords(t *testing.T) {
+	secret := []byte("sharedkey")
+	expiry := time.Now().Add(TURNCredentialTTL)
+
+	_, p1 := makeTURNCredential(secret, "session-aaa", expiry)
+	_, p2 := makeTURNCredential(secret, "session-bbb", expiry)
+
+	if p1 == p2 {
+		t.Error("different session IDs must produce different credentials")
+	}
+}
+
+func TestMakeTURNCredential_Expiry(t *testing.T) {
+	secret := []byte("sharedkey")
+
+	u1, _ := makeTURNCredential(secret, "s1", time.Now().Add(1*time.Hour))
+	u2, _ := makeTURNCredential(secret, "s1", time.Now().Add(24*time.Hour))
+
+	// Timestamps embedded in usernames should differ.
+	if u1 == u2 {
+		t.Error("different expiry times must produce different usernames")
+	}
+}
+
+// --- ICEConfigProvider tests ---
+
+func TestICEConfigProvider_Empty(t *testing.T) {
+	p := NewICEConfigProvider(nil, nil, nil)
+	if !p.IsEmpty() {
+		t.Error("provider with no servers should be empty")
+	}
+	cfg := p.ConfigForSession("s1")
+	if len(cfg.ICEServers) != 0 {
+		t.Errorf("expected 0 ICE servers, got %d", len(cfg.ICEServers))
+	}
+}
+
+func TestICEConfigProvider_STUNOnly(t *testing.T) {
+	stun := []string{"stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"}
+	p := NewICEConfigProvider(stun, nil, nil)
+
+	if p.IsEmpty() {
+		t.Error("provider with STUN servers should not be empty")
+	}
+	cfg := p.ConfigForSession("s1")
+	if len(cfg.ICEServers) != 1 {
+		t.Fatalf("expected 1 ICE server entry (grouped STUN), got %d", len(cfg.ICEServers))
+	}
+	entry := cfg.ICEServers[0]
+	if len(entry.URLs) != 2 {
+		t.Errorf("expected 2 STUN URLs, got %d", len(entry.URLs))
+	}
+	if entry.Username != "" || entry.Credential != "" {
+		t.Error("STUN entry must not have credentials")
+	}
+}
+
+func TestICEConfigProvider_TURNWithSecret(t *testing.T) {
+	turn := []string{"turn:turn.example.com:3478"}
+	secret := []byte("s3cr3t")
+	p := NewICEConfigProvider(nil, turn, secret)
+
+	cfg := p.ConfigForSession("mysession")
+	if len(cfg.ICEServers) != 1 {
+		t.Fatalf("expected 1 TURN server entry, got %d", len(cfg.ICEServers))
+	}
+	entry := cfg.ICEServers[0]
+	if entry.Username == "" {
+		t.Error("TURN entry must have a username")
+	}
+	if entry.Credential == "" {
+		t.Error("TURN entry must have a credential")
+	}
+	// Username must embed the session ID.
+	if !strings.Contains(entry.Username, "mysession") {
+		t.Errorf("username %q does not contain session ID", entry.Username)
+	}
+	// Validate the credential.
+	mac := hmac.New(sha1.New, secret) //nolint:gosec
+	mac.Write([]byte(entry.Username)) //nolint:errcheck
+	wantCred := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	if entry.Credential != wantCred {
+		t.Errorf("credential mismatch: got %q, want %q", entry.Credential, wantCred)
+	}
+}
+
+func TestICEConfigProvider_TURNWithoutSecret(t *testing.T) {
+	// TURN servers configured but no secret — server returns URL without creds.
+	turn := []string{"turn:open.example.com:3478"}
+	p := NewICEConfigProvider(nil, turn, nil)
+
+	cfg := p.ConfigForSession("s1")
+	if len(cfg.ICEServers) != 1 {
+		t.Fatalf("expected 1 TURN entry, got %d", len(cfg.ICEServers))
+	}
+	entry := cfg.ICEServers[0]
+	if entry.Username != "" || entry.Credential != "" {
+		t.Error("TURN entry without secret must not carry credentials")
+	}
+}
+
+func TestICEConfigProvider_STUNAndTURN(t *testing.T) {
+	stun := []string{"stun:stun.l.google.com:19302"}
+	turn := []string{"turn:turn.example.com:3478"}
+	p := NewICEConfigProvider(stun, turn, []byte("key"))
+
+	cfg := p.ConfigForSession("session42")
+	// Expect: 1 entry for all STUN URLs + 1 entry per TURN URL.
+	if len(cfg.ICEServers) != 2 {
+		t.Fatalf("expected 2 ICE server entries (STUN + TURN), got %d", len(cfg.ICEServers))
+	}
+	// STUN entry has no credentials.
+	if cfg.ICEServers[0].Username != "" {
+		t.Error("first entry (STUN) must not have credentials")
+	}
+	// TURN entry has credentials.
+	if cfg.ICEServers[1].Username == "" {
+		t.Error("second entry (TURN) must have credentials")
+	}
+}
+
+// --- Integration: hub returns ice_servers in registered payload ---
+
+func TestRegister_IncludesICEServers(t *testing.T) {
+	stun := []string{"stun:stun.l.google.com:19302"}
+	turn := []string{"turn:turn.example.com:3478"}
+	ice := NewICEConfigProvider(stun, turn, []byte("testkey"))
+
+	h, cancel := hubWithICE(t, ice)
+	defer cancel()
+
+	conn := newFakeConn()
+	h.Join("s1", conn)
+	h.Register("s1", "Alice")
+	sync()
+
+	msgs := drainConn(conn)
+	if len(msgs) != 1 || msgs[0].Type != MsgRegistered {
+		t.Fatalf("expected 1 registered message, got %v", msgs)
+	}
+
+	var p RegisteredPayload
+	if err := json.Unmarshal(msgs[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.DisplayName != "Alice" {
+		t.Errorf("expected display name Alice, got %q", p.DisplayName)
+	}
+	// Two entries: one STUN group + one TURN.
+	if len(p.ICEServers) != 2 {
+		t.Fatalf("expected 2 ICE server entries in registered payload, got %d: %+v", len(p.ICEServers), p.ICEServers)
+	}
+	// TURN entry should carry credentials.
+	turnEntry := p.ICEServers[1]
+	if turnEntry.Username == "" || turnEntry.Credential == "" {
+		t.Error("TURN entry in registered payload must carry credentials")
+	}
+}
+
+func TestRegister_NoICEServersConfigured_EmptyList(t *testing.T) {
+	h, cancel := hubWithContext(t) // hubWithContext uses empty ICEConfigProvider
+	defer cancel()
+
+	conn := newFakeConn()
+	h.Join("s1", conn)
+	h.Register("s1", "Alice")
+	sync()
+
+	msgs := drainConn(conn)
+	if len(msgs) != 1 || msgs[0].Type != MsgRegistered {
+		t.Fatalf("expected 1 registered message, got %v", msgs)
+	}
+	var p RegisteredPayload
+	json.Unmarshal(msgs[0].Payload, &p) //nolint:errcheck
+	// Must be an array (not null) even when empty.
+	if p.ICEServers == nil {
+		t.Error("ice_servers must be an array even when empty, not null/omitted")
+	}
+	if len(p.ICEServers) != 0 {
+		t.Errorf("expected empty ICE servers, got %d entries", len(p.ICEServers))
+	}
+}
+
+func TestTURNCredentials_UniquePerSession(t *testing.T) {
+	// Different sessions must get different credentials (prevents credential sharing).
+	ice := NewICEConfigProvider(nil, []string{"turn:turn.example.com:3478"}, []byte("key"))
+
+	h, cancel := hubWithICE(t, ice)
+	defer cancel()
+
+	c1 := newFakeConn()
+	c2 := newFakeConn()
+	h.Join("sess-aaa", c1)
+	h.Join("sess-bbb", c2)
+	h.Register("sess-aaa", "Alice")
+	h.Register("sess-bbb", "Bob")
+	sync()
+
+	msgs1 := drainConn(c1)
+	msgs2 := drainConn(c2)
+
+	var p1, p2 RegisteredPayload
+	json.Unmarshal(msgs1[0].Payload, &p1) //nolint:errcheck
+	json.Unmarshal(msgs2[0].Payload, &p2) //nolint:errcheck
+
+	if len(p1.ICEServers) == 0 || len(p2.ICEServers) == 0 {
+		t.Fatal("both sessions must receive ICE servers")
+	}
+
+	// Credentials must differ between sessions.
+	if p1.ICEServers[0].Username == p2.ICEServers[0].Username {
+		t.Error("different sessions must receive different TURN usernames")
+	}
+	if p1.ICEServers[0].Credential == p2.ICEServers[0].Credential {
+		t.Error("different sessions must receive different TURN credentials")
+	}
+}
+
+// --- parseCommaSeparated ---
+
+func TestParseCommaSeparated(t *testing.T) {
+	cases := []struct {
+		input string
+		want  []string
+	}{
+		{"", nil},
+		{"stun:a.com:19302", []string{"stun:a.com:19302"}},
+		{"stun:a.com, stun:b.com", []string{"stun:a.com", "stun:b.com"}},
+		{"  , ", nil}, // only whitespace/commas → nil
+	}
+	for _, tc := range cases {
+		got := parseCommaSeparated(tc.input)
+		if len(got) != len(tc.want) {
+			t.Errorf("parseCommaSeparated(%q): got %v, want %v", tc.input, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("parseCommaSeparated(%q)[%d]: got %q, want %q", tc.input, i, got[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/infra/orchestrator/internal/signaling/messages.go
+++ b/infra/orchestrator/internal/signaling/messages.go
@@ -53,9 +53,13 @@ type RegisterPayload struct {
 }
 
 // RegisteredPayload is the server's acknowledgement.
+// ICEServers carries the full ICE configuration the client should pass to its
+// RTCPeerConnection constructor. This avoids a separate round-trip and means
+// the client always uses fresh TURN credentials (short-lived HMAC-signed).
 type RegisteredPayload struct {
-	SessionID   string `json:"session_id"`
-	DisplayName string `json:"display_name"`
+	SessionID   string      `json:"session_id"`
+	DisplayName string      `json:"display_name"`
+	ICEServers  []ICEServer `json:"ice_servers"` // may be empty if no ICE servers configured
 }
 
 // --- Lobbies ---


### PR DESCRIPTION
## Summary

Implements Story 22.6: STUN/TURN ICE server configuration and short-lived TURN credential rotation in the signaling server.

## Changes

### `internal/signaling/ice.go` (new)
- `ICEConfigProvider` — reads `STUN_SERVERS`, `TURN_SERVERS`, `TURN_SECRET` env vars at startup
- `ConfigForSession(sessionID)` — returns per-session ICE config with fresh HMAC-SHA1 TURN credentials
- `makeTURNCredential` — implements the RFC 8489 §9.2 / draft-uberti-behave-turn-rest-00 'REST API' credential scheme  
  - Username: `<expiry_unix>:<sessionID>`  
  - Password: `base64(HMAC-SHA1(secret, username))`  
  - 24-hour TTL per credential  
  - Compatible with Coturn `--use-auth-secret` mode

### `internal/signaling/messages.go`
- `RegisteredPayload` gains `ICEServers []ICEServer` field — client receives the full ICE config (including fresh TURN creds) in the register acknowledgement, zero extra round-trips

### `internal/signaling/hub.go`
- `NewHub` now takes `*ICEConfigProvider` — wired at startup
- `cmdRegister` handler calls `ice.ConfigForSession` and includes the result in the registered response

### `cmd/signaling/main.go`
- Wires `NewICEConfigProviderFromEnv()` at startup; updated docs comment with env var descriptions

### `internal/signaling/ice_test.go` (new, 12 tests)
- Credential format, uniqueness across sessions, expiry differences
- Provider empty/STUN-only/TURN-with-secret/TURN-without-secret/STUN+TURN
- Hub integration: `ice_servers` present in registered payload, empty-list case, per-session credential uniqueness

## Test Results

```
20/20 tests pass (make sig-check)
```

8 original + 12 new. Pre-commit Docker failures (cmd/server, internal/db) are pre-existing on develop — not caused by this PR (see PR #468).

## Notes on the AC

The task AC specifies 'WebRTC connection succeeds across symmetric NATs in CI test using two containers on separate networks.' That end-to-end test requires:
1. A live TURN relay (Coturn or equivalent) reachable from CI
2. Two Docker containers on isolated bridge networks
3. A WebRTC peer connection stack (beyond what this Go server contains)

This PR delivers the server-side half: correct ICE server config delivery and credential generation that a TURN server can validate. The CI container NAT test would be a follow-up integration task once a TURN server is provisioned in the infra.

Closes #22.6