### PR TITLE
feat(persistence): generation-version mismatch detection

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -29,6 +29,46 @@ pub mod schema;
 
 use bevy::prelude::*;
 
+/// Fired by the save loader after it calls
+/// [`schema::SaveHeader::check_generation_version`] and finds that the saved
+/// world-generation algorithm version differs from the currently compiled
+/// [`crate::world_generation::GENERATION_VERSION`].
+///
+/// The event is **not** fired on an exact match — only on a version delta.
+///
+/// # Who emits this
+///
+/// The save loader (a future story) emits this message after decoding the
+/// [`schema::SaveHeader`] and before applying any game state.  For a
+/// `SavedNewer` result the loader also refuses the load; even so it fires this
+/// event first so any subscribed systems (UI, logging) can capture the
+/// diagnosis.
+///
+/// # Who reads this
+///
+/// A future HUD or journal system can subscribe to emit in-world feedback to
+/// the player.  For now the `warn!` logged inside
+/// [`schema::SaveHeader::check_generation_version`] is the canonical
+/// player-visible output.
+///
+/// # Diegetic rule
+///
+/// Any in-game surface for this warning must comply with the diegetic feedback
+/// contract: it may appear as a journal log entry, datapad readout, or console
+/// output, but NOT as a raw HUD popup or tooltip.  The player reads the world;
+/// the world does not narrate itself.
+#[derive(Clone, Debug, Message)]
+pub struct OnSaveGenerationMismatchEvent {
+    /// The generation version stored in the save file.
+    pub saved: u32,
+    /// The generation version compiled into this binary.
+    pub current: u32,
+    /// `true` if the save was created with a *newer* binary and the load must
+    /// be refused.  `false` if the save is older and the load continues with a
+    /// warning.
+    pub is_newer: bool,
+}
+
 /// Bevy plugin that registers the persistence resources.
 ///
 /// Add this to your `App` before any systems that need to emit mutations:
@@ -42,6 +82,10 @@ pub struct PersistencePlugin;
 
 impl Plugin for PersistencePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<mutation::MutationBus>();
+        app.init_resource::<mutation::MutationBus>()
+            // Register the message type so future systems can subscribe.  The
+            // save loader (a future story) will write to this channel after
+            // deserialising a header with a mismatched generation_version.
+            .add_message::<OnSaveGenerationMismatchEvent>();
     }
 }

--- a/src/persistence/schema.rs
+++ b/src/persistence/schema.rs
@@ -36,7 +36,24 @@
 //! mismatch).  A save with a **lower** `generation_version` can be loaded but
 //! must mark any un-revisited chunks as stale so they are re-generated on next
 //! visit.
+//!
+//! # Generation-version mismatch detection
+//!
+//! After deserialising a save file, call [`SaveHeader::check_generation_version`]
+//! to compare the saved algorithm version against the currently compiled
+//! [`crate::world_generation::GENERATION_VERSION`].  The method returns a
+//! [`GenerationVersionCheck`] that tells the loader exactly what to do:
+//!
+//! | Variant | Meaning | Loader action |
+//! |---|---|---|
+//! | [`GenerationVersionCheck::Match`] | Versions are identical. | Proceed normally. |
+//! | [`GenerationVersionCheck::SavedOlder`] | Save was written with an older generator. Unvisited chunks may look different if regenerated. | Log a `warn!`, surface a player-visible message, allow the player to cancel before any state is applied. |
+//! | [`GenerationVersionCheck::SavedNewer`] | Save was written with a *newer* generator than the currently compiled binary. Regenerating chunks would silently corrupt the world. | Refuse to load — return an error to the caller, do not apply any state. |
+//!
+//! See [`SaveHeader::check_generation_version`] for the exact log messages
+//! emitted and the data carried in each variant.
 
+use bevy::log::warn;
 use serde::{Deserialize, Serialize};
 
 /// Current schema version for the binary save format.
@@ -86,6 +103,55 @@ pub struct SaveHeader {
     pub world_seed: u64,
 }
 
+/// Result of comparing a [`SaveHeader::generation_version`] against the
+/// currently compiled [`crate::world_generation::GENERATION_VERSION`].
+///
+/// Returned by [`SaveHeader::check_generation_version`].  The caller (save
+/// loader) uses this to decide whether to proceed, warn, or refuse the load.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenerationVersionCheck {
+    /// The saved generation version matches the compiled constant exactly.
+    ///
+    /// The world will regenerate identically for any unvisited chunks — no
+    /// player action is required.
+    Match,
+
+    /// The save file was written with an *older* world-generation algorithm
+    /// (saved version < compiled version).
+    ///
+    /// Chunks the player has already visited are preserved verbatim.
+    /// Unvisited chunks will be regenerated using the newer algorithm and
+    /// may look different near visit boundaries.  The loader MUST surface a
+    /// player-visible warning before applying any state.
+    ///
+    /// Fields:
+    /// - `saved`: the `generation_version` found in the file.
+    /// - `current`: the compiled [`crate::world_generation::GENERATION_VERSION`].
+    SavedOlder {
+        /// The generation version stored in the save file.
+        saved: u32,
+        /// The generation version compiled into this binary.
+        current: u32,
+    },
+
+    /// The save file was written with a *newer* world-generation algorithm
+    /// (saved version > compiled version).
+    ///
+    /// Regenerating chunks using the older (current) algorithm would
+    /// silently produce different content than the player originally saw.
+    /// **The loader MUST refuse to load and return an error to the caller.**
+    ///
+    /// Fields:
+    /// - `saved`: the `generation_version` found in the file.
+    /// - `current`: the compiled [`crate::world_generation::GENERATION_VERSION`].
+    SavedNewer {
+        /// The generation version stored in the save file.
+        saved: u32,
+        /// The generation version compiled into this binary.
+        current: u32,
+    },
+}
+
 impl SaveHeader {
     /// Constructs a new header for a fresh save.
     ///
@@ -96,6 +162,69 @@ impl SaveHeader {
             schema_version: SAVE_SCHEMA_VERSION,
             generation_version: crate::world_generation::GENERATION_VERSION,
             world_seed,
+        }
+    }
+
+    /// Compares the header's `generation_version` against the currently
+    /// compiled [`crate::world_generation::GENERATION_VERSION`] and returns
+    /// a [`GenerationVersionCheck`] describing the result.
+    ///
+    /// # Side effects
+    ///
+    /// When the result is [`GenerationVersionCheck::SavedOlder`] or
+    /// [`GenerationVersionCheck::SavedNewer`] this method logs a prominent
+    /// `warn!` via `bevy::log` so the mismatch is visible in the application
+    /// log regardless of whether the caller also surfaces a UI message.
+    ///
+    /// # What the caller must do
+    ///
+    /// | Result | Required caller action |
+    /// |---|---|
+    /// | `Match` | Proceed normally. |
+    /// | `SavedOlder` | Surface a player-visible warning (console, dialog, or toast) explaining that the world seed may produce different terrain for unvisited chunks.  Do NOT block loading — the player decides. |
+    /// | `SavedNewer` | Refuse to load entirely.  Return an error up the call stack. Do NOT apply any game state. |
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let header = decode_header(&bytes)?;
+    /// match header.check_generation_version() {
+    ///     GenerationVersionCheck::Match => {}
+    ///     GenerationVersionCheck::SavedOlder { saved, current } => {
+    ///         surface_warning(&format!(
+    ///             "Save file uses world generation v{saved}; this binary uses v{current}. \
+    ///              Unvisited terrain may look different."
+    ///         ));
+    ///         // Continue loading — player was warned.
+    ///     }
+    ///     GenerationVersionCheck::SavedNewer { saved, current } => {
+    ///         return Err(LoadError::GenerationVersionTooNew { saved, current });
+    ///     }
+    /// }
+    /// ```
+    pub fn check_generation_version(&self) -> GenerationVersionCheck {
+        let current = crate::world_generation::GENERATION_VERSION;
+        let saved = self.generation_version;
+
+        match saved.cmp(&current) {
+            std::cmp::Ordering::Equal => GenerationVersionCheck::Match,
+            std::cmp::Ordering::Less => {
+                warn!(
+                    "Save generation version {} differs from current {}; \
+                     world may regenerate differently for unvisited chunks",
+                    saved, current
+                );
+                GenerationVersionCheck::SavedOlder { saved, current }
+            }
+            std::cmp::Ordering::Greater => {
+                warn!(
+                    "Save generation version {} differs from current {}; \
+                     save was created with a newer binary — refusing to load \
+                     to prevent silent world corruption",
+                    saved, current
+                );
+                GenerationVersionCheck::SavedNewer { saved, current }
+            }
         }
     }
 }
@@ -158,5 +287,83 @@ mod tests {
             header.schema_version, SAVE_SCHEMA_VERSION,
             "SaveHeader::schema_version must equal SAVE_SCHEMA_VERSION"
         );
+    }
+
+    // ── generation-version mismatch detection ─────────────────────────────────
+
+    /// A header whose `generation_version` matches the compiled constant must
+    /// return [`GenerationVersionCheck::Match`].
+    #[test]
+    fn check_generation_version_exact_match() {
+        let header = SaveHeader::new(99);
+        assert_eq!(
+            header.check_generation_version(),
+            GenerationVersionCheck::Match,
+            "A fresh header (generation_version == GENERATION_VERSION) must be Match"
+        );
+    }
+
+    /// A header with `generation_version` *lower* than the compiled constant
+    /// must return [`GenerationVersionCheck::SavedOlder`] with the correct
+    /// saved/current fields.
+    #[test]
+    fn check_generation_version_saved_older() {
+        let current = crate::world_generation::GENERATION_VERSION;
+        // Only run this test if bumping would actually produce a lower version.
+        // GENERATION_VERSION is 1 in the shipped codebase; this test uses a
+        // header with generation_version = 0 to exercise the SavedOlder arm.
+        let header = SaveHeader {
+            schema_version: SAVE_SCHEMA_VERSION,
+            generation_version: 0,
+            world_seed: 1,
+        };
+        assert_eq!(
+            header.check_generation_version(),
+            GenerationVersionCheck::SavedOlder { saved: 0, current },
+            "A header with generation_version < GENERATION_VERSION must be SavedOlder"
+        );
+    }
+
+    /// A header with `generation_version` *higher* than the compiled constant
+    /// must return [`GenerationVersionCheck::SavedNewer`] with the correct
+    /// saved/current fields.
+    #[test]
+    fn check_generation_version_saved_newer() {
+        let current = crate::world_generation::GENERATION_VERSION;
+        let future_version = current + 1;
+        let header = SaveHeader {
+            schema_version: SAVE_SCHEMA_VERSION,
+            generation_version: future_version,
+            world_seed: 1,
+        };
+        assert_eq!(
+            header.check_generation_version(),
+            GenerationVersionCheck::SavedNewer {
+                saved: future_version,
+                current
+            },
+            "A header with generation_version > GENERATION_VERSION must be SavedNewer"
+        );
+    }
+
+    /// Verify that [`GenerationVersionCheck`] carries the correct `saved` and
+    /// `current` payload for a multi-version gap — not just a ± 1 delta.
+    #[test]
+    fn check_generation_version_multi_version_gap() {
+        let current = crate::world_generation::GENERATION_VERSION;
+        // Simulate a save that is many versions behind.
+        let old_version = current.saturating_sub(5);
+        let header = SaveHeader {
+            schema_version: SAVE_SCHEMA_VERSION,
+            generation_version: old_version,
+            world_seed: 42,
+        };
+        match header.check_generation_version() {
+            GenerationVersionCheck::SavedOlder { saved, current: c } => {
+                assert_eq!(saved, old_version, "saved must equal the header value");
+                assert_eq!(c, current, "current must equal GENERATION_VERSION");
+            }
+            other => panic!("expected SavedOlder, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Wires up load-time generation-version mismatch detection that was unimplemented after parent PR #446 added the `SaveHeader.generation_version` field and the `GENERATION_VERSION` constant.

## Changes

### `src/persistence/schema.rs`
- **`GenerationVersionCheck` enum** — three variants:
  - `Match` — saved and current versions are identical (no-op path)
  - `SavedOlder { saved, current }` — save pre-dates current binary; loader should warn the player but continue loading
  - `SavedNewer { saved, current }` — save was created with a newer binary; loader **must refuse** the load to avoid data corruption
- **`SaveHeader::check_generation_version()`** — compares `self.generation_version` against `crate::world_generation::GENERATION_VERSION`, emits `warn!` on any mismatch, returns the appropriate variant
- **4 new unit tests**: exact match, saved-older, saved-newer, multi-version gap

### `src/persistence.rs`
- **`OnSaveGenerationMismatchEvent`** (`#[derive(Clone, Debug, Message)]`) — fields: `saved: u32`, `current: u32`, `is_newer: bool`
- Registered via `.add_message::<OnSaveGenerationMismatchEvent>()` in `PersistencePlugin::build`

## Contract for the future save loader
When the loader calls `header.check_generation_version()`:
- `Match` → proceed normally
- `SavedOlder` → send `OnSaveGenerationMismatchEvent { is_newer: false }`, continue loading with a player-visible warning (journal/datapad)
- `SavedNewer` → send `OnSaveGenerationMismatchEvent { is_newer: true }`, **abort the load** — the world state may be incompatible

## Tests
800/800 tests pass. `make check` (fmt + clippy + test + doctest + build) green.

Closes #[link to task if applicable]. Follows on from #446.