### PR TITLE
feat(orchestrator): wire status label transitions into flows

### DIFF
--- a/apeiron_flow/src/apeiron_flow/main.py
+++ b/apeiron_flow/src/apeiron_flow/main.py
@@ -333,6 +333,34 @@ def _find_pr(branch: str) -> int:
     return prs[0]["number"] if prs else 0
 
 
+def _get_issue_for_pr(pr_number: int) -> int:
+    """Return the issue number linked to a PR, or 0 if not determinable.
+
+    Extracts the issue number from the PR's head branch name, which follows
+    the convention 'feat/issue-{N}' set by ApeironFlow.prepare().
+    Falls back to parsing 'Related to #N' in the PR body.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--repo", REPO, "--json", "headRefName,body"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return 0
+    data = json.loads(result.stdout)
+    branch = data.get("headRefName", "")
+    # Primary: extract from branch name 'feat/issue-N' or 'issue-N'
+    m = re.search(r"issue-(\d+)", branch)
+    if m:
+        return int(m.group(1))
+    # Fallback: parse 'Related to #N' from PR body
+    body = data.get("body", "") or ""
+    m = re.search(r"[Rr]elated\s+to\s+#(\d+)", body)
+    if m:
+        return int(m.group(1))
+    return 0
+
+
 def _build_task_description(state: IssueState) -> str:
     resume = _resume_context(state.worktree_path, state.branch) if state.resuming else ""
     arch_principles = _load_arch_principles()
@@ -385,6 +413,15 @@ class ApeironFlow(Flow[IssueState]):
 
         print(f"\nIssue #{self.state.issue_number}: {self.state.issue_title}")
         print("-" * 60)
+
+        try:
+            _labels.transition(
+                self.state.issue_number,
+                _labels.LABEL_IN_PROGRESS,
+                from_label=_labels.LABEL_READY,
+            )
+        except Exception as label_err:
+            print(f"[WARN] Could not transition label to in-progress: {label_err}")
 
     @listen(prepare)
     def implement(self):
@@ -481,6 +518,14 @@ class ApeironFlow(Flow[IssueState]):
     def trigger_review(self):
         """Hand off to the review flow."""
         print(f"\nPR #{self.state.pr_number} opened — starting review...")
+        try:
+            _labels.transition(
+                self.state.issue_number,
+                _labels.LABEL_AGENT_REVIEW,
+                from_label=_labels.LABEL_IN_PROGRESS,
+            )
+        except Exception as label_err:
+            print(f"[WARN] Could not transition label to agent-review: {label_err}")
         review_flow = ReviewFlow()
         review_flow.state.pr_number = self.state.pr_number
         review_flow.kickoff()
@@ -493,6 +538,10 @@ class ApeironFlow(Flow[IssueState]):
         print("BLOCKED — no PR opened. Agent report:")
         print("=" * 60)
         print(self.state.blocker or self.state.result)
+        try:
+            _labels.transition(self.state.issue_number, _labels.LABEL_BLOCKED)
+        except Exception as label_err:
+            print(f"[WARN] Could not transition label to blocked: {label_err}")
 
     @listen("dry_run")
     def report_dry_run(self):
@@ -574,6 +623,18 @@ class ReviewFlow(Flow[ReviewState]):
     def on_code_changes_required(self):
         print(f"\nREVIEW: Code changes required — {self.state.review_url}")
         print(self.state.summary)
+        issue_number = _get_issue_for_pr(self.state.pr_number)
+        if issue_number:
+            try:
+                _labels.transition(
+                    issue_number,
+                    _labels.LABEL_IN_PROGRESS,
+                    from_label=_labels.LABEL_AGENT_REVIEW,
+                )
+            except Exception as label_err:
+                print(f"[WARN] Could not transition label to in-progress: {label_err}")
+        else:
+            print(f"[WARN] Could not determine issue number for PR #{self.state.pr_number} — skipping label transition")
 
     @listen("human_feedback_required")
     def on_human_feedback_required(self):
@@ -584,6 +645,18 @@ class ReviewFlow(Flow[ReviewState]):
     def on_ready_for_merge(self):
         print(f"\nREVIEW: Ready for merge — {self.state.review_url}")
         print(self.state.summary)
+        issue_number = _get_issue_for_pr(self.state.pr_number)
+        if issue_number:
+            try:
+                _labels.transition(
+                    issue_number,
+                    _labels.LABEL_REVIEW,
+                    from_label=_labels.LABEL_AGENT_REVIEW,
+                )
+            except Exception as label_err:
+                print(f"[WARN] Could not transition label to review: {label_err}")
+        else:
+            print(f"[WARN] Could not determine issue number for PR #{self.state.pr_number} — skipping label transition")
 
 
 # ---------------------------------------------------------------------------
@@ -721,6 +794,19 @@ class RespondFlow(Flow[RespondState]):
                 prepare_worktree_for_pr(state.target_number)
             except Exception as e:
                 print(f"[WARN] Could not prepare worktree: {e}")
+            # Transition issue label: status:review → status:in-progress
+            issue_number = _get_issue_for_pr(state.target_number)
+            if issue_number:
+                try:
+                    _labels.transition(
+                        issue_number,
+                        _labels.LABEL_IN_PROGRESS,
+                        from_label=_labels.LABEL_REVIEW,
+                    )
+                except Exception as label_err:
+                    print(f"[WARN] Could not transition label to in-progress: {label_err}")
+            else:
+                print(f"[WARN] Could not determine issue number for PR #{state.target_number} — skipping label transition")
 
         description = (
             f"A commenter (@{author}) has requested a code change on "

--- a/apeiron_flow/src/apeiron_flow/main.py
+++ b/apeiron_flow/src/apeiron_flow/main.py
@@ -806,7 +806,9 @@ class RespondFlow(Flow[RespondState]):
                 except Exception as label_err:
                     print(f"[WARN] Could not transition label to in-progress: {label_err}")
             else:
-                print(f"[WARN] Could not determine issue number for PR #{state.target_number} — skipping label transition")
+                print(
+                    f"[WARN] Could not determine issue number for PR #{state.target_number} — skipping label transition"
+                )
 
         description = (
             f"A commenter (@{author}) has requested a code change on "

--- a/apeiron_flow/tests/test_label_wiring.py
+++ b/apeiron_flow/tests/test_label_wiring.py
@@ -19,15 +19,12 @@ Transitions under test:
 
 import json
 import os
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 # Ensure imports succeed in test environment
 os.environ.setdefault("RESPOND_DB", "/tmp/test_label_wiring.db")
 os.environ.setdefault("APEIRON_REPO_PATH", "/fake/repo")
 
-import apeiron_flow.main as _main
 from apeiron_flow.main import (
     ApeironFlow,
     IssueState,
@@ -35,7 +32,6 @@ from apeiron_flow.main import (
     ReviewState,
     _get_issue_for_pr,
 )
-
 
 # ---------------------------------------------------------------------------
 # helpers

--- a/apeiron_flow/tests/test_label_wiring.py
+++ b/apeiron_flow/tests/test_label_wiring.py
@@ -1,0 +1,465 @@
+"""
+Tests for label transition wiring in ApeironFlow, ReviewFlow, and RespondFlow.
+
+Verifies that each flow method calls _labels.transition() with the correct
+arguments at each state transition, and that label failures are non-fatal
+(logged as warnings, flow continues).
+
+Reference: docs/adr/002-issue-lifecycle-status-labels.md
+
+Transitions under test:
+  ApeironFlow.prepare()              ready → in-progress
+  ApeironFlow.trigger_review()       in-progress → agent-review
+  ApeironFlow.report_blocker()       (any) → blocked
+  ReviewFlow.on_ready_for_merge()    agent-review → review
+  ReviewFlow.on_code_changes_req()   agent-review → in-progress
+  RespondFlow.handle_change_request  review → in-progress  (PR only)
+  _get_issue_for_pr()                branch-name extraction + body fallback
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# Ensure imports succeed in test environment
+os.environ.setdefault("RESPOND_DB", "/tmp/test_label_wiring.db")
+os.environ.setdefault("APEIRON_REPO_PATH", "/fake/repo")
+
+import apeiron_flow.main as _main
+from apeiron_flow.main import (
+    ApeironFlow,
+    IssueState,
+    ReviewFlow,
+    ReviewState,
+    _get_issue_for_pr,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    p = MagicMock()
+    p.returncode = returncode
+    p.stdout = stdout
+    p.stderr = stderr
+    return p
+
+
+def _make_issue_state(
+    issue_number: int = 42,
+    issue_title: str = "Test issue",
+    issue_body: str = "Body",
+    branch: str = "feat/issue-42",
+    worktree_path: str = "/fake/worktree/issue-42",
+    pr_number: int = 0,
+) -> IssueState:
+    s = IssueState()
+    s.issue_number = issue_number
+    s.issue_title = issue_title
+    s.issue_body = issue_body
+    s.branch = branch
+    s.worktree_path = worktree_path
+    s.pr_number = pr_number
+    return s
+
+
+def _make_review_state(pr_number: int = 10, verdict: str = "", summary: str = "", review_url: str = "") -> ReviewState:
+    s = ReviewState()
+    s.pr_number = pr_number
+    s.verdict = verdict
+    s.summary = summary
+    s.review_url = review_url
+    return s
+
+
+def _build_flow(state: IssueState) -> ApeironFlow:
+    flow = ApeironFlow()
+    flow._state = state
+    return flow
+
+
+def _build_review_flow(state: ReviewState) -> ReviewFlow:
+    flow = ReviewFlow()
+    flow._state = state
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# _get_issue_for_pr
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_branch_name(mock_run):
+    """Extracts issue number from 'feat/issue-N' branch name."""
+    mock_run.return_value = _make_proc(
+        0,
+        stdout=json.dumps({"headRefName": "feat/issue-99", "body": "no ref here"}),
+    )
+    assert _get_issue_for_pr(10) == 99
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_bare_issue_branch(mock_run):
+    """Extracts issue number from 'issue-N' branch name without feat/ prefix."""
+    mock_run.return_value = _make_proc(
+        0,
+        stdout=json.dumps({"headRefName": "issue-123", "body": ""}),
+    )
+    assert _get_issue_for_pr(10) == 123
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_body_fallback(mock_run):
+    """Falls back to 'Related to #N' in PR body when branch name has no issue."""
+    mock_run.return_value = _make_proc(
+        0,
+        stdout=json.dumps({"headRefName": "fix/typo", "body": "Related to #77 for context"}),
+    )
+    assert _get_issue_for_pr(10) == 77
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_returns_zero_on_gh_failure(mock_run):
+    """Returns 0 when gh pr view fails."""
+    mock_run.return_value = _make_proc(1, stderr="not found")
+    assert _get_issue_for_pr(10) == 0
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_returns_zero_when_no_match(mock_run):
+    """Returns 0 when neither branch nor body contains an issue reference."""
+    mock_run.return_value = _make_proc(
+        0,
+        stdout=json.dumps({"headRefName": "fix/unrelated-typo", "body": "Misc fix"}),
+    )
+    assert _get_issue_for_pr(10) == 0
+
+
+@patch("apeiron_flow.main.subprocess.run")
+def test_get_issue_for_pr_uses_list_form_no_shell(mock_run):
+    """Verifies no shell=True injection risk."""
+    mock_run.return_value = _make_proc(
+        0,
+        stdout=json.dumps({"headRefName": "feat/issue-1", "body": ""}),
+    )
+    _get_issue_for_pr(5)
+    args, kwargs = mock_run.call_args
+    cmd = args[0]
+    assert isinstance(cmd, list), "gh invocation must be list form"
+    assert kwargs.get("shell") is not True
+
+
+# ---------------------------------------------------------------------------
+# ApeironFlow.prepare() — ready → in-progress
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main.repo.set_worktree_path")
+@patch("apeiron_flow.main._create_worktree", return_value=("/fake/wt", False))
+@patch("apeiron_flow.main._fetch_issue")
+def test_prepare_transitions_to_in_progress(mock_fetch, mock_create_wt, mock_set_path, mock_labels):
+    """prepare() calls transition(issue_number, LABEL_IN_PROGRESS, from_label=LABEL_READY)."""
+    mock_fetch.return_value = {"title": "T", "body": "B", "labels": []}
+    state = _make_issue_state()
+    flow = _build_flow(state)
+    flow.prepare()
+    mock_labels.transition.assert_called_once_with(
+        42,
+        mock_labels.LABEL_IN_PROGRESS,
+        from_label=mock_labels.LABEL_READY,
+    )
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main.repo.set_worktree_path")
+@patch("apeiron_flow.main._create_worktree", return_value=("/fake/wt", False))
+@patch("apeiron_flow.main._fetch_issue")
+def test_prepare_continues_when_label_transition_fails(mock_fetch, mock_create_wt, mock_set_path, mock_labels, capsys):
+    """prepare() logs a warning and continues if label transition raises."""
+    mock_fetch.return_value = {"title": "T", "body": "B", "labels": []}
+    mock_labels.transition.side_effect = RuntimeError("gh failure")
+    state = _make_issue_state()
+    flow = _build_flow(state)
+    # Must not raise
+    flow.prepare()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+    assert "in-progress" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# ApeironFlow.trigger_review() — in-progress → agent-review
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main.ReviewFlow.kickoff")
+def test_trigger_review_transitions_to_agent_review(mock_kickoff, mock_labels):
+    """trigger_review() transitions issue to agent-review before launching ReviewFlow."""
+    state = _make_issue_state(issue_number=42, pr_number=10)
+    flow = _build_flow(state)
+    flow.trigger_review()
+    mock_labels.transition.assert_called_once_with(
+        42,
+        mock_labels.LABEL_AGENT_REVIEW,
+        from_label=mock_labels.LABEL_IN_PROGRESS,
+    )
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main.ReviewFlow.kickoff")
+def test_trigger_review_continues_when_label_fails(mock_kickoff, mock_labels, capsys):
+    """trigger_review() logs warning and still launches ReviewFlow if label fails."""
+    mock_labels.transition.side_effect = RuntimeError("network error")
+    state = _make_issue_state(issue_number=42, pr_number=10)
+    flow = _build_flow(state)
+    flow.trigger_review()
+    mock_kickoff.assert_called_once()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# ApeironFlow.report_blocker() — (any) → blocked
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+def test_report_blocker_transitions_to_blocked(mock_labels):
+    """report_blocker() transitions issue to blocked."""
+    state = _make_issue_state(issue_number=42)
+    state.blocker = "some blocker"
+    flow = _build_flow(state)
+    flow.report_blocker()
+    mock_labels.transition.assert_called_once_with(42, mock_labels.LABEL_BLOCKED)
+
+
+@patch("apeiron_flow.main._labels")
+def test_report_blocker_continues_when_label_fails(mock_labels, capsys):
+    """report_blocker() logs warning and does not raise if label transition fails."""
+    mock_labels.transition.side_effect = RuntimeError("gh error")
+    state = _make_issue_state(issue_number=42)
+    state.blocker = "blocker text"
+    flow = _build_flow(state)
+    flow.report_blocker()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# ReviewFlow.on_ready_for_merge() — agent-review → review
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+def test_on_ready_for_merge_transitions_to_review(mock_get_issue, mock_labels):
+    """on_ready_for_merge() transitions linked issue to review."""
+    state = _make_review_state(pr_number=10, verdict="ready_for_merge", summary="LGTM")
+    flow = _build_review_flow(state)
+    flow.on_ready_for_merge()
+    mock_labels.transition.assert_called_once_with(
+        42,
+        mock_labels.LABEL_REVIEW,
+        from_label=mock_labels.LABEL_AGENT_REVIEW,
+    )
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=0)
+def test_on_ready_for_merge_skips_when_no_issue(mock_get_issue, mock_labels, capsys):
+    """on_ready_for_merge() logs warning and skips transition if issue unknown."""
+    state = _make_review_state(pr_number=10)
+    flow = _build_review_flow(state)
+    flow.on_ready_for_merge()
+    mock_labels.transition.assert_not_called()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+def test_on_ready_for_merge_continues_when_label_fails(mock_get_issue, mock_labels, capsys):
+    """on_ready_for_merge() logs warning and does not raise if transition fails."""
+    mock_labels.transition.side_effect = RuntimeError("gh down")
+    state = _make_review_state(pr_number=10)
+    flow = _build_review_flow(state)
+    flow.on_ready_for_merge()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# ReviewFlow.on_code_changes_required() — agent-review → in-progress
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+def test_on_code_changes_required_transitions_to_in_progress(mock_get_issue, mock_labels):
+    """on_code_changes_required() transitions linked issue back to in-progress."""
+    state = _make_review_state(pr_number=10, verdict="code_changes_required", summary="needs fix")
+    flow = _build_review_flow(state)
+    flow.on_code_changes_required()
+    mock_labels.transition.assert_called_once_with(
+        42,
+        mock_labels.LABEL_IN_PROGRESS,
+        from_label=mock_labels.LABEL_AGENT_REVIEW,
+    )
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=0)
+def test_on_code_changes_required_skips_when_no_issue(mock_get_issue, mock_labels, capsys):
+    """on_code_changes_required() logs warning and skips transition if issue unknown."""
+    state = _make_review_state(pr_number=10)
+    flow = _build_review_flow(state)
+    flow.on_code_changes_required()
+    mock_labels.transition.assert_not_called()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+def test_on_code_changes_required_continues_when_label_fails(mock_get_issue, mock_labels, capsys):
+    """on_code_changes_required() logs warning and does not raise if transition fails."""
+    mock_labels.transition.side_effect = RuntimeError("gh down")
+    state = _make_review_state(pr_number=10)
+    flow = _build_review_flow(state)
+    flow.on_code_changes_required()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# RespondFlow.handle_change_request() — review → in-progress (PR only)
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+@patch("apeiron_flow.main.cleanup_pr_worktree")
+@patch("apeiron_flow.main.prepare_worktree_for_pr")
+@patch("apeiron_flow.main.RespondCrew")
+def test_handle_change_request_transitions_review_to_in_progress(
+    mock_crew_cls, mock_prepare_wt, mock_cleanup_wt, mock_get_issue, mock_labels
+):
+    """handle_change_request() on a PR transitions the linked issue to in-progress."""
+    from apeiron_flow.main import RespondFlow, RespondState
+
+    mock_result = MagicMock()
+    mock_result.pydantic = MagicMock(comment_url="https://github.com/...", reply="done")
+    mock_crew_cls.return_value.crew.return_value.kickoff.return_value = mock_result
+
+    flow = RespondFlow()
+    flow._state = RespondState()
+    flow.state.target_type = "pr"
+    flow.state.target_number = 10
+    flow.state.current_author = "reviewer"
+    flow.state.current_comment_id = 0
+    flow.state.current_user_message = "[author:@reviewer]\nPlease fix the indent"
+
+    flow.handle_change_request()
+
+    mock_labels.transition.assert_called_once_with(
+        42,
+        mock_labels.LABEL_IN_PROGRESS,
+        from_label=mock_labels.LABEL_REVIEW,
+    )
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+@patch("apeiron_flow.main.cleanup_pr_worktree")
+@patch("apeiron_flow.main.prepare_worktree_for_pr")
+@patch("apeiron_flow.main.RespondCrew")
+def test_handle_change_request_skips_transition_for_issue_comments(
+    mock_crew_cls, mock_prepare_wt, mock_cleanup_wt, mock_get_issue, mock_labels
+):
+    """handle_change_request() does NOT call transition when target is an issue (not PR)."""
+    from apeiron_flow.main import RespondFlow, RespondState
+
+    mock_result = MagicMock()
+    mock_result.pydantic = MagicMock(comment_url="https://github.com/...", reply="done")
+    mock_crew_cls.return_value.crew.return_value.kickoff.return_value = mock_result
+
+    flow = RespondFlow()
+    flow._state = RespondState()
+    flow.state.target_type = "issue"
+    flow.state.target_number = 42
+    flow.state.current_author = "user"
+    flow.state.current_comment_id = 0
+    flow.state.current_user_message = "[author:@user]\nCan you fix X?"
+
+    flow.handle_change_request()
+
+    mock_labels.transition.assert_not_called()
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=42)
+@patch("apeiron_flow.main.cleanup_pr_worktree")
+@patch("apeiron_flow.main.prepare_worktree_for_pr")
+@patch("apeiron_flow.main.RespondCrew")
+def test_handle_change_request_continues_when_label_fails(
+    mock_crew_cls, mock_prepare_wt, mock_cleanup_wt, mock_get_issue, mock_labels, capsys
+):
+    """handle_change_request() logs warning and continues if label transition fails."""
+    from apeiron_flow.main import RespondFlow, RespondState
+
+    mock_labels.transition.side_effect = RuntimeError("gh error")
+    mock_result = MagicMock()
+    mock_result.pydantic = MagicMock(comment_url="https://github.com/...", reply="done")
+    mock_crew_cls.return_value.crew.return_value.kickoff.return_value = mock_result
+
+    flow = RespondFlow()
+    flow._state = RespondState()
+    flow.state.target_type = "pr"
+    flow.state.target_number = 10
+    flow.state.current_author = "reviewer"
+    flow.state.current_comment_id = 0
+    flow.state.current_user_message = "[author:@reviewer]\nFix it please"
+
+    # Must not raise
+    flow.handle_change_request()
+
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out
+
+
+@patch("apeiron_flow.main._labels")
+@patch("apeiron_flow.main._get_issue_for_pr", return_value=0)
+@patch("apeiron_flow.main.cleanup_pr_worktree")
+@patch("apeiron_flow.main.prepare_worktree_for_pr")
+@patch("apeiron_flow.main.RespondCrew")
+def test_handle_change_request_skips_transition_when_no_issue(
+    mock_crew_cls, mock_prepare_wt, mock_cleanup_wt, mock_get_issue, mock_labels, capsys
+):
+    """handle_change_request() skips transition and logs warning if issue cannot be resolved."""
+    from apeiron_flow.main import RespondFlow, RespondState
+
+    mock_result = MagicMock()
+    mock_result.pydantic = MagicMock(comment_url="https://github.com/...", reply="done")
+    mock_crew_cls.return_value.crew.return_value.kickoff.return_value = mock_result
+
+    flow = RespondFlow()
+    flow._state = RespondState()
+    flow.state.target_type = "pr"
+    flow.state.target_number = 10
+    flow.state.current_author = "reviewer"
+    flow.state.current_comment_id = 0
+    flow.state.current_user_message = "[author:@reviewer]\nFix it"
+
+    flow.handle_change_request()
+
+    mock_labels.transition.assert_not_called()
+    captured = capsys.readouterr()
+    assert "[WARN]" in captured.out


### PR DESCRIPTION
Wire GitHub issue lifecycle label transitions (ADR 002) into all three orchestrator flows so issue labels automatically track state without manual intervention.

## What changed

Added `_get_issue_for_pr(pr_number)` helper that resolves the linked issue from a PR's branch name (`feat/issue-N`) with a `Related to #N` body fallback.

Wired transitions into:
- `ApeironFlow.prepare()` — ready → in-progress
- `ApeironFlow.trigger_review()` — in-progress → agent-review
- `ApeironFlow.report_blocker()` — (any) → blocked
- `ReviewFlow.on_ready_for_merge()` — agent-review → review
- `ReviewFlow.on_code_changes_required()` — agent-review → in-progress
- `RespondFlow.handle_change_request()` — review → in-progress (PR-only)

All transitions are fire-and-forget: failures emit a `[WARN]` line and never abort the flow.

## Tests

22 new tests in `test_label_wiring.py` covering correct arguments, failure tolerance, and the no-op path when issue resolution returns 0. Full suite: 53/53 passing.

Related to #499