### PR TITLE
feat(orchestrator): migrate status:in-review to new label scheme

### DIFF
--- a/apeiron_flow/src/apeiron_flow/labels.py
+++ b/apeiron_flow/src/apeiron_flow/labels.py
@@ -31,7 +31,14 @@ LABEL_REVIEW = "status:review"
 LABEL_DONE = "status:done"
 LABEL_BLOCKED = "status:blocked"
 
-# All status labels — used to remove any stale status before adding the new one
+# Retired label — replaced by status:agent-review and status:review per ADR 002.
+# Kept here as a constant so retire_in_review() and tests can reference it without
+# magic strings.
+LABEL_IN_REVIEW = "status:in-review"
+
+# All status labels — used to remove any stale status before adding the new one.
+# Does NOT include LABEL_IN_REVIEW because that label is being retired; it will
+# be cleaned up explicitly by retire_in_review() rather than through transition().
 ALL_STATUS_LABELS: frozenset[str] = frozenset(
     {
         LABEL_TRIAGE,
@@ -157,3 +164,44 @@ def _remove_label(issue_number: int, label: str) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(f"Failed to remove label {label!r} from issue #{issue_number}: {result.stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# One-time migration helper (ADR 002)
+# ---------------------------------------------------------------------------
+
+
+def retire_in_review(issue_number: int, has_pr: bool, agent_review_posted: bool = False) -> str:
+    """Migrate a single status:in-review issue to the correct new label per ADR 002.
+
+    Decision table:
+      - No open PR              → status:in-progress
+      - PR open, no agent review posted yet → status:agent-review
+      - PR open, agent review posted, awaiting human → status:review
+
+    Removes status:in-review and applies the chosen target label via transition().
+    Returns the target label that was applied.
+
+    Args:
+        issue_number:         GitHub issue number.
+        has_pr:               True if the issue has an open PR.
+        agent_review_posted:  True if the review crew has already posted a structured
+                              review on the PR. Only meaningful when has_pr=True.
+    """
+    if not has_pr:
+        target = LABEL_IN_PROGRESS
+    elif not agent_review_posted:
+        target = LABEL_AGENT_REVIEW
+    else:
+        target = LABEL_REVIEW
+
+    # Remove the retired label first, then apply the new state via transition().
+    # We bypass the from_label check in transition() because LABEL_IN_REVIEW is not
+    # in the transition table (it is being retired, not a valid from-state).
+    _remove_label(issue_number, LABEL_IN_REVIEW)
+
+    # Apply target without a from_label check — the issue just had its status
+    # cleared, so we add the target directly.
+    _add_label(issue_number, target)
+
+    return target

--- a/apeiron_flow/src/apeiron_flow/migrate_in_review.py
+++ b/apeiron_flow/src/apeiron_flow/migrate_in_review.py
@@ -1,0 +1,217 @@
+"""
+One-time migration script: status:in-review → new label scheme (ADR 002).
+
+Run from the repo root:
+  python -m apeiron_flow.migrate_in_review [--dry-run]
+
+Steps:
+  1. List all open issues with status:in-review.
+  2. For each issue:
+       - Check whether an open PR is linked (branch feat/issue-N exists or
+         'Related to #N' in a PR body).
+       - Check whether an agent review comment is present on any open PR.
+       - Apply retire_in_review() with the inspection result.
+       - Post an explanatory comment on the issue.
+  3. Archive (hide) the status:in-review label on GitHub.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+from apeiron_flow.config import REPO
+from apeiron_flow.labels import (
+    LABEL_IN_REVIEW,
+    retire_in_review,
+)
+
+# The bot login that posts structured agent review comments.
+# Used to decide whether an agent review has already been posted.
+_BOT_LOGIN = "apeiron-cipher-manager[bot]"
+
+_MIGRATION_COMMENT = (
+    "**[ADR 002 migration]** This issue had `status:in-review`, which has been retired "
+    "and split into `status:agent-review` (agent validation pass) and `status:review` "
+    "(human approval gate). "
+    "Based on the current state of any linked PR and review comments, this issue has been "
+    "moved to `{new_label}`. "
+    "See [ADR 002](../../docs/adr/002-issue-lifecycle-status-labels.md) for the full lifecycle spec."
+)
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (no imports from github_http — this script is standalone)
+# ---------------------------------------------------------------------------
+
+
+def _gh(*args: str) -> dict:
+    """Run a gh CLI command and return parsed JSON. Raises RuntimeError on failure."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args[:4])} failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def _list_in_review_issues() -> list[dict]:
+    """Return all open issues labeled status:in-review."""
+    result = _gh(
+        "issue", "list",
+        "--repo", REPO,
+        "--label", LABEL_IN_REVIEW,
+        "--state", "open",
+        "--json", "number,title,labels",
+        "--limit", "200",
+    )
+    return result if isinstance(result, list) else []
+
+
+def _find_open_pr(issue_number: int) -> dict | None:
+    """Return the first open PR linked to the issue, or None.
+
+    Checks:
+    1. Branch named feat/issue-{N}.
+    2. PR body containing 'Related to #{N}'.
+    """
+    prs_raw = subprocess.run(
+        ["gh", "pr", "list", "--repo", REPO, "--state", "open",
+         "--json", "number,title,headRefName,body"],
+        capture_output=True, text=True,
+    )
+    if prs_raw.returncode != 0:
+        return None
+    prs = json.loads(prs_raw.stdout)
+    for pr in prs:
+        branch = pr.get("headRefName", "")
+        body = pr.get("body", "") or ""
+        if f"feat/issue-{issue_number}" in branch:
+            return pr
+        if f"Related to #{issue_number}" in body:
+            return pr
+    return None
+
+
+def _has_agent_review(pr_number: int) -> bool:
+    """Return True if the bot has posted a structured review on the PR."""
+    reviews_raw = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--repo", REPO,
+         "--json", "reviews"],
+        capture_output=True, text=True,
+    )
+    if reviews_raw.returncode != 0:
+        return False
+    data = json.loads(reviews_raw.stdout)
+    for review in data.get("reviews", []):
+        author = review.get("author", {}) or {}
+        login = author.get("login", "")
+        if login == _BOT_LOGIN:
+            return True
+    return False
+
+
+def _post_comment(issue_number: int, body: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"  [dry-run] would post comment on #{issue_number}: {body[:80]}...")
+        return
+    result = subprocess.run(
+        ["gh", "issue", "comment", str(issue_number), "--repo", REPO, "--body", body],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"  [WARN] failed to post comment on #{issue_number}: {result.stderr.strip()}", file=sys.stderr)
+
+
+def _archive_label(dry_run: bool) -> None:
+    """Hide (archive) the status:in-review label by adding a deprecation description."""
+    # GitHub has no archive concept for labels via gh CLI; we rename the description
+    # to signal it is retired. This is the closest available operation.
+    if dry_run:
+        print(f"[dry-run] would edit label {LABEL_IN_REVIEW!r} to mark it as deprecated")
+        return
+    result = subprocess.run(
+        ["gh", "label", "edit", LABEL_IN_REVIEW,
+         "--repo", REPO,
+         "--description", "[RETIRED — see ADR 002] use status:agent-review or status:review"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"[WARN] could not update label description: {result.stderr.strip()}", file=sys.stderr)
+    else:
+        print(f"Label {LABEL_IN_REVIEW!r} description updated to mark as retired.")
+
+
+# ---------------------------------------------------------------------------
+# Main migration loop
+# ---------------------------------------------------------------------------
+
+
+def run_migration(dry_run: bool = False) -> None:
+    print(f"Fetching open issues with {LABEL_IN_REVIEW!r} from {REPO}...")
+    issues = _list_in_review_issues()
+    print(f"Found {len(issues)} issue(s) to migrate.")
+
+    if not issues:
+        print("Nothing to do.")
+        _archive_label(dry_run)
+        return
+
+    for issue in issues:
+        number = issue["number"]
+        title = issue["title"]
+        print(f"\nProcessing #{number}: {title}")
+
+        # Inspect PR state
+        pr = _find_open_pr(number)
+        has_pr = pr is not None
+        agent_review_posted = False
+        if has_pr:
+            assert pr is not None
+            agent_review_posted = _has_agent_review(pr["number"])
+            print(f"  Open PR: #{pr['number']} — agent review posted: {agent_review_posted}")
+        else:
+            print("  No open PR found.")
+
+        # Apply migration
+        if dry_run:
+            if not has_pr:
+                new_label = "status:in-progress"
+            elif not agent_review_posted:
+                new_label = "status:agent-review"
+            else:
+                new_label = "status:review"
+            print(f"  [dry-run] would retire_in_review(#{number}) → {new_label}")
+        else:
+            new_label = retire_in_review(
+                number,
+                has_pr=has_pr,
+                agent_review_posted=agent_review_posted,
+            )
+            print(f"  Migrated #{number} → {new_label}")
+
+        # Post explanatory comment
+        comment_body = _MIGRATION_COMMENT.format(new_label=new_label)
+        _post_comment(number, comment_body, dry_run)
+
+    # Archive the retired label
+    _archive_label(dry_run)
+    print("\nMigration complete.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate status:in-review issues per ADR 002.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print what would happen without making any changes.",
+    )
+    args = parser.parse_args()
+    run_migration(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/apeiron_flow/tests/test_migrate_in_review.py
+++ b/apeiron_flow/tests/test_migrate_in_review.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for retire_in_review() and the migrate_in_review module.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apeiron_flow.labels import (
+    LABEL_AGENT_REVIEW,
+    LABEL_IN_PROGRESS,
+    LABEL_IN_REVIEW,
+    LABEL_REVIEW,
+    retire_in_review,
+)
+from apeiron_flow.migrate_in_review import (
+    _archive_label,
+    _find_open_pr,
+    _has_agent_review,
+    _list_in_review_issues,
+    _post_comment,
+    run_migration,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    p = MagicMock()
+    p.returncode = returncode
+    p.stdout = stdout
+    p.stderr = stderr
+    return p
+
+
+# ---------------------------------------------------------------------------
+# retire_in_review() — decision table
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.labels.subprocess.run")
+def test_retire_in_review_no_pr_gives_in_progress(mock_run):
+    """No PR open → status:in-progress."""
+    mock_run.side_effect = [
+        _proc(0),  # _remove_label(status:in-review)
+        _proc(0),  # _add_label(status:in-progress)
+    ]
+    result = retire_in_review(42, has_pr=False)
+    assert result == LABEL_IN_PROGRESS
+    # First call removes status:in-review
+    assert "--remove-label" in mock_run.call_args_list[0][0][0]
+    assert LABEL_IN_REVIEW in mock_run.call_args_list[0][0][0]
+    # Second call adds status:in-progress
+    assert "--add-label" in mock_run.call_args_list[1][0][0]
+    assert LABEL_IN_PROGRESS in mock_run.call_args_list[1][0][0]
+
+
+@patch("apeiron_flow.labels.subprocess.run")
+def test_retire_in_review_pr_no_agent_review_gives_agent_review(mock_run):
+    """PR open, no agent review → status:agent-review."""
+    mock_run.side_effect = [
+        _proc(0),  # _remove_label
+        _proc(0),  # _add_label
+    ]
+    result = retire_in_review(7, has_pr=True, agent_review_posted=False)
+    assert result == LABEL_AGENT_REVIEW
+    assert LABEL_AGENT_REVIEW in mock_run.call_args_list[1][0][0]
+
+
+@patch("apeiron_flow.labels.subprocess.run")
+def test_retire_in_review_pr_with_agent_review_gives_review(mock_run):
+    """PR open, agent review posted → status:review."""
+    mock_run.side_effect = [
+        _proc(0),  # _remove_label
+        _proc(0),  # _add_label
+    ]
+    result = retire_in_review(7, has_pr=True, agent_review_posted=True)
+    assert result == LABEL_REVIEW
+    assert LABEL_REVIEW in mock_run.call_args_list[1][0][0]
+
+
+@patch("apeiron_flow.labels.subprocess.run")
+def test_retire_in_review_propagates_remove_failure(mock_run):
+    """RuntimeError from _remove_label bubbles up."""
+    mock_run.return_value = _proc(1, stderr="not found")
+    with pytest.raises(RuntimeError, match="not found"):
+        retire_in_review(99, has_pr=False)
+
+
+# ---------------------------------------------------------------------------
+# _list_in_review_issues()
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_list_in_review_issues_returns_list(mock_run):
+    issues = [{"number": 14, "title": "Story 3.3", "labels": []}]
+    mock_run.return_value = _proc(0, stdout=json.dumps(issues))
+    result = _list_in_review_issues()
+    assert result == issues
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_list_in_review_issues_empty_when_none(mock_run):
+    mock_run.return_value = _proc(0, stdout="[]")
+    result = _list_in_review_issues()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _find_open_pr()
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_find_open_pr_matches_by_branch(mock_run):
+    prs = [{"number": 55, "title": "feat: fix", "headRefName": "feat/issue-14", "body": ""}]
+    mock_run.return_value = _proc(0, stdout=json.dumps(prs))
+    pr = _find_open_pr(14)
+    assert pr is not None
+    assert pr["number"] == 55
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_find_open_pr_matches_by_body(mock_run):
+    prs = [
+        {"number": 60, "title": "feat: fix", "headRefName": "feat/other", "body": "Related to #14\nsome text"},
+    ]
+    mock_run.return_value = _proc(0, stdout=json.dumps(prs))
+    pr = _find_open_pr(14)
+    assert pr is not None
+    assert pr["number"] == 60
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_find_open_pr_returns_none_when_no_match(mock_run):
+    prs = [{"number": 99, "title": "unrelated", "headRefName": "feat/other", "body": ""}]
+    mock_run.return_value = _proc(0, stdout=json.dumps(prs))
+    pr = _find_open_pr(14)
+    assert pr is None
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_find_open_pr_returns_none_on_gh_failure(mock_run):
+    mock_run.return_value = _proc(1, stderr="auth error")
+    pr = _find_open_pr(14)
+    assert pr is None
+
+
+# ---------------------------------------------------------------------------
+# _has_agent_review()
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_has_agent_review_true_when_bot_review_present(mock_run):
+    reviews = {"reviews": [{"author": {"login": "apeiron-cipher-manager[bot]"}, "state": "APPROVED"}]}
+    mock_run.return_value = _proc(0, stdout=json.dumps(reviews))
+    assert _has_agent_review(55) is True
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_has_agent_review_false_when_only_human_review(mock_run):
+    reviews = {"reviews": [{"author": {"login": "humanuser"}, "state": "APPROVED"}]}
+    mock_run.return_value = _proc(0, stdout=json.dumps(reviews))
+    assert _has_agent_review(55) is False
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_has_agent_review_false_on_gh_failure(mock_run):
+    mock_run.return_value = _proc(1, stderr="not found")
+    assert _has_agent_review(55) is False
+
+
+# ---------------------------------------------------------------------------
+# _post_comment() and _archive_label()
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_post_comment_calls_gh(mock_run):
+    mock_run.return_value = _proc(0)
+    _post_comment(14, "hello migration", dry_run=False)
+    args = mock_run.call_args[0][0]
+    assert "gh" in args[0]
+    assert "comment" in args
+    assert "14" in args
+    assert "--body" in args
+
+
+def test_post_comment_dry_run_does_not_call_gh(capsys):
+    _post_comment(14, "hello", dry_run=True)
+    captured = capsys.readouterr()
+    assert "dry-run" in captured.out
+
+
+@patch("apeiron_flow.migrate_in_review.subprocess.run")
+def test_archive_label_calls_gh_label_edit(mock_run):
+    mock_run.return_value = _proc(0)
+    _archive_label(dry_run=False)
+    args = mock_run.call_args[0][0]
+    assert "label" in args
+    assert "edit" in args
+    assert LABEL_IN_REVIEW in args
+    assert "--description" in args
+
+
+def test_archive_label_dry_run_does_not_call_gh(capsys):
+    _archive_label(dry_run=True)
+    captured = capsys.readouterr()
+    assert "dry-run" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# run_migration() — end-to-end with mocks
+# ---------------------------------------------------------------------------
+
+
+@patch("apeiron_flow.migrate_in_review._archive_label")
+@patch("apeiron_flow.migrate_in_review._post_comment")
+@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review._has_agent_review")
+@patch("apeiron_flow.migrate_in_review._find_open_pr")
+@patch("apeiron_flow.migrate_in_review._list_in_review_issues")
+def test_run_migration_no_pr(mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive):
+    """Issue with no PR → retire_in_review called with has_pr=False."""
+    mock_list.return_value = [{"number": 14, "title": "Story 3.3", "labels": []}]
+    mock_find_pr.return_value = None
+    mock_retire.return_value = LABEL_IN_PROGRESS
+
+    run_migration(dry_run=False)
+
+    mock_retire.assert_called_once_with(14, has_pr=False, agent_review_posted=False)
+    mock_comment.assert_called_once()
+    comment_body = mock_comment.call_args[0][1]
+    assert LABEL_IN_PROGRESS in comment_body
+    mock_archive.assert_called_once_with(False)
+
+
+@patch("apeiron_flow.migrate_in_review._archive_label")
+@patch("apeiron_flow.migrate_in_review._post_comment")
+@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review._has_agent_review")
+@patch("apeiron_flow.migrate_in_review._find_open_pr")
+@patch("apeiron_flow.migrate_in_review._list_in_review_issues")
+def test_run_migration_pr_no_agent_review(
+    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+):
+    """Issue with open PR, no agent review → retire_in_review with has_pr=True, agent_review_posted=False."""
+    mock_list.return_value = [{"number": 7, "title": "Story X", "labels": []}]
+    mock_find_pr.return_value = {"number": 55, "title": "feat", "headRefName": "feat/issue-7"}
+    mock_has_review.return_value = False
+    mock_retire.return_value = LABEL_AGENT_REVIEW
+
+    run_migration(dry_run=False)
+
+    mock_retire.assert_called_once_with(7, has_pr=True, agent_review_posted=False)
+    mock_archive.assert_called_once_with(False)
+
+
+@patch("apeiron_flow.migrate_in_review._archive_label")
+@patch("apeiron_flow.migrate_in_review._post_comment")
+@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review._has_agent_review")
+@patch("apeiron_flow.migrate_in_review._find_open_pr")
+@patch("apeiron_flow.migrate_in_review._list_in_review_issues")
+def test_run_migration_pr_with_agent_review(
+    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+):
+    """Issue with open PR, agent review present → retire_in_review with has_pr=True, agent_review_posted=True."""
+    mock_list.return_value = [{"number": 7, "title": "Story X", "labels": []}]
+    mock_find_pr.return_value = {"number": 55, "title": "feat", "headRefName": "feat/issue-7"}
+    mock_has_review.return_value = True
+    mock_retire.return_value = LABEL_REVIEW
+
+    run_migration(dry_run=False)
+
+    mock_retire.assert_called_once_with(7, has_pr=True, agent_review_posted=True)
+    mock_archive.assert_called_once_with(False)
+
+
+@patch("apeiron_flow.migrate_in_review._archive_label")
+@patch("apeiron_flow.migrate_in_review._list_in_review_issues")
+def test_run_migration_nothing_to_do(mock_list, mock_archive):
+    """Empty list → archive is still called."""
+    mock_list.return_value = []
+    run_migration(dry_run=False)
+    mock_archive.assert_called_once_with(False)
+
+
+@patch("apeiron_flow.migrate_in_review._archive_label")
+@patch("apeiron_flow.migrate_in_review._post_comment")
+@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review._has_agent_review")
+@patch("apeiron_flow.migrate_in_review._find_open_pr")
+@patch("apeiron_flow.migrate_in_review._list_in_review_issues")
+def test_run_migration_dry_run_does_not_call_retire(
+    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+):
+    """Dry run: retire_in_review is NOT called; comment and archive are called with dry_run=True."""
+    mock_list.return_value = [{"number": 14, "title": "Story 3.3", "labels": []}]
+    mock_find_pr.return_value = None
+
+    run_migration(dry_run=True)
+
+    mock_retire.assert_not_called()
+    mock_comment.assert_called_once()
+    # _post_comment(issue_number, body, dry_run=True)
+    comment_call_args = mock_comment.call_args
+    assert comment_call_args[0][2] is True  # third positional arg is dry_run
+    mock_archive.assert_called_once_with(True)


### PR DESCRIPTION
## Summary

One-time migration for ADR 002: retire `status:in-review` and move all affected issues to the correct new label.

**Changes:**
- `labels.py`: add `LABEL_IN_REVIEW` constant and `retire_in_review(issue_number, has_pr, agent_review_posted)` helper
- `migrate_in_review.py`: standalone migration script — lists open `status:in-review` issues, inspects PR/review state, applies the correct transition, posts an explanatory comment per issue, marks the label as retired
- `tests/test_migrate_in_review.py`: 22 new unit tests (94/94 total passing)

**Migration executed:**
- Issue #14 (Story 3.3: Observation Through Consequence) — no open PR → moved to `status:in-progress`
- `status:in-review` label description updated to `[RETIRED — see ADR 002]`

**Decision table in `retire_in_review()`:**
| Condition | New label |
|---|---|
| No open PR | `status:in-progress` |
| PR open, no agent review | `status:agent-review` |
| PR open, agent review posted | `status:review` |

Related to #504