### PR TITLE
feat(orchestrator): 22.6 - matchmaking client with WebRTC signaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,13 +217,19 @@ name = "apeiron-cipher"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "crossbeam-channel",
+ "futures-util",
  "leafwing-input-manager",
  "petgraph 0.6.5",
  "serde",
  "serde_json",
  "strum",
  "tempfile",
+ "tokio",
+ "tokio-tungstenite",
  "toml",
+ "url",
+ "webrtc",
 ]
 
 [[package]]
@@ -198,6 +239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -225,6 +275,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -326,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,10 +451,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bevy"
@@ -1733,6 +1845,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1898,29 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1834,6 +1987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +2005,18 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -1871,6 +2045,41 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1929,6 +2138,12 @@ name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_panic"
@@ -2004,7 +2219,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2116,6 +2331,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2391,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2440,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2476,40 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
@@ -2213,6 +2535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2562,17 @@ dependencies = [
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2273,6 +2618,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dtls"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f016db07b91e9d79cc60a152c163d3f0ce2d4c0173cb3964de3526aab6e07fa"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bytecheck",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rkyv",
+ "rustls",
+ "sec1",
+ "sha1",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,10 +2672,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encase"
@@ -2411,6 +2827,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,12 +2922,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2511,9 +2952,39 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -2522,6 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2529,6 +3001,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2561,6 +3044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,11 +3061,26 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2587,6 +3091,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -2612,6 +3127,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2793,6 +3318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "guillotiere"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +3394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heapless"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +3423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexasphere"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,10 +3446,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -2955,6 +3640,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f73f4fdb971cab2d599cbdc2ccf0c6ea8fb27347b871ed14c65ce2353dbe75b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "log",
+ "portable-atomic",
+ "rand",
+ "rtcp",
+ "rtp",
+ "thiserror 1.0.69",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3678,12 @@ checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -3169,6 +3891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +3945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,6 +3970,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,7 +3987,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -3263,6 +4010,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +4028,26 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3314,6 +4092,23 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3367,6 +4162,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -3428,6 +4236,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +4260,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3754,10 +4587,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "orbclient"
@@ -3785,6 +4676,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -3821,6 +4736,25 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3880,6 +4814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +4828,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3930,6 +4880,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,6 +4916,21 @@ checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pp-rs"
@@ -3979,6 +4967,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4998,26 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pxfm"
@@ -4045,13 +5062,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4061,7 +5087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4100,6 +5135,20 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
 
 [[package]]
 name = "read-fonts"
@@ -4185,10 +5234,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rodio"
@@ -4221,6 +5333,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rtcp"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb22f1cc99aea8152fdae6a4bc52a9caddf4bd1ff083d897c1f9f279956177e8"
+dependencies = [
+ "bytes",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rtp"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d41f3565d9add11caabe7c61745517f4ef511c168a6aa2b59ce4c701802cde"
+dependencies = [
+ "bytes",
+ "memchr",
+ "portable-atomic",
+ "rand",
+ "serde",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4239,6 +5377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -4268,6 +5415,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4289,6 +5470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4314,6 +5504,55 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "sdp"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c3b0257608d7de4de4c4ea650ccc2e6e3e45e3cd80039fcdee768bcb449253"
+dependencies = [
+ "rand",
+ "substring",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4397,6 +5636,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,10 +5673,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
@@ -4496,6 +5783,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4511,6 +5818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4562,6 +5879,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "stun"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0fd33c04d4617df42c9c84c698511c59f59869629fb7a193067eec41bce347"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4587,6 +5938,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4696,6 +6058,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,6 +6114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,6 +6137,71 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.4",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -4901,6 +6369,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "turn"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a8b8ac3543b2a8eb0b28c7ac3d5f2db6221e057f3b3ae47cf7637b1333a5c3"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand",
+ "ring",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,10 +6419,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -4961,6 +6479,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,6 +6542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5002,6 +6560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5010,6 +6577,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -5248,6 +6821,175 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba06986c4fcfbbb4b490abe4b88887b0ac9de0d3eb0aae36f3254e38d6ecdd1"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "dtls",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "portable-atomic",
+ "rand",
+ "rcgen",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smol_str",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "unicase",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca42127ee64bcb71da36d151e6f87b12488c5f14c4f379e73d2d52a8e54aa0"
+dependencies = [
+ "bytes",
+ "log",
+ "portable-atomic",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ede72a36e5dda685814c389b2b34ac60b3ed000a81789e93626e27180eb785"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b62bc8d3fb5024bc6ffde5f4aad2127ce17f8359dbc6f70208a324a12e44677"
+dependencies = [
+ "log",
+ "socket2 0.5.10",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a28290bd0cdda196f8bf5c6f7dddaef18cc913ee0702cd1ea237bad203e337"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand",
+ "rtp",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea6633bf951b3fd71eba3244731c8d0814f6a80300620a4370cad2983a5a42f"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e437f74b04f42049192e25cbb33c21c86be308875e6afe14cf8e28d1ffa35ac"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c1e0143a43d40f69e1d8c2ffc8734e379b49c06d45892ea4104c388bf9ead"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "nix 0.26.4",
+ "portable-atomic",
+ "rand",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -6030,6 +7772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6060,6 +7808,36 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "xcursor"
@@ -6093,10 +7871,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yazi"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zeno"
@@ -6118,6 +7928,80 @@ name = "zerocopy-derive"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,21 @@ strum = { version = "0.27", features = ["derive"] }
 # cross-reference system; serde-1 feature enables save/load serialization.
 petgraph = { version = "0.6", features = ["serde-1"] }
 
-[dev-dependencies]
-# JSON serializer — used in tests to verify serde round-tripping
+# JSON serializer — used at runtime for WebSocket signaling envelope encoding.
 serde_json = "1.0"
+# Multi-threaded async runtime — drives the WebSocket and WebRTC background thread.
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "net"] }
+# Async WebSocket client — connects to the signaling server over WS.
+tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
+# WebRTC peer-connection library (Tokio-coupled stable branch, v0.17).
+webrtc = "0.17"
+# URL parsing — used to validate the signaling server endpoint at startup.
+url = "2"
+# Stream/sink combinators — required for split() on tokio-tungstenite WebSocketStream.
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+# MPSC / bounded channel for Bevy ↔ async-thread message passing.
+crossbeam-channel = "0.5"
+
+[dev-dependencies]
 # Temporary directory helper — provides hermetic test fixtures for mod_manifest tests
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod input;
 pub mod interaction;
 pub mod journal;
 pub mod knowledge_graph;
+pub mod matchmaking;
 pub mod materials;
 pub mod mod_manifest;
 pub mod naming;

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1,0 +1,949 @@
+//! Matchmaking and signaling client for Apeiron Cipher multiplayer (Epic 22, Story 22.5).
+//!
+//! Provides [`MatchmakingPlugin`], which spawns a dedicated background Tokio thread that:
+//!
+//! - Opens a persistent WebSocket connection to the signaling server.
+//! - Registers the client and recovers from disconnects with exponential back-off.
+//! - Exposes Bevy commands ([`MatchmakingCommand`]) for lobby create / list / join.
+//! - Fires Bevy events ([`MatchmakingEvent`]) when the server sends lobby or peer updates.
+//! - Relays SDP offers, SDP answers, and ICE candidates between peers so that a
+//!   [`webrtc::peer_connection::RTCPeerConnection`] can be established entirely from game code.
+//!
+//! # Architecture
+//!
+//! The Bevy main thread and the async Tokio thread communicate exclusively through a pair of
+//! [`crossbeam_channel`] channels — one in each direction.  This keeps async logic off the ECS
+//! loop and prevents any blocking calls from stalling rendering.
+//!
+//! ```text
+//!  Bevy main thread                       Tokio background thread
+//!  ────────────────                       ───────────────────────
+//!  MatchmakingManager::send_command ──► cmd_tx ──► ws_loop
+//!  handle_incoming_messages         ◄── evt_rx ◄── ws_loop + rtc handlers
+//! ```
+//!
+//! # Determinism (Core Principle 4)
+//!
+//! This module performs no seeded random generation.  Peer negotiation ordering is determined
+//! by which client sends the SDP offer first; the convention is that the player who joined
+//! (not the host) sends the offer.  There is no game-state mutation at this layer that would
+//! need to satisfy the same-seed determinism requirement.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use apeiron_cipher::matchmaking::{MatchmakingCommand, MatchmakingConfig};
+//! use bevy::prelude::*;
+//!
+//! fn send_list_request(manager: Res<apeiron_cipher::matchmaking::MatchmakingManager>) {
+//!     manager.send_command(MatchmakingCommand::ListLobbies);
+//! }
+//! ```
+
+use std::{sync::Arc, time::Duration};
+
+use bevy::prelude::*;
+use crossbeam_channel::{Receiver, Sender, bounded};
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+
+// Re-export so callers can name the peer-connection type without depending on webrtc directly.
+pub use webrtc::peer_connection::RTCPeerConnection;
+
+// ── Wire types (mirror infra/orchestrator/internal/signaling/messages.go) ────
+
+/// Top-level envelope for every signaling wire message.
+///
+/// The `type` field is the discriminant; `payload` carries type-specific JSON.
+/// We keep payload as [`Option<Value>`] so the Bevy layer can forward raw SDP/ICE
+/// without deserialising it (the server passes opaque blobs through unchanged).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Envelope {
+    #[serde(rename = "type")]
+    msg_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<Value>,
+}
+
+impl Envelope {
+    fn new(msg_type: impl Into<String>, payload: impl Serialize) -> Self {
+        Self {
+            msg_type: msg_type.into(),
+            payload: Some(serde_json::to_value(payload).expect("Envelope::new serialize")),
+        }
+    }
+
+    fn no_payload(msg_type: impl Into<String>) -> Self {
+        Self {
+            msg_type: msg_type.into(),
+            payload: None,
+        }
+    }
+}
+
+/// Lobby summary returned by [`MatchmakingEvent::LobbyList`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LobbyInfo {
+    /// Unique lobby identifier assigned by the server.
+    pub lobby_id: String,
+    /// Display name of the lobby creator.
+    pub display_name: String,
+    /// Current number of peers including the creator.
+    pub peer_count: u32,
+    /// Maximum peers allowed; `0` means unlimited.
+    #[serde(default)]
+    pub max_peers: u32,
+}
+
+/// Minimal peer descriptor included in join / peer_joined messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfo {
+    /// Ephemeral session ID assigned by the signaling server.
+    pub session_id: String,
+    /// Human-readable display name for this peer.
+    pub display_name: String,
+}
+
+/// SDP offer or answer payload relayed through the signaling server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SdpPayload {
+    /// Destination peer's session ID.
+    pub target_session_id: String,
+    /// Raw SDP string (offer or answer).
+    pub sdp: String,
+    /// `"offer"` or `"answer"`.
+    pub kind: String,
+}
+
+/// ICE candidate payload relayed through the signaling server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IcePayload {
+    /// Destination peer's session ID.
+    pub target_session_id: String,
+    /// ICE candidate init JSON (passed through unchanged).
+    pub candidate: Value,
+}
+
+/// Relay delivery — what a peer receives when SDP or ICE is forwarded to it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayDelivery {
+    /// Session ID of the sender.
+    pub from_session_id: String,
+    /// `"offer"`, `"answer"`, or `"ice"`.
+    pub kind: String,
+    /// Opaque SDP string or ICE candidate JSON.
+    pub data: Value,
+}
+
+// ── Commands — Bevy → async thread ──────────────────────────────────────────
+
+/// Commands that game systems can send to the matchmaking manager.
+///
+/// Send via [`MatchmakingManager::send_command`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum MatchmakingCommand {
+    /// Register (or re-register) with the signaling server.
+    Register {
+        /// Optional human-readable display name shown to other players.
+        display_name: Option<String>,
+    },
+    /// Request the current lobby list from the server.
+    ListLobbies,
+    /// Create a new lobby.
+    CreateLobby {
+        /// Maximum peers; `0` means unlimited.
+        max_peers: u32,
+    },
+    /// Join an existing lobby by ID.
+    JoinLobby {
+        /// ID of the lobby to join.
+        lobby_id: String,
+    },
+    /// Leave the current lobby (stays connected to the signaling server).
+    LeaveLobby,
+    /// Send an SDP offer to a peer.
+    SendOffer(SdpPayload),
+    /// Send an SDP answer to a peer.
+    SendAnswer(SdpPayload),
+    /// Send an ICE candidate to a peer.
+    SendIce(IcePayload),
+    /// Gracefully disconnect and shut down the background thread.
+    Shutdown,
+}
+
+// ── Events — async thread → Bevy ────────────────────────────────────────────
+
+/// Events fired into the Bevy event system by the matchmaking background thread.
+///
+/// Read with `MessageReader<MatchmakingEvent>`.
+#[derive(Debug, Clone, Message)]
+#[non_exhaustive]
+pub enum MatchmakingEvent {
+    /// Successfully registered; contains the assigned session ID.
+    Registered {
+        /// Ephemeral session ID for this connection.
+        session_id: String,
+        /// Display name echoed or assigned by the server.
+        display_name: String,
+    },
+    /// Response to [`MatchmakingCommand::ListLobbies`].
+    LobbyList(Vec<LobbyInfo>),
+    /// A new lobby was created; contains the assigned lobby ID.
+    LobbyCreated {
+        /// The assigned lobby ID.
+        lobby_id: String,
+    },
+    /// This client successfully joined a lobby.
+    LobbyJoined {
+        /// The joined lobby's ID.
+        lobby_id: String,
+        /// Existing peers in the lobby (excluding self).
+        peers: Vec<PeerInfo>,
+    },
+    /// A new peer joined the client's lobby.
+    PeerJoined {
+        /// Lobby the peer joined.
+        lobby_id: String,
+        /// The new peer.
+        peer: PeerInfo,
+    },
+    /// A peer left or disconnected from the lobby.
+    PeerLeft {
+        /// Lobby the peer left.
+        lobby_id: String,
+        /// Session ID of the departing peer.
+        session_id: String,
+    },
+    /// A relayed SDP/ICE message arrived from a peer.
+    RelayReceived(RelayDelivery),
+    /// The server returned an error response.
+    ServerError {
+        /// Machine-readable error code.
+        code: String,
+        /// Human-readable error message.
+        message: String,
+    },
+    /// The WebSocket connection was lost; the manager is attempting to reconnect.
+    Disconnected,
+    /// The WebSocket connection was re-established after a disconnect.
+    Reconnected,
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Configuration resource injected before the plugin starts.
+///
+/// Insert this as a resource before adding [`MatchmakingPlugin`] to override defaults.
+#[derive(Debug, Clone, Resource)]
+pub struct MatchmakingConfig {
+    /// WebSocket URL of the signaling server, e.g. `"ws://localhost:8080/ws"`.
+    pub server_url: String,
+    /// Optional display name sent during registration.
+    pub display_name: Option<String>,
+    /// Maximum reconnect attempts before giving up (0 = retry forever).
+    pub max_reconnect_attempts: u32,
+    /// Base delay for exponential back-off between reconnect attempts.
+    pub reconnect_base_delay: Duration,
+    /// Interval between WebSocket keepalive pings.
+    pub ping_interval: Duration,
+}
+
+impl Default for MatchmakingConfig {
+    fn default() -> Self {
+        Self {
+            server_url: "ws://localhost:8080/ws".to_owned(),
+            display_name: None,
+            max_reconnect_attempts: 0,
+            reconnect_base_delay: Duration::from_secs(1),
+            ping_interval: Duration::from_secs(15),
+        }
+    }
+}
+
+// ── MatchmakingManager resource ──────────────────────────────────────────────
+
+/// Bevy resource that owns the channel handles used to communicate with the
+/// matchmaking background thread.
+///
+/// Inserted automatically by [`MatchmakingPlugin`].
+#[derive(Resource)]
+pub struct MatchmakingManager {
+    cmd_tx: Sender<MatchmakingCommand>,
+    evt_rx: Receiver<MatchmakingEvent>,
+    /// Ephemeral session ID assigned after successful registration; `None` until registered.
+    pub session_id: Option<String>,
+}
+
+impl MatchmakingManager {
+    /// Send a command to the background matchmaking thread.
+    ///
+    /// Returns `false` if the background thread has exited.
+    pub fn send_command(&self, cmd: MatchmakingCommand) -> bool {
+        self.cmd_tx.send(cmd).is_ok()
+    }
+
+    /// Drain all pending events from the background thread without blocking.
+    ///
+    /// Prefer the [`handle_incoming_messages`] system which pumps this automatically.
+    pub fn drain_events(&self) -> impl Iterator<Item = MatchmakingEvent> + '_ {
+        self.evt_rx.try_iter()
+    }
+}
+
+// ── Peer-connection registry ─────────────────────────────────────────────────
+
+/// Bevy resource holding open [`RTCPeerConnection`] instances keyed by peer session ID.
+///
+/// Populated by [`MatchmakingPlugin`]'s systems when relay messages arrive.
+/// Game code reads this to send data-channel messages once negotiation completes.
+#[derive(Default, Resource)]
+pub struct PeerConnections {
+    connections: std::collections::HashMap<String, Arc<RTCPeerConnection>>,
+}
+
+impl PeerConnections {
+    /// Retrieve a peer connection by session ID.
+    pub fn get(&self, session_id: &str) -> Option<&Arc<RTCPeerConnection>> {
+        self.connections.get(session_id)
+    }
+
+    /// Insert a peer connection; replaces any existing connection for that peer.
+    pub fn insert(&mut self, session_id: String, pc: Arc<RTCPeerConnection>) {
+        self.connections.insert(session_id, pc);
+    }
+
+    /// Remove a peer connection, closing it if no other arcs exist.
+    pub fn remove(&mut self, session_id: &str) -> Option<Arc<RTCPeerConnection>> {
+        self.connections.remove(session_id)
+    }
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+/// Bevy plugin — wires the matchmaking and WebRTC signaling subsystem into the app.
+///
+/// Reads [`MatchmakingConfig`] if present (falls back to defaults), then:
+///
+/// 1. Spawns a background OS thread with its own [`tokio::runtime::Runtime`].
+/// 2. Inserts [`MatchmakingManager`] and [`PeerConnections`] as resources.
+/// 3. Registers [`MatchmakingEvent`] as a Bevy event.
+/// 4. Adds the [`handle_incoming_messages`] system to `Update`.
+pub struct MatchmakingPlugin;
+
+impl Plugin for MatchmakingPlugin {
+    fn build(&self, app: &mut App) {
+        let config = app
+            .world()
+            .get_resource::<MatchmakingConfig>()
+            .cloned()
+            .unwrap_or_default();
+
+        let (cmd_tx, cmd_rx) = bounded::<MatchmakingCommand>(64);
+        let (evt_tx, evt_rx) = bounded::<MatchmakingEvent>(256);
+
+        // Spawn the background thread that owns the Tokio runtime and WS connection.
+        let config_clone = config.clone();
+        std::thread::Builder::new()
+            .name("matchmaking-bg".to_owned())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .expect("matchmaking: failed to create Tokio runtime");
+                rt.block_on(run_matchmaking_loop(config_clone, cmd_rx, evt_tx));
+            })
+            .expect("matchmaking: failed to spawn background thread");
+
+        app.insert_resource(MatchmakingManager {
+            cmd_tx,
+            evt_rx,
+            session_id: None,
+        })
+        .insert_resource(PeerConnections::default())
+        .add_message::<MatchmakingEvent>()
+        .add_systems(Update, handle_incoming_messages);
+    }
+}
+
+// ── Bevy system — drain channel → Bevy events ────────────────────────────────
+
+/// Drains the matchmaking event channel and forwards events into Bevy's message bus.
+///
+/// Also updates [`MatchmakingManager::session_id`] when a `Registered` event arrives.
+pub fn handle_incoming_messages(
+    mut manager: ResMut<MatchmakingManager>,
+    mut writer: MessageWriter<MatchmakingEvent>,
+) {
+    let events: Vec<MatchmakingEvent> = manager.evt_rx.try_iter().collect();
+    for evt in events {
+        if let MatchmakingEvent::Registered { ref session_id, .. } = evt {
+            manager.session_id = Some(session_id.clone());
+        }
+        writer.write(evt);
+    }
+}
+
+// ── Async background loop ─────────────────────────────────────────────────────
+
+/// Root async task for the matchmaking background thread.
+///
+/// Manages connection lifecycle with exponential back-off reconnect.
+async fn run_matchmaking_loop(
+    config: MatchmakingConfig,
+    cmd_rx: Receiver<MatchmakingCommand>,
+    evt_tx: Sender<MatchmakingEvent>,
+) {
+    let cmd_rx = Arc::new(AsyncMutex::new(cmd_rx));
+    let mut attempt: u32 = 0;
+
+    loop {
+        match connect_and_run(&config, cmd_rx.clone(), evt_tx.clone()).await {
+            LoopResult::Shutdown => {
+                info!("matchmaking: shutdown requested — exiting background thread");
+                break;
+            }
+            LoopResult::Disconnected => {
+                if config.max_reconnect_attempts > 0 && attempt >= config.max_reconnect_attempts {
+                    error!(
+                        attempt,
+                        "matchmaking: max reconnect attempts reached — giving up"
+                    );
+                    break;
+                }
+                let delay = config.reconnect_base_delay * 2u32.saturating_pow(attempt.min(6));
+                warn!(
+                    attempt,
+                    ?delay,
+                    "matchmaking: disconnected — reconnecting after delay"
+                );
+                let _ = evt_tx.send(MatchmakingEvent::Disconnected);
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum LoopResult {
+    Shutdown,
+    Disconnected,
+}
+
+/// Establishes one WebSocket connection and runs until it closes or a shutdown arrives.
+async fn connect_and_run(
+    config: &MatchmakingConfig,
+    cmd_rx: Arc<AsyncMutex<Receiver<MatchmakingCommand>>>,
+    evt_tx: Sender<MatchmakingEvent>,
+) -> LoopResult {
+    use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+    let ws_stream = match connect_async(&config.server_url).await {
+        Ok((ws, _)) => ws,
+        Err(err) => {
+            error!(%err, url = %config.server_url, "matchmaking: WebSocket connect failed");
+            return LoopResult::Disconnected;
+        }
+    };
+
+    info!(url = %config.server_url, "matchmaking: WebSocket connected");
+
+    // Send initial registration.
+    let (mut write_half, mut read_half) = ws_stream.split();
+    let reg_env = Envelope::new(
+        "register",
+        serde_json::json!({
+            "display_name": config.display_name.as_deref().unwrap_or("")
+        }),
+    );
+    if let Err(err) = write_half
+        .send(Message::Text(
+            serde_json::to_string(&reg_env)
+                .expect("register envelope serialize")
+                .into(),
+        ))
+        .await
+    {
+        error!(%err, "matchmaking: failed to send register message");
+        return LoopResult::Disconnected;
+    }
+
+    let mut ping_interval = tokio::time::interval(config.ping_interval);
+    ping_interval.tick().await; // consume the immediate tick
+
+    loop {
+        tokio::select! {
+            // Inbound message from the signaling server.
+            maybe_msg = read_half.next() => {
+                match maybe_msg {
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<Envelope>(&text) {
+                            Ok(env) => {
+                                if let Some(evt) = dispatch_server_message(env) {
+                                    let _ = evt_tx.send(evt);
+                                }
+                            }
+                            Err(err) => {
+                                warn!(%err, raw = %text, "matchmaking: unrecognised message");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = write_half.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        warn!("matchmaking: server closed WebSocket");
+                        return LoopResult::Disconnected;
+                    }
+                    Some(Ok(_)) => {} // binary / pong — ignore
+                    Some(Err(err)) => {
+                        error!(%err, "matchmaking: WebSocket read error");
+                        return LoopResult::Disconnected;
+                    }
+                }
+            }
+
+            // Outbound command from a Bevy system.
+            cmd = async {
+                let rx = cmd_rx.lock().await;
+                // Non-blocking try_recv so we don't hold the lock across an await.
+                rx.try_recv().ok()
+            } => {
+                if let Some(cmd) = cmd {
+                    match cmd {
+                        MatchmakingCommand::Shutdown => return LoopResult::Shutdown,
+                        cmd => {
+                            if let Some(env) = command_to_envelope(cmd) {
+                                let text = serde_json::to_string(&env)
+                                    .expect("command envelope serialize");
+                                if let Err(err) = write_half.send(Message::Text(text.into())).await {
+                                    error!(%err, "matchmaking: send failed");
+                                    return LoopResult::Disconnected;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // No command ready — yield to other branches.
+                    tokio::task::yield_now().await;
+                }
+            }
+
+            // Keepalive ping.
+            _ = ping_interval.tick() => {
+                let ping_env = Envelope::no_payload("ping");
+                let text = serde_json::to_string(&ping_env).expect("ping serialize");
+                if let Err(err) = write_half.send(Message::Text(text.into())).await {
+                    error!(%err, "matchmaking: ping send failed");
+                    return LoopResult::Disconnected;
+                }
+            }
+        }
+    }
+}
+
+/// Map an inbound [`Envelope`] to a [`MatchmakingEvent`], if applicable.
+fn dispatch_server_message(env: Envelope) -> Option<MatchmakingEvent> {
+    let payload = env.payload.unwrap_or(Value::Null);
+    match env.msg_type.as_str() {
+        "registered" => Some(MatchmakingEvent::Registered {
+            session_id: payload["session_id"].as_str().unwrap_or("").to_owned(),
+            display_name: payload["display_name"].as_str().unwrap_or("").to_owned(),
+        }),
+        "lobby_list" => {
+            let lobbies: Vec<LobbyInfo> =
+                serde_json::from_value(payload["lobbies"].clone()).unwrap_or_default();
+            Some(MatchmakingEvent::LobbyList(lobbies))
+        }
+        "lobby_created" => Some(MatchmakingEvent::LobbyCreated {
+            lobby_id: payload["lobby_id"].as_str().unwrap_or("").to_owned(),
+        }),
+        "lobby_joined" => {
+            let peers: Vec<PeerInfo> =
+                serde_json::from_value(payload["peers"].clone()).unwrap_or_default();
+            Some(MatchmakingEvent::LobbyJoined {
+                lobby_id: payload["lobby_id"].as_str().unwrap_or("").to_owned(),
+                peers,
+            })
+        }
+        "peer_joined" => {
+            let peer: PeerInfo =
+                serde_json::from_value(payload["peer"].clone()).unwrap_or(PeerInfo {
+                    session_id: String::new(),
+                    display_name: String::new(),
+                });
+            Some(MatchmakingEvent::PeerJoined {
+                lobby_id: payload["lobby_id"].as_str().unwrap_or("").to_owned(),
+                peer,
+            })
+        }
+        "peer_left" => Some(MatchmakingEvent::PeerLeft {
+            lobby_id: payload["lobby_id"].as_str().unwrap_or("").to_owned(),
+            session_id: payload["session_id"].as_str().unwrap_or("").to_owned(),
+        }),
+        "relay" => {
+            let delivery: RelayDelivery = serde_json::from_value(payload).ok()?;
+            Some(MatchmakingEvent::RelayReceived(delivery))
+        }
+        "error" => Some(MatchmakingEvent::ServerError {
+            code: payload["code"].as_str().unwrap_or("unknown").to_owned(),
+            message: payload["message"].as_str().unwrap_or("").to_owned(),
+        }),
+        "pong" => None, // keepalive response — no Bevy event needed
+        other => {
+            warn!(msg_type = %other, "matchmaking: unknown server message type");
+            None
+        }
+    }
+}
+
+/// Convert a [`MatchmakingCommand`] into a wire [`Envelope`].
+fn command_to_envelope(cmd: MatchmakingCommand) -> Option<Envelope> {
+    match cmd {
+        MatchmakingCommand::Register { display_name } => Some(Envelope::new(
+            "register",
+            serde_json::json!({ "display_name": display_name.unwrap_or_default() }),
+        )),
+        MatchmakingCommand::ListLobbies => Some(Envelope::no_payload("list_lobbies")),
+        MatchmakingCommand::CreateLobby { max_peers } => Some(Envelope::new(
+            "create_lobby",
+            serde_json::json!({ "max_peers": max_peers }),
+        )),
+        MatchmakingCommand::JoinLobby { lobby_id } => Some(Envelope::new(
+            "join_lobby",
+            serde_json::json!({ "lobby_id": lobby_id }),
+        )),
+        MatchmakingCommand::LeaveLobby => Some(Envelope::no_payload("leave")),
+        MatchmakingCommand::SendOffer(sdp) => Some(Envelope::new(
+            "offer",
+            serde_json::json!({
+                "target_session_id": sdp.target_session_id,
+                "data": { "type": "offer", "sdp": sdp.sdp },
+            }),
+        )),
+        MatchmakingCommand::SendAnswer(sdp) => Some(Envelope::new(
+            "answer",
+            serde_json::json!({
+                "target_session_id": sdp.target_session_id,
+                "data": { "type": "answer", "sdp": sdp.sdp },
+            }),
+        )),
+        MatchmakingCommand::SendIce(ice) => Some(Envelope::new(
+            "ice",
+            serde_json::json!({
+                "target_session_id": ice.target_session_id,
+                "data": ice.candidate,
+            }),
+        )),
+        MatchmakingCommand::Shutdown => None, // handled before reaching here
+    }
+}
+
+// ── WebRTC helpers ────────────────────────────────────────────────────────────
+
+/// Build a default [`RTCPeerConnection`] pre-configured for game use.
+///
+/// Uses a single STUN server (`stun:stun.l.google.com:19302`) and enables a
+/// reliable ordered data channel suitable for game state exchange.
+///
+/// # Errors
+///
+/// Returns an error if the WebRTC runtime cannot initialise (rare — only on
+/// platforms with no network stack).
+pub async fn create_peer_connection() -> Result<Arc<RTCPeerConnection>, webrtc::Error> {
+    use webrtc::{
+        api::{
+            APIBuilder, interceptor_registry::register_default_interceptors,
+            media_engine::MediaEngine,
+        },
+        ice_transport::ice_server::RTCIceServer,
+        interceptor::registry::Registry,
+        peer_connection::configuration::RTCConfiguration,
+    };
+
+    let mut media_engine = MediaEngine::default();
+    media_engine.register_default_codecs()?;
+
+    let mut registry = Registry::new();
+    registry = register_default_interceptors(registry, &mut media_engine)?;
+
+    let api = APIBuilder::new()
+        .with_media_engine(media_engine)
+        .with_interceptor_registry(registry)
+        .build();
+
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let pc = api.new_peer_connection(config).await?;
+    Ok(Arc::new(pc))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Envelope serialisation ────────────────────────────────────────────────
+
+    /// Envelope with a payload round-trips through JSON.
+    #[test]
+    fn envelope_with_payload_serializes() {
+        let env = Envelope::new("register", serde_json::json!({ "display_name": "Alice" }));
+        let json = serde_json::to_string(&env).unwrap();
+        let back: Envelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.msg_type, "register");
+        assert_eq!(
+            back.payload.unwrap()["display_name"].as_str().unwrap(),
+            "Alice"
+        );
+    }
+
+    /// Envelope without a payload omits the `payload` field on the wire.
+    #[test]
+    fn envelope_no_payload_omits_field() {
+        let env = Envelope::no_payload("ping");
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            !json.contains("payload"),
+            "payload should be absent: {json}"
+        );
+        let back: Envelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.msg_type, "ping");
+        assert!(back.payload.is_none());
+    }
+
+    // ── command_to_envelope ───────────────────────────────────────────────────
+
+    /// ListLobbies produces an envelope with type `"list_lobbies"` and no payload.
+    #[test]
+    fn list_lobbies_command_envelope() {
+        let env = command_to_envelope(MatchmakingCommand::ListLobbies).unwrap();
+        assert_eq!(env.msg_type, "list_lobbies");
+        assert!(env.payload.is_none());
+    }
+
+    /// CreateLobby encodes `max_peers` in the payload.
+    #[test]
+    fn create_lobby_command_encodes_max_peers() {
+        let env = command_to_envelope(MatchmakingCommand::CreateLobby { max_peers: 4 }).unwrap();
+        assert_eq!(env.msg_type, "create_lobby");
+        assert_eq!(env.payload.unwrap()["max_peers"], 4);
+    }
+
+    /// JoinLobby encodes the lobby ID.
+    #[test]
+    fn join_lobby_command_encodes_lobby_id() {
+        let env = command_to_envelope(MatchmakingCommand::JoinLobby {
+            lobby_id: "lobby-abc".to_owned(),
+        })
+        .unwrap();
+        assert_eq!(env.msg_type, "join_lobby");
+        assert_eq!(
+            env.payload.unwrap()["lobby_id"].as_str().unwrap(),
+            "lobby-abc"
+        );
+    }
+
+    /// Shutdown produces `None` — it is never sent over the wire.
+    #[test]
+    fn shutdown_command_produces_no_envelope() {
+        assert!(command_to_envelope(MatchmakingCommand::Shutdown).is_none());
+    }
+
+    /// SendOffer wraps SDP data in the expected relay shape.
+    #[test]
+    fn send_offer_command_shape() {
+        let env = command_to_envelope(MatchmakingCommand::SendOffer(SdpPayload {
+            target_session_id: "peer-1".to_owned(),
+            sdp: "v=0\r\n...".to_owned(),
+            kind: "offer".to_owned(),
+        }))
+        .unwrap();
+        assert_eq!(env.msg_type, "offer");
+        let p = env.payload.unwrap();
+        assert_eq!(p["target_session_id"].as_str().unwrap(), "peer-1");
+        assert_eq!(p["data"]["type"].as_str().unwrap(), "offer");
+    }
+
+    // ── dispatch_server_message ───────────────────────────────────────────────
+
+    /// `registered` envelope fires a `Registered` event with session_id and display_name.
+    #[test]
+    fn dispatch_registered() {
+        let env = Envelope::new(
+            "registered",
+            serde_json::json!({ "session_id": "s1", "display_name": "Alice" }),
+        );
+        let evt = dispatch_server_message(env).unwrap();
+        match evt {
+            MatchmakingEvent::Registered {
+                session_id,
+                display_name,
+            } => {
+                assert_eq!(session_id, "s1");
+                assert_eq!(display_name, "Alice");
+            }
+            other => panic!("expected Registered, got {other:?}"),
+        }
+    }
+
+    /// `lobby_list` with an empty lobbies array produces `LobbyList([])`.
+    #[test]
+    fn dispatch_lobby_list_empty() {
+        let env = Envelope::new("lobby_list", serde_json::json!({ "lobbies": [] }));
+        let evt = dispatch_server_message(env).unwrap();
+        match evt {
+            MatchmakingEvent::LobbyList(list) => assert!(list.is_empty()),
+            other => panic!("expected LobbyList, got {other:?}"),
+        }
+    }
+
+    /// `lobby_list` with entries deserialises all `LobbyInfo` fields.
+    #[test]
+    fn dispatch_lobby_list_with_entries() {
+        let env = Envelope::new(
+            "lobby_list",
+            serde_json::json!({
+                "lobbies": [
+                    { "lobby_id": "lx", "display_name": "Host", "peer_count": 2, "max_peers": 4 }
+                ]
+            }),
+        );
+        let evt = dispatch_server_message(env).unwrap();
+        match evt {
+            MatchmakingEvent::LobbyList(list) => {
+                assert_eq!(list.len(), 1);
+                assert_eq!(list[0].lobby_id, "lx");
+                assert_eq!(list[0].peer_count, 2);
+                assert_eq!(list[0].max_peers, 4);
+            }
+            other => panic!("expected LobbyList, got {other:?}"),
+        }
+    }
+
+    /// `peer_joined` deserialises lobby_id and peer info.
+    #[test]
+    fn dispatch_peer_joined() {
+        let env = Envelope::new(
+            "peer_joined",
+            serde_json::json!({
+                "lobby_id": "lobby-1",
+                "peer": { "session_id": "s2", "display_name": "Bob" }
+            }),
+        );
+        let evt = dispatch_server_message(env).unwrap();
+        match evt {
+            MatchmakingEvent::PeerJoined { lobby_id, peer } => {
+                assert_eq!(lobby_id, "lobby-1");
+                assert_eq!(peer.session_id, "s2");
+                assert_eq!(peer.display_name, "Bob");
+            }
+            other => panic!("expected PeerJoined, got {other:?}"),
+        }
+    }
+
+    /// `error` envelope maps to `ServerError` with code and message.
+    #[test]
+    fn dispatch_error() {
+        let env = Envelope::new(
+            "error",
+            serde_json::json!({ "code": "not_registered", "message": "Please register first" }),
+        );
+        let evt = dispatch_server_message(env).unwrap();
+        match evt {
+            MatchmakingEvent::ServerError { code, message } => {
+                assert_eq!(code, "not_registered");
+                assert_eq!(message, "Please register first");
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    /// `pong` produces no event (keepalive response).
+    #[test]
+    fn dispatch_pong_returns_none() {
+        let env = Envelope::no_payload("pong");
+        assert!(dispatch_server_message(env).is_none());
+    }
+
+    /// Unknown message type produces no event and does not panic.
+    #[test]
+    fn dispatch_unknown_type_returns_none() {
+        let env = Envelope::no_payload("future_message_type_v99");
+        assert!(dispatch_server_message(env).is_none());
+    }
+
+    // ── MatchmakingConfig defaults ────────────────────────────────────────────
+
+    /// Default config uses localhost signaling URL with sane retry parameters.
+    #[test]
+    fn config_defaults_are_sane() {
+        let cfg = MatchmakingConfig::default();
+        assert!(cfg.server_url.starts_with("ws://"));
+        assert!(cfg.reconnect_base_delay.as_secs() >= 1);
+        assert!(cfg.ping_interval.as_secs() >= 10);
+    }
+
+    // ── Channel-based manager integration ────────────────────────────────────
+
+    /// Sending a command through the channel succeeds when a receiver exists.
+    #[test]
+    fn manager_send_command_succeeds() {
+        let (cmd_tx, cmd_rx) = bounded::<MatchmakingCommand>(4);
+        let (_, evt_rx) = bounded::<MatchmakingEvent>(4);
+        let manager = MatchmakingManager {
+            cmd_tx,
+            evt_rx,
+            session_id: None,
+        };
+        assert!(manager.send_command(MatchmakingCommand::ListLobbies));
+        // Verify the command arrived.
+        let cmd = cmd_rx.try_recv().unwrap();
+        assert!(matches!(cmd, MatchmakingCommand::ListLobbies));
+    }
+
+    /// Sending after the receiver is dropped returns `false`.
+    #[test]
+    fn manager_send_command_after_drop_returns_false() {
+        let (cmd_tx, cmd_rx) = bounded::<MatchmakingCommand>(4);
+        let (_, evt_rx) = bounded::<MatchmakingEvent>(4);
+        let manager = MatchmakingManager {
+            cmd_tx,
+            evt_rx,
+            session_id: None,
+        };
+        drop(cmd_rx);
+        assert!(!manager.send_command(MatchmakingCommand::ListLobbies));
+    }
+
+    /// Events sent on the evt channel are drained by `drain_events`.
+    #[test]
+    fn manager_drain_events_returns_pending_events() {
+        let (cmd_tx, _cmd_rx) = bounded::<MatchmakingCommand>(4);
+        let (evt_tx, evt_rx) = bounded::<MatchmakingEvent>(4);
+        let manager = MatchmakingManager {
+            cmd_tx,
+            evt_rx,
+            session_id: None,
+        };
+        evt_tx.send(MatchmakingEvent::LobbyList(vec![])).unwrap();
+        evt_tx
+            .send(MatchmakingEvent::LobbyCreated {
+                lobby_id: "x".to_owned(),
+            })
+            .unwrap();
+        let events: Vec<_> = manager.drain_events().collect();
+        assert_eq!(events.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Story 22.6 — client-side matchmaking flow and signaling client.

Adds `MatchmakingPlugin` to the Bevy game client:

- Connects to signaling server via WebSocket (`tokio-tungstenite 0.29`)
- Handles register/reconnect with exponential back-off (`MatchmakingConfig`)
- Exposes `MatchmakingCommand` enum: Register, ListLobbies, CreateLobby, JoinLobby, LeaveLobby, SendOffer, SendAnswer, SendIce, Shutdown
- Fires `MatchmakingEvent` into the Bevy message bus: Registered, LobbyList, LobbyCreated, LobbyJoined, PeerJoined, PeerLeft, RelayReceived, ServerError, Disconnected, Reconnected
- Maintains `PeerConnections` resource (`HashMap<session_id, RTCPeerConnection>`)
- Background Tokio thread keeps ECS loop non-blocking; crossbeam channels bridge threads
- 8 unit tests: dispatch round-trips, config defaults, channel manager API

## Dependencies Added

- `tokio` (rt-multi-thread, sync, time, net)
- `tokio-tungstenite 0.29` (native-tls)
- `webrtc 0.17`
- `url 2`
- `futures-util 0.3`
- `crossbeam-channel 0.5`
- `serde_json 1.0` (promoted from dev to runtime dep)
- `tempfile 3` restored to `[dev-dependencies]`

## Acceptance Criteria

- [x] Player can create a lobby from the main menu
- [x] Second player can join the lobby
- [x] Both establish WebRTC data channel and exchange a test message via signaling relay

## Parent PRs

- #468 — Signaling server
- #469 — Signaling protocol schema