### PR TITLE
feat(orchestrator): Story 22.6 — signaling server deployment (Docker Compose + systemd)

### DIFF
--- a/infra/orchestrator/cmd/signaling/main.go
+++ b/infra/orchestrator/cmd/signaling/main.go
@@ -4,13 +4,27 @@
 //
 // Configuration via environment variables:
 //
-//	PORT            — TCP port to listen on (default: 9090)
+//	PORT             — TCP port to listen on (default: 9090)
 //	SIGNALING_ORIGIN — comma-separated allowed origins for WebSocket upgrade
 //	                   (default: * — allow all, NOT suitable for production)
+//	STUN_SERVERS     — comma-separated STUN URLs returned to clients on register
+//	                   (e.g. "stun:stun.l.google.com:19302")
+//	TURN_SERVERS     — comma-separated TURN URLs returned to clients on register
+//	                   (e.g. "turn:turn.example.com:3478")
+//	TURN_SECRET      — shared HMAC-SHA1 secret for short-lived credential
+//	                   generation (RFC 8489 §9.2 / draft-uberti-behave-turn-rest-00).
+//	                   Compatible with Coturn --use-auth-secret mode.
+//	MAX_SESSIONS     — maximum simultaneous WebSocket sessions (0 = unlimited,
+//	                   default: 0). New connections are rejected with 503 when
+//	                   the limit is reached.
+//	LOG_LEVEL        — verbosity: "debug" enables per-message logs;
+//	                   "info" (default) logs connections and lifecycle events;
+//	                   "warn" / "error" suppress info logs.
 //
 // The server exposes:
 //
-//	GET /health   — liveness probe, returns 200 "ok"
+//	GET /healthz  — liveness probe, returns 200 "ok"
+//	GET /health   — alias for /healthz (backward compat)
 //	GET /ws       — WebSocket upgrade endpoint for signaling clients
 //
 // The server is intentionally stateless beyond in-memory session mapping.
@@ -23,6 +37,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +48,16 @@ import (
 func main() {
 	port := envOrDefault("PORT", "9090")
 	allowedOrigins := parseOrigins(os.Getenv("SIGNALING_ORIGIN"))
+	maxSessions := parseMaxSessions(os.Getenv("MAX_SESSIONS"))
+	logLevel := strings.ToLower(envOrDefault("LOG_LEVEL", "info"))
+
+	// Configure log verbosity. Go's standard logger has no built-in level
+	// system, so we model it as a flag passed into the hub / handler layer.
+	// "debug" enables per-message logs; anything else uses the default quiet mode.
+	debugLogging := logLevel == "debug"
+	if debugLogging {
+		log.Println("signaling: debug logging enabled")
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -40,12 +65,20 @@ func main() {
 	hub := signaling.NewHub()
 	go hub.Run(ctx)
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+	healthHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok")) //nolint:errcheck
-	})
-	mux.HandleFunc("GET /ws", originMiddleware(allowedOrigins, signaling.Handler(hub)))
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", healthHandler)
+	mux.HandleFunc("GET /health", healthHandler) // backward-compat alias
+	mux.HandleFunc("GET /ws", originMiddleware(allowedOrigins,
+		signaling.HandlerWithOptions(hub, signaling.HandlerOptions{
+			MaxSessions: maxSessions,
+			Debug:       debugLogging,
+		}),
+	))
 
 	srv := &http.Server{
 		Addr:         ":" + port,
@@ -56,7 +89,8 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("signaling server listening on :%s", port)
+		log.Printf("signaling server listening on :%s (max_sessions=%d, log_level=%s)",
+			port, maxSessions, logLevel)
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 			log.Fatalf("signaling server error: %v", err)
 		}
@@ -107,6 +141,20 @@ func parseOrigins(s string) []string {
 		}
 	}
 	return out
+}
+
+// parseMaxSessions converts the MAX_SESSIONS env string to an int.
+// Returns 0 (unlimited) for empty or unparseable values.
+func parseMaxSessions(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		log.Printf("signaling: invalid MAX_SESSIONS %q — defaulting to unlimited", s)
+		return 0
+	}
+	return n
 }
 
 func envOrDefault(key, def string) string {

--- a/infra/orchestrator/internal/signaling/handler.go
+++ b/infra/orchestrator/internal/signaling/handler.go
@@ -3,11 +3,12 @@
 // on the Conn's send channel and written by its internal writeLoop.
 //
 // The handler is responsible for:
-//   1. Upgrading the HTTP connection to WebSocket.
-//   2. Generating a session ID and joining the hub.
-//   3. Dispatching inbound messages to the hub by type.
-//   4. Sending pong responses immediately (no hub round-trip needed).
-//   5. Calling hub.Leave when the connection closes.
+//  1. Upgrading the HTTP connection to WebSocket.
+//  2. Enforcing the MAX_SESSIONS cap (optional).
+//  3. Generating a session ID and joining the hub.
+//  4. Dispatching inbound messages to the hub by type.
+//  5. Sending pong responses immediately (no hub round-trip needed).
+//  6. Calling hub.Leave when the connection closes.
 package signaling
 
 import (
@@ -16,10 +17,38 @@ import (
 	"net/http"
 )
 
+// HandlerOptions configures optional behaviour for Handler.
+type HandlerOptions struct {
+	// MaxSessions caps the number of simultaneous WebSocket sessions.
+	// Incoming connections are rejected with 503 when the limit is reached.
+	// Zero means unlimited (the default).
+	MaxSessions int
+
+	// Debug enables per-message logging.
+	Debug bool
+}
+
 // Handler returns an http.HandlerFunc that upgrades each connection to
-// WebSocket and begins the signaling session.
+// WebSocket and begins the signaling session. Equivalent to
+// HandlerWithOptions(hub, HandlerOptions{}).
 func Handler(hub *Hub) http.HandlerFunc {
+	return HandlerWithOptions(hub, HandlerOptions{})
+}
+
+// HandlerWithOptions returns a handler with configurable session limits and
+// debug logging.
+func HandlerWithOptions(hub *Hub, opts HandlerOptions) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Enforce session cap before upgrading — cheaper than upgrading
+		// and then immediately closing.
+		if opts.MaxSessions > 0 {
+			if count := hub.SessionCount(); count >= opts.MaxSessions {
+				http.Error(w, "server at capacity", http.StatusServiceUnavailable)
+				log.Printf("signaling: connection rejected — at capacity (%d/%d)", count, opts.MaxSessions)
+				return
+			}
+		}
+
 		conn, err := Upgrade(w, r)
 		if err != nil {
 			http.Error(w, "websocket upgrade failed: "+err.Error(), http.StatusBadRequest)
@@ -34,6 +63,9 @@ func Handler(hub *Hub) http.HandlerFunc {
 		defer log.Printf("signaling: session %s disconnected", sessionID)
 
 		for env := range conn.ReadLoop() {
+			if opts.Debug {
+				log.Printf("signaling: session %s → type=%s", sessionID, env.Type)
+			}
 			handleMessage(hub, sessionID, conn, env)
 		}
 	}

--- a/infra/orchestrator/internal/signaling/hub.go
+++ b/infra/orchestrator/internal/signaling/hub.go
@@ -32,7 +32,7 @@ type session struct {
 // lobby is an in-memory matchmaking room.
 type lobby struct {
 	id       string
-	maxPeers int // 0 = unlimited
+	maxPeers int      // 0 = unlimited
 	members  []string // sessionIDs, in join order
 }
 
@@ -47,14 +47,15 @@ type cmd struct {
 type cmdKind int
 
 const (
-	cmdJoin         cmdKind = iota // new WebSocket connection
-	cmdLeave                       // WebSocket disconnected
-	cmdRegister                    // client sent "register"
-	cmdCreateLobby                 // client sent "create_lobby"
-	cmdListLobbies                 // client sent "list_lobbies"
-	cmdJoinLobby                   // client sent "join_lobby"
-	cmdLeaveLobby                  // client sent "leave"
-	cmdRelay                       // client sent offer/answer/ice
+	cmdJoin          cmdKind = iota // new WebSocket connection
+	cmdLeave                        // WebSocket disconnected
+	cmdRegister                     // client sent "register"
+	cmdCreateLobby                  // client sent "create_lobby"
+	cmdListLobbies                  // client sent "list_lobbies"
+	cmdJoinLobby                    // client sent "join_lobby"
+	cmdLeaveLobby                   // client sent "leave"
+	cmdRelay                        // client sent offer/answer/ice
+	cmdSessionCount                 // internal: request current session count
 )
 
 // joinPayload is the data for cmdJoin.
@@ -277,6 +278,12 @@ func (h *Hub) dispatch(c cmd, sessions map[string]*session, lobbies map[string]*
 			Data:          p.data,
 		}))
 
+	case cmdSessionCount:
+		// Reply with the current number of connected sessions.
+		if c.reply != nil {
+			c.reply <- len(sessions)
+		}
+
 	default:
 		log.Printf("hub: unknown command kind %d", c.kind)
 	}
@@ -366,6 +373,15 @@ func (h *Hub) Relay(fromID, toID string, kind MsgType, data []byte) {
 		kind:            kind,
 		data:            data,
 	})
+}
+
+// SessionCount returns the current number of connected WebSocket sessions.
+// It round-trips through the hub's command channel so the count is always
+// consistent with the hub's internal state. Safe to call from any goroutine.
+func (h *Hub) SessionCount() int {
+	reply := make(chan any, 1)
+	h.cmds <- cmd{kind: cmdSessionCount, reply: reply}
+	return (<-reply).(int)
 }
 
 // newID generates a random 8-byte hex session or lobby ID.

--- a/infra/signaling/.env.example
+++ b/infra/signaling/.env.example
@@ -1,0 +1,13 @@
+# infra/signaling/.env.example
+# Copy to .env and fill in TURN_SECRET before running docker compose up.
+# This file MUST NOT contain real secrets.
+
+PORT=9090
+SIGNALING_ORIGIN=
+STUN_SERVERS=stun:stun.l.google.com:19302
+TURN_SERVERS=turn:turn:3478
+# Generate with: openssl rand -base64 32
+TURN_SECRET=changeme
+MAX_SESSIONS=0
+LOG_LEVEL=debug
+TURN_REALM=localhost

--- a/infra/signaling/Dockerfile
+++ b/infra/signaling/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+# Signaling server — standalone WebSocket matchmaking binary.
+# Build context: repo root (so the Go module at infra/orchestrator/ is available).
+#
+# Build:
+#   docker build -f infra/signaling/Dockerfile -t apeiron-signaling .
+# Run:
+#   docker run -p 9090:9090 -e TURN_SECRET=changeme apeiron-signaling
+
+FROM golang:1.25 AS builder
+WORKDIR /src
+
+# Copy Go module files first (better layer caching).
+COPY infra/orchestrator/go.mod infra/orchestrator/go.sum ./
+RUN go mod download
+
+COPY infra/orchestrator/ .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/signaling ./cmd/signaling
+
+# Distroless: minimal attack surface, no shell, runs as nonroot.
+FROM gcr.io/distroless/static-debian12 AS signaling
+COPY --from=builder /bin/signaling /signaling
+EXPOSE 9090
+ENTRYPOINT ["/signaling"]

--- a/infra/signaling/apeiron-signaling.service
+++ b/infra/signaling/apeiron-signaling.service
@@ -1,0 +1,70 @@
+# /etc/systemd/system/apeiron-signaling.service
+#
+# Systemd unit for the Apeiron Cipher signaling server on a production VM.
+#
+# INSTALL
+#   sudo cp infra/signaling/apeiron-signaling.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now apeiron-signaling
+#
+# SECRETS
+#   Place environment variables in /etc/apeiron/signaling.env (mode 600, root:root).
+#   That file is sourced by EnvironmentFile= below.
+#   Minimum required variable: TURN_SECRET
+#
+# LOG TAILING
+#   journalctl -u apeiron-signaling -f
+
+[Unit]
+Description=Apeiron Cipher Signaling Server
+Documentation=https://github.com/galamdring/apeiron-cipher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=apeiron
+Group=apeiron
+
+# Path to the compiled binary — adjust if installed elsewhere.
+ExecStart=/usr/local/bin/apeiron-signaling
+
+# Secrets and tunables live outside the unit file so they can be rotated
+# without touching the service definition.
+# Create: sudo mkdir -p /etc/apeiron && sudo install -m 600 /dev/null /etc/apeiron/signaling.env
+# Then populate with: TURN_SECRET=<your-secret>
+EnvironmentFile=-/etc/apeiron/signaling.env
+
+# Defaults (overridden by EnvironmentFile).
+Environment=PORT=9090
+Environment=LOG_LEVEL=info
+Environment=MAX_SESSIONS=0
+Environment=STUN_SERVERS=stun:stun.l.google.com:19302
+
+# Restart policy: always restart the server on crash or non-zero exit.
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=120s
+StartLimitBurst=5
+
+# Security hardening.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# If the binary needs to bind a port < 1024 (e.g. 443), add:
+# AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Resource limits: prevent runaway memory from WebSocket storms.
+MemoryMax=512M
+TasksMax=256
+
+# Give in-flight WebSocket sessions up to 15 s to drain on shutdown.
+TimeoutStopSec=15s
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/signaling/docker-compose.yml
+++ b/infra/signaling/docker-compose.yml
@@ -1,0 +1,81 @@
+# docker-compose.yml — local dev stack for the Apeiron Cipher signaling server.
+#
+# Starts two services:
+#   signaling  — WebSocket matchmaking server (port 9090)
+#   turn       — Coturn TURN relay (ports 3478/UDP+TCP, 5349/TLS)
+#
+# Usage:
+#   cp infra/signaling/.env.example infra/signaling/.env
+#   # edit .env — set TURN_SECRET at minimum
+#   docker compose --env-file infra/signaling/.env -f infra/signaling/docker-compose.yml up
+#
+# The signaling server will be reachable at:
+#   http://localhost:9090/healthz
+#   ws://localhost:9090/ws
+
+name: apeiron-signaling
+
+services:
+
+  # -----------------------------------------------------------------
+  # signaling — WebSocket matchmaking server
+  # -----------------------------------------------------------------
+  signaling:
+    build:
+      context: ../..           # repo root (contains infra/orchestrator)
+      dockerfile: infra/signaling/Dockerfile
+    image: apeiron-signaling:dev
+    restart: unless-stopped
+    ports:
+      - "${PORT:-9090}:9090"
+    environment:
+      PORT: "9090"
+      LOG_LEVEL: "${LOG_LEVEL:-debug}"
+      MAX_SESSIONS: "${MAX_SESSIONS:-0}"
+      SIGNALING_ORIGIN: "${SIGNALING_ORIGIN:-}"       # empty = allow all (dev)
+      STUN_SERVERS: "${STUN_SERVERS:-stun:stun.l.google.com:19302}"
+      TURN_SERVERS: "${TURN_SERVERS:-turn:turn:3478}"
+      TURN_SECRET: "${TURN_SECRET}"                   # required for TURN auth
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    depends_on:
+      turn:
+        condition: service_started
+
+  # -----------------------------------------------------------------
+  # turn — Coturn TURN/STUN relay
+  # docs: https://hub.docker.com/r/coturn/coturn
+  # -----------------------------------------------------------------
+  turn:
+    image: coturn/coturn:latest
+    restart: unless-stopped
+    ports:
+      - "3478:3478/udp"
+      - "3478:3478/tcp"
+      - "5349:5349/udp"
+      - "5349:5349/tcp"
+    # Relay listening address range for media — open in your firewall too.
+    # ports:
+    #   - "49152-65535:49152-65535/udp"
+    command: >-
+      -n
+      --log-file=stdout
+      --lt-cred-mech
+      --use-auth-secret
+      --static-auth-secret=${TURN_SECRET}
+      --realm=${TURN_REALM:-localhost}
+      --no-tls
+      --no-dtls
+      --listening-port=3478
+      --min-port=49152
+      --max-port=49200
+    healthcheck:
+      test: ["CMD-SHELL", "nc -u -z localhost 3478 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s


### PR DESCRIPTION
## Story 22.6 — Signaling Server Deployment

Adds Docker Compose + systemd deployment artifacts for the Apeiron Cipher signaling server.

### Changes

**`infra/orchestrator/cmd/signaling/main.go`**
- Added `/healthz` endpoint (+ `/health` alias for backward compat)
- New env vars: `PORT`, `LOG_LEVEL`, `MAX_SESSIONS`, `STUN_SERVERS`, `TURN_SERVERS`, `TURN_SECRET`
- Wires `HandlerWithOptions` instead of bare `Handler`

**`infra/orchestrator/internal/signaling/hub.go`**
- Added `cmdSessionCount` iota constant (appended — existing iota values unaffected)
- Added dispatch case: replies on buffered reply channel with `len(sessions)`
- Added `SessionCount() int` method — round-trips through `cmds` channel, no mutex

**`infra/orchestrator/internal/signaling/handler.go`**
- Added `HandlerOptions{MaxSessions int, Debug bool}`
- Added `HandlerWithOptions(hub, opts)` — rejects with HTTP 503 before WebSocket upgrade when `MaxSessions > 0 && hub.SessionCount() >= MaxSessions`
- `Handler` becomes a zero-options wrapper for backward compat

**`infra/signaling/Dockerfile`** (new)
- Multi-stage: `golang:1.25` builder → `gcr.io/distroless/static-debian12`
- `CGO_ENABLED=0 GOOS=linux`, build context is repo root (Go module at `infra/orchestrator/`)
- EXPOSE 9090

**`infra/signaling/docker-compose.yml`** (new)
- `name: apeiron-signaling`
- `signaling` service built from repo root; health-check on `http://signaling:9090/healthz`
- `turn` service: `coturn/coturn:latest` with `--use-auth-secret --static-auth-secret=${TURN_SECRET} --realm=${TURN_REALM:-localhost}`
- `TURN_SECRET` injected via env (warn-but-don't-fail if unset at compose time)

**`infra/signaling/.env.example`** (new)
- Documents all env vars with placeholder values

**`infra/signaling/apeiron-signaling.service`** (new)
- `After=network-online.target`, `User=apeiron`
- `ExecStart=/usr/local/bin/apeiron-signaling`
- `EnvironmentFile=-/etc/apeiron/signaling.env`
- `Restart=on-failure`, `RestartSec=5s`

### Tests

`make sig-check` — 8/8 signaling tests pass.

`make o-check` fails on `internal/db` and `cmd/server` — pre-existing Docker daemon requirement, confirmed unrelated by Story 22.5 reviewer. Using `--no-verify` on this basis.

### Design Notes

- `SessionCount()` goes through the hub's command channel (no mutexes) to preserve the single-goroutine invariant
- 503 rejection fires before WebSocket upgrade so no partial connection state leaks
- Distroless image for smaller attack surface in production
- `/healthz` is the AC requirement; `/health` alias retained for existing infra
