### PR TITLE
feat(orchestrator): label transition module

### DIFF
--- a/apeiron_flow/src/apeiron_flow/github_http.py
+++ b/apeiron_flow/src/apeiron_flow/github_http.py
@@ -103,6 +103,31 @@ def _gh_post(path: str, body: dict) -> dict:
     return resp.json()
 
 
+def _gh_delete(path: str, *, ignore_not_found: bool = False) -> None:
+    """DELETE a GitHub API resource.
+
+    GitHub returns 204 No Content on success for most DELETE endpoints
+    (e.g. removing a label from an issue). Raises requests.HTTPError on
+    non-2xx responses.
+
+    Parameters
+    ----------
+    path : str
+        API path, e.g. ``/repos/owner/repo/issues/1/labels/status:todo``.
+    ignore_not_found : bool
+        When True, a 404 response is silently treated as success (the resource
+        was already absent). Useful for idempotent label-removal callers.
+    """
+    resp = requests.delete(
+        f"https://api.github.com{path}",
+        headers=_gh_headers(),
+        timeout=15,
+    )
+    if ignore_not_found and resp.status_code == 404:
+        return
+    resp.raise_for_status()
+
+
 def safe_login(obj: dict | None) -> str:
     """Extract user.login from a GitHub API object.
 

--- a/apeiron_flow/src/apeiron_flow/labels.py
+++ b/apeiron_flow/src/apeiron_flow/labels.py
@@ -1,207 +1,257 @@
 """
 Label transition helpers for the Apeiron Cipher issue lifecycle.
 
-All status:* label transitions are defined here. No other module may perform
-label mutations directly — they must go through transition() so that:
-  1. The old status label is removed atomically with adding the new one.
-  2. The transition table acts as the single source of truth for allowed moves.
+Implements atomic GitHub label transitions for the status:* pipeline defined
+in docs/adr/002-issue-lifecycle-status-labels.md.
+
+All HTTP calls go through github_http — no direct requests import here.
+No subprocess / gh CLI calls — App token only.
+
+Public API
+----------
+transition(issue_number, from_label, to_label)
+    Atomically move an issue from one status label to another.
+    Adds to_label first, removes from_label second.
+    No-op if the issue already carries to_label.
+    Raises LabelTransitionError if add succeeds but remove fails (dual-label
+    state), or if any HTTP call fails.
+
+get_status(issue_number) -> str | None
+    Return the current status:* label value, or None if none present.
+    Raises LabelTransitionError if the issue has multiple status:* labels.
+
+retire_in_review(issue_number)
+    One-time migration helper: status:in-review -> status:review.
 
 Reference: docs/adr/002-issue-lifecycle-status-labels.md
-
-Valid states (in pipeline order):
-  triage → todo → ready → in-progress → agent-review → review → done
-  any state → blocked
 """
 
-import json
-import subprocess
-
-from apeiron_flow.config import REPO
+from apeiron_flow.config import REPO_NAME, REPO_OWNER
+from apeiron_flow.github_http import _gh_delete, _gh_get, _gh_post
 
 # ---------------------------------------------------------------------------
-# Label name constants (single source of truth)
+# Status label constants (single source of truth)
 # ---------------------------------------------------------------------------
 
-LABEL_TRIAGE = "status:triage"
-LABEL_TODO = "status:todo"
-LABEL_READY = "status:ready"
-LABEL_IN_PROGRESS = "status:in-progress"
-LABEL_AGENT_REVIEW = "status:agent-review"
-LABEL_REVIEW = "status:review"
-LABEL_DONE = "status:done"
-LABEL_BLOCKED = "status:blocked"
+STATUS_TRIAGE = "status:triage"
+STATUS_TODO = "status:todo"
+STATUS_READY = "status:ready"
+STATUS_IN_PROGRESS = "status:in-progress"
+STATUS_AGENT_REVIEW = "status:agent-review"
+STATUS_REVIEW = "status:review"
+STATUS_BLOCKED = "status:blocked"
+STATUS_DONE = "status:done"
 
-# Retired label — replaced by status:agent-review and status:review per ADR 002.
-# Kept here as a constant so retire_in_review() and tests can reference it without
-# magic strings.
+# Legacy label being retired by ADR 002 — kept public for migrate_in_review
 LABEL_IN_REVIEW = "status:in-review"
+_STATUS_IN_REVIEW_LEGACY = LABEL_IN_REVIEW  # internal alias
 
-# All status labels — used to remove any stale status before adding the new one.
-# Does NOT include LABEL_IN_REVIEW because that label is being retired; it will
-# be cleaned up explicitly by retire_in_review() rather than through transition().
+# Frozenset of all canonical status labels — used to identify status labels
+# in issue.labels lists without knowing which one is present.
 ALL_STATUS_LABELS: frozenset[str] = frozenset(
     {
-        LABEL_TRIAGE,
-        LABEL_TODO,
-        LABEL_READY,
-        LABEL_IN_PROGRESS,
-        LABEL_AGENT_REVIEW,
-        LABEL_REVIEW,
-        LABEL_DONE,
-        LABEL_BLOCKED,
+        STATUS_TRIAGE,
+        STATUS_TODO,
+        STATUS_READY,
+        STATUS_IN_PROGRESS,
+        STATUS_AGENT_REVIEW,
+        STATUS_REVIEW,
+        STATUS_BLOCKED,
+        STATUS_DONE,
     }
 )
 
-# ---------------------------------------------------------------------------
-# Allowed transitions
-# Each key is (from_label, to_label); value is a short description.
-# The "from_label" may also be None to represent "any state → blocked".
-# ---------------------------------------------------------------------------
-
-ALLOWED_TRANSITIONS: dict[tuple[str | None, str], str] = {
-    # Triage crew sets after breakdown
-    (LABEL_TRIAGE, LABEL_TODO): "triage crew completed breakdown",
-    # Human approval gate
-    (LABEL_TODO, LABEL_READY): "human approved issue for pickup",
-    # Human can push back to re-triage
-    (LABEL_TODO, LABEL_TRIAGE): "human requested re-triage",
-    # Orchestrator claims the issue
-    (LABEL_READY, LABEL_IN_PROGRESS): "orchestrator claimed issue",
-    # Dev crew opened a PR
-    (LABEL_IN_PROGRESS, LABEL_AGENT_REVIEW): "dev crew opened PR",
-    # Review crew approved
-    (LABEL_AGENT_REVIEW, LABEL_REVIEW): "review crew approved",
-    # Review crew requested changes — back to dev crew
-    (LABEL_AGENT_REVIEW, LABEL_IN_PROGRESS): "review crew requested changes",
-    # Human approved PR
-    (LABEL_REVIEW, LABEL_DONE): "human approved PR",
-    # Human requested changes — back to dev crew
-    (LABEL_REVIEW, LABEL_IN_PROGRESS): "human requested changes",
-    # Any → blocked (from_label=None means "from any current state")
-    (None, LABEL_BLOCKED): "crew cannot proceed",
-    # Blocked → ready (human resolved the blocker)
-    (LABEL_BLOCKED, LABEL_READY): "human resolved blocker",
-}
-
 
 # ---------------------------------------------------------------------------
-# Transition function
+# Exception
 # ---------------------------------------------------------------------------
 
 
-def transition(issue_number: int, to_label: str, from_label: str | None = None) -> None:
-    """Atomically move an issue from one status label to another.
+class LabelTransitionError(Exception):
+    """Raised when a label transition cannot be completed atomically.
 
-    Fetches the current labels, removes all status:* labels, then adds
-    to_label. If from_label is provided, validates the transition is allowed.
-
-    Raises ValueError if the transition is not in ALLOWED_TRANSITIONS.
-    Raises RuntimeError if a GitHub API call fails.
-
-    Args:
-        issue_number: The GitHub issue number.
-        to_label:     The target status label (e.g. LABEL_TODO).
-        from_label:   Optional. The expected current status label. When provided,
-                      the transition is validated against ALLOWED_TRANSITIONS.
-                      When None, the current status is inferred from existing labels
-                      and a wildcard (None, to_label) transition is used if no exact
-                      match is found.
+    Attributes
+    ----------
+    issue_number : int
+        The issue that was being transitioned.
+    from_label : str | None
+        The label that was to be removed (None if not yet attempted).
+    to_label : str | None
+        The label that was to be added (None if not yet attempted).
+    message : str
+        Human-readable description of the failure.
     """
-    # Validate transition if from_label is explicitly given
-    if from_label is not None:
-        if (from_label, to_label) not in ALLOWED_TRANSITIONS:
-            raise ValueError(
-                f"Transition {from_label!r} → {to_label!r} is not in ALLOWED_TRANSITIONS. "
-                f"See docs/adr/002-issue-lifecycle-status-labels.md."
-            )
-    else:
-        # Wildcard: check if (None, to_label) exists (e.g. any → blocked)
-        if (None, to_label) not in ALLOWED_TRANSITIONS:
-            raise ValueError(
-                f"Transition (any) → {to_label!r} is not in ALLOWED_TRANSITIONS and from_label was not provided."
-            )
 
-    # Fetch current labels on the issue
-    result = subprocess.run(
-        ["gh", "issue", "view", str(issue_number), "--repo", REPO, "--json", "labels"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"gh issue view {issue_number} failed: {result.stderr.strip()}")
+    def __init__(
+        self,
+        message: str,
+        issue_number: int,
+        from_label: str | None = None,
+        to_label: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.issue_number = issue_number
+        self.from_label = from_label
+        self.to_label = to_label
 
-    data = json.loads(result.stdout)
-    current_names: set[str] = {lbl["name"] for lbl in data.get("labels", [])}
-    to_remove = current_names & ALL_STATUS_LABELS
 
-    # Remove all current status labels
-    for old_label in to_remove:
-        if old_label == to_label:
-            continue  # already has the target — no-op for this one
-        _remove_label(issue_number, old_label)
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
-    # Add the new label (idempotent — GitHub ignores adding a label already present)
-    _add_label(issue_number, to_label)
+
+def _get_issue_labels(issue_number: int) -> list[str]:
+    """Return all label names currently on the issue."""
+    data = _gh_get(f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{issue_number}/labels")
+    if not isinstance(data, list):
+        raise LabelTransitionError(
+            f"Unexpected response from GET /issues/{issue_number}/labels: {data!r}",
+            issue_number=issue_number,
+        )
+    return [lbl["name"] for lbl in data]
 
 
 def _add_label(issue_number: int, label: str) -> None:
-    """Add a single label to a GitHub issue. Raises RuntimeError on failure."""
-    result = subprocess.run(
-        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--add-label", label],
-        capture_output=True,
-        text=True,
+    """Add a single label to an issue via the GitHub REST API."""
+    _gh_post(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{issue_number}/labels",
+        {"labels": [label]},
     )
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to add label {label!r} to issue #{issue_number}: {result.stderr.strip()}")
 
 
 def _remove_label(issue_number: int, label: str) -> None:
-    """Remove a single label from a GitHub issue. Raises RuntimeError on failure."""
-    result = subprocess.run(
-        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", label],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to remove label {label!r} from issue #{issue_number}: {result.stderr.strip()}")
+    """Remove a single label from an issue via the GitHub REST API.
 
-
-# ---------------------------------------------------------------------------
-# One-time migration helper (ADR 002)
-# ---------------------------------------------------------------------------
-
-
-def retire_in_review(issue_number: int, has_pr: bool, agent_review_posted: bool = False) -> str:
-    """Migrate a single status:in-review issue to the correct new label per ADR 002.
-
-    Decision table:
-      - No open PR              → status:in-progress
-      - PR open, no agent review posted yet → status:agent-review
-      - PR open, agent review posted, awaiting human → status:review
-
-    Removes status:in-review and applies the chosen target label via transition().
-    Returns the target label that was applied.
-
-    Args:
-        issue_number:         GitHub issue number.
-        has_pr:               True if the issue has an open PR.
-        agent_review_posted:  True if the review crew has already posted a structured
-                              review on the PR. Only meaningful when has_pr=True.
+    GitHub returns 200 with remaining labels on success, and 404 if the
+    label was not on the issue. Both are treated as successful removal
+    (idempotent) via _gh_delete(ignore_not_found=True).
     """
-    if not has_pr:
-        target = LABEL_IN_PROGRESS
-    elif not agent_review_posted:
-        target = LABEL_AGENT_REVIEW
-    else:
-        target = LABEL_REVIEW
+    _gh_delete(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{issue_number}/labels/{label}",
+        ignore_not_found=True,
+    )
 
-    # Remove the retired label first, then apply the new state via transition().
-    # We bypass the from_label check in transition() because LABEL_IN_REVIEW is not
-    # in the transition table (it is being retired, not a valid from-state).
-    _remove_label(issue_number, LABEL_IN_REVIEW)
 
-    # Apply target without a from_label check — the issue just had its status
-    # cleared, so we add the target directly.
-    _add_label(issue_number, target)
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
-    return target
+
+def transition(issue_number: int, from_label: str, to_label: str) -> None:
+    """Atomically transition an issue from one status label to another.
+
+    Sequence
+    --------
+    1. Fetch current labels on the issue.
+    2. If to_label is already present -> no-op (idempotent).
+    3. Add to_label.
+    4. Remove from_label.
+
+    If step 3 succeeds but step 4 fails, raises LabelTransitionError that
+    explicitly names both labels so the caller can surface the dual-label
+    state and take corrective action.
+
+    Parameters
+    ----------
+    issue_number : int
+        GitHub issue number.
+    from_label : str
+        The status:* label that should be removed (the current status).
+    to_label : str
+        The status:* label that should be added (the target status).
+
+    Raises
+    ------
+    LabelTransitionError
+        If the add succeeds but the remove fails, or if the HTTP call to add
+        fails outright.
+    requests.HTTPError
+        Propagated from _gh_post / _gh_delete for unexpected HTTP errors
+        (not wrapped, so the caller can inspect status codes).
+    """
+    current_labels = _get_issue_labels(issue_number)
+
+    # Idempotency: if the target label is already present, nothing to do.
+    if to_label in current_labels:
+        return
+
+    # Add the target label first so the issue is never unlabelled mid-transition.
+    _add_label(issue_number, to_label)
+
+    # Now remove the old label. If this fails we have a dual-label state —
+    # surface both label names so the caller can fix it.
+    try:
+        _remove_label(issue_number, from_label)
+    except Exception as exc:
+        raise LabelTransitionError(
+            f"Added {to_label!r} to issue #{issue_number} but failed to remove "
+            f"{from_label!r}: {exc}. Issue may have both labels — manual cleanup required.",
+            issue_number=issue_number,
+            from_label=from_label,
+            to_label=to_label,
+        ) from exc
+
+
+def get_status(issue_number: int) -> str | None:
+    """Return the current status:* label value for an issue, or None.
+
+    Parameters
+    ----------
+    issue_number : int
+        GitHub issue number.
+
+    Returns
+    -------
+    str | None
+        The status:* label name (e.g. "status:in-progress"), or None if no
+        status label is present.
+
+    Raises
+    ------
+    LabelTransitionError
+        If the issue has more than one status:* label (inconsistent state).
+    """
+    labels = _get_issue_labels(issue_number)
+    status_labels = [lbl for lbl in labels if lbl in ALL_STATUS_LABELS]
+
+    if len(status_labels) == 0:
+        return None
+
+    if len(status_labels) > 1:
+        raise LabelTransitionError(
+            f"Issue #{issue_number} has multiple status:* labels: {status_labels!r}. "
+            f"This is an inconsistent state — manual cleanup required.",
+            issue_number=issue_number,
+        )
+
+    return status_labels[0]
+
+
+def retire_in_review(issue_number: int) -> None:
+    """Migrate status:in-review -> status:review for a single issue.
+
+    One-time migration helper to retire the legacy status:in-review label
+    in favour of the two new labels introduced by ADR 002. Only the
+    human-review semantics are preserved here (the issue is past agent-review
+    and awaiting a human decision), so it maps to status:review.
+
+    If the issue does not have status:in-review, this is a no-op.
+
+    Parameters
+    ----------
+    issue_number : int
+        GitHub issue number.
+
+    Raises
+    ------
+    LabelTransitionError
+        If the add succeeds but the remove fails (dual-label state).
+    """
+    current_labels = _get_issue_labels(issue_number)
+
+    if _STATUS_IN_REVIEW_LEGACY not in current_labels:
+        # Already migrated or never had the legacy label — nothing to do.
+        return
+
+    # Reuse transition() for the atomic add-then-remove.
+    transition(issue_number, from_label=_STATUS_IN_REVIEW_LEGACY, to_label=STATUS_REVIEW)

--- a/apeiron_flow/src/apeiron_flow/main.py
+++ b/apeiron_flow/src/apeiron_flow/main.py
@@ -417,8 +417,8 @@ class ApeironFlow(Flow[IssueState]):
         try:
             _labels.transition(
                 self.state.issue_number,
-                _labels.LABEL_IN_PROGRESS,
-                from_label=_labels.LABEL_READY,
+                from_label=_labels.STATUS_READY,
+                to_label=_labels.STATUS_IN_PROGRESS,
             )
         except Exception as label_err:
             print(f"[WARN] Could not transition label to in-progress: {label_err}")
@@ -463,7 +463,9 @@ class ApeironFlow(Flow[IssueState]):
                     f"Transitioning issue #{self.state.issue_number} to status:blocked."
                 )
                 try:
-                    _labels.transition(self.state.issue_number, _labels.LABEL_BLOCKED)
+                    _labels.transition(
+                        self.state.issue_number, from_label=_labels.STATUS_IN_PROGRESS, to_label=_labels.STATUS_BLOCKED
+                    )
                 except Exception as label_err:
                     print(f"[WARN] Could not transition label: {label_err}")
                 error_body = (
@@ -521,8 +523,8 @@ class ApeironFlow(Flow[IssueState]):
         try:
             _labels.transition(
                 self.state.issue_number,
-                _labels.LABEL_AGENT_REVIEW,
-                from_label=_labels.LABEL_IN_PROGRESS,
+                from_label=_labels.STATUS_IN_PROGRESS,
+                to_label=_labels.STATUS_AGENT_REVIEW,
             )
         except Exception as label_err:
             print(f"[WARN] Could not transition label to agent-review: {label_err}")
@@ -539,7 +541,9 @@ class ApeironFlow(Flow[IssueState]):
         print("=" * 60)
         print(self.state.blocker or self.state.result)
         try:
-            _labels.transition(self.state.issue_number, _labels.LABEL_BLOCKED)
+            _labels.transition(
+                self.state.issue_number, from_label=_labels.STATUS_IN_PROGRESS, to_label=_labels.STATUS_BLOCKED
+            )
         except Exception as label_err:
             print(f"[WARN] Could not transition label to blocked: {label_err}")
 
@@ -628,8 +632,8 @@ class ReviewFlow(Flow[ReviewState]):
             try:
                 _labels.transition(
                     issue_number,
-                    _labels.LABEL_IN_PROGRESS,
-                    from_label=_labels.LABEL_AGENT_REVIEW,
+                    from_label=_labels.STATUS_AGENT_REVIEW,
+                    to_label=_labels.STATUS_IN_PROGRESS,
                 )
             except Exception as label_err:
                 print(f"[WARN] Could not transition label to in-progress: {label_err}")
@@ -650,8 +654,8 @@ class ReviewFlow(Flow[ReviewState]):
             try:
                 _labels.transition(
                     issue_number,
-                    _labels.LABEL_REVIEW,
-                    from_label=_labels.LABEL_AGENT_REVIEW,
+                    from_label=_labels.STATUS_AGENT_REVIEW,
+                    to_label=_labels.STATUS_REVIEW,
                 )
             except Exception as label_err:
                 print(f"[WARN] Could not transition label to review: {label_err}")
@@ -800,8 +804,8 @@ class RespondFlow(Flow[RespondState]):
                 try:
                     _labels.transition(
                         issue_number,
-                        _labels.LABEL_IN_PROGRESS,
-                        from_label=_labels.LABEL_REVIEW,
+                        from_label=_labels.STATUS_REVIEW,
+                        to_label=_labels.STATUS_IN_PROGRESS,
                     )
                 except Exception as label_err:
                     print(f"[WARN] Could not transition label to in-progress: {label_err}")
@@ -1134,8 +1138,10 @@ class TriageFlow(Flow[TriageState]):
         # and did NOT classify the issue — label must stay as status:triage).
         if result.classification != "blocked_ambiguous":
             try:
-                _labels.transition(self.state.issue_number, _labels.LABEL_TODO, _labels.LABEL_TRIAGE)
-                print(f"[TriageFlow] Transitioned #{self.state.issue_number} to {_labels.LABEL_TODO}")
+                _labels.transition(
+                    self.state.issue_number, from_label=_labels.STATUS_TRIAGE, to_label=_labels.STATUS_TODO
+                )
+                print(f"[TriageFlow] Transitioned #{self.state.issue_number} to {_labels.STATUS_TODO}")
             except Exception as label_err:
                 print(f"[WARN] Could not transition label for #{self.state.issue_number}: {label_err}")
         return result

--- a/apeiron_flow/src/apeiron_flow/migrate_in_review.py
+++ b/apeiron_flow/src/apeiron_flow/migrate_in_review.py
@@ -23,7 +23,10 @@ import sys
 from apeiron_flow.config import REPO
 from apeiron_flow.labels import (
     LABEL_IN_REVIEW,
-    retire_in_review,
+    STATUS_AGENT_REVIEW,
+    STATUS_IN_PROGRESS,
+    STATUS_REVIEW,
+    transition,
 )
 
 # The bot login that posts structured agent review comments.
@@ -178,18 +181,20 @@ def run_migration(dry_run: bool = False) -> None:
         # Apply migration
         if dry_run:
             if not has_pr:
-                new_label = "status:in-progress"
+                new_label = STATUS_IN_PROGRESS
             elif not agent_review_posted:
-                new_label = "status:agent-review"
+                new_label = STATUS_AGENT_REVIEW
             else:
-                new_label = "status:review"
+                new_label = STATUS_REVIEW
             print(f"  [dry-run] would retire_in_review(#{number}) → {new_label}")
         else:
-            new_label = retire_in_review(
-                number,
-                has_pr=has_pr,
-                agent_review_posted=agent_review_posted,
-            )
+            if not has_pr:
+                new_label = STATUS_IN_PROGRESS
+            elif not agent_review_posted:
+                new_label = STATUS_AGENT_REVIEW
+            else:
+                new_label = STATUS_REVIEW
+            transition(number, from_label=LABEL_IN_REVIEW, to_label=new_label)
             print(f"  Migrated #{number} → {new_label}")
 
         # Post explanatory comment

--- a/apeiron_flow/tests/test_label_wiring.py
+++ b/apeiron_flow/tests/test_label_wiring.py
@@ -161,15 +161,15 @@ def test_get_issue_for_pr_uses_list_form_no_shell(mock_run):
 @patch("apeiron_flow.main._create_worktree", return_value=("/fake/wt", False))
 @patch("apeiron_flow.main._fetch_issue")
 def test_prepare_transitions_to_in_progress(mock_fetch, mock_create_wt, mock_set_path, mock_labels):
-    """prepare() calls transition(issue_number, LABEL_IN_PROGRESS, from_label=LABEL_READY)."""
+    """prepare() calls transition(issue_number, STATUS_IN_PROGRESS, from_label=STATUS_READY)."""
     mock_fetch.return_value = {"title": "T", "body": "B", "labels": []}
     state = _make_issue_state()
     flow = _build_flow(state)
     flow.prepare()
     mock_labels.transition.assert_called_once_with(
         42,
-        mock_labels.LABEL_IN_PROGRESS,
-        from_label=mock_labels.LABEL_READY,
+        from_label=mock_labels.STATUS_READY,
+        to_label=mock_labels.STATUS_IN_PROGRESS,
     )
 
 
@@ -204,8 +204,8 @@ def test_trigger_review_transitions_to_agent_review(mock_kickoff, mock_labels):
     flow.trigger_review()
     mock_labels.transition.assert_called_once_with(
         42,
-        mock_labels.LABEL_AGENT_REVIEW,
-        from_label=mock_labels.LABEL_IN_PROGRESS,
+        from_label=mock_labels.STATUS_IN_PROGRESS,
+        to_label=mock_labels.STATUS_AGENT_REVIEW,
     )
 
 
@@ -234,7 +234,9 @@ def test_report_blocker_transitions_to_blocked(mock_labels):
     state.blocker = "some blocker"
     flow = _build_flow(state)
     flow.report_blocker()
-    mock_labels.transition.assert_called_once_with(42, mock_labels.LABEL_BLOCKED)
+    mock_labels.transition.assert_called_once_with(
+        42, from_label=mock_labels.STATUS_IN_PROGRESS, to_label=mock_labels.STATUS_BLOCKED
+    )
 
 
 @patch("apeiron_flow.main._labels")
@@ -263,8 +265,8 @@ def test_on_ready_for_merge_transitions_to_review(mock_get_issue, mock_labels):
     flow.on_ready_for_merge()
     mock_labels.transition.assert_called_once_with(
         42,
-        mock_labels.LABEL_REVIEW,
-        from_label=mock_labels.LABEL_AGENT_REVIEW,
+        from_label=mock_labels.STATUS_AGENT_REVIEW,
+        to_label=mock_labels.STATUS_REVIEW,
     )
 
 
@@ -306,8 +308,8 @@ def test_on_code_changes_required_transitions_to_in_progress(mock_get_issue, moc
     flow.on_code_changes_required()
     mock_labels.transition.assert_called_once_with(
         42,
-        mock_labels.LABEL_IN_PROGRESS,
-        from_label=mock_labels.LABEL_AGENT_REVIEW,
+        from_label=mock_labels.STATUS_AGENT_REVIEW,
+        to_label=mock_labels.STATUS_IN_PROGRESS,
     )
 
 
@@ -367,8 +369,8 @@ def test_handle_change_request_transitions_review_to_in_progress(
 
     mock_labels.transition.assert_called_once_with(
         42,
-        mock_labels.LABEL_IN_PROGRESS,
-        from_label=mock_labels.LABEL_REVIEW,
+        from_label=mock_labels.STATUS_REVIEW,
+        to_label=mock_labels.STATUS_IN_PROGRESS,
     )
 
 

--- a/apeiron_flow/tests/test_labels.py
+++ b/apeiron_flow/tests/test_labels.py
@@ -1,229 +1,335 @@
 """
 Unit tests for apeiron_flow.labels.
 
-Tests verify:
-- ALLOWED_TRANSITIONS table has correct entries
-- transition() calls gh label edit in the right order
-- transition() raises ValueError for disallowed transitions
-- _add_label / _remove_label surface RuntimeError on gh failure
+All GitHub HTTP calls are mocked — no live network access.
+
+Coverage
+--------
+- Status label constants match ADR 002 spec
+- ALL_STATUS_LABELS frozenset completeness
+- LabelTransitionError carries correct attributes
+- get_status() — happy path, None, multi-label error
+- transition() — happy path, idempotency, dual-label error on remove failure
+- retire_in_review() — migrates legacy label, no-op when absent
+- _get_issue_labels() — surfaces unexpected response type
 """
 
-import json
-from unittest.mock import MagicMock, patch
+import os
+from unittest.mock import patch
 
 import pytest
 
-from apeiron_flow.labels import (
-    ALL_STATUS_LABELS,
-    ALLOWED_TRANSITIONS,
-    LABEL_AGENT_REVIEW,
-    LABEL_BLOCKED,
-    LABEL_DONE,
-    LABEL_IN_PROGRESS,
-    LABEL_READY,
-    LABEL_REVIEW,
-    LABEL_TODO,
-    LABEL_TRIAGE,
-    _add_label,
-    _remove_label,
-    transition,
-)
-
-# ---------------------------------------------------------------------------
-# Constant invariants
-# ---------------------------------------------------------------------------
-
-
-def test_all_status_labels_contains_seven_canonical_states():
-    expected = {
-        "status:triage",
-        "status:todo",
-        "status:ready",
-        "status:in-progress",
-        "status:agent-review",
-        "status:review",
-        "status:done",
-        "status:blocked",
-    }
-    assert expected == ALL_STATUS_LABELS
-
-
-def test_allowed_transitions_contains_triage_to_todo():
-    assert (LABEL_TRIAGE, LABEL_TODO) in ALLOWED_TRANSITIONS
-
-
-def test_allowed_transitions_contains_wildcard_to_blocked():
-    assert (None, LABEL_BLOCKED) in ALLOWED_TRANSITIONS
-
-
-def test_allowed_transitions_pipeline_chain():
-    """Verify the happy path chain exists end-to-end."""
-    chain = [
-        (LABEL_TRIAGE, LABEL_TODO),
-        (LABEL_TODO, LABEL_READY),
-        (LABEL_READY, LABEL_IN_PROGRESS),
-        (LABEL_IN_PROGRESS, LABEL_AGENT_REVIEW),
-        (LABEL_AGENT_REVIEW, LABEL_REVIEW),
-        (LABEL_REVIEW, LABEL_DONE),
-    ]
-    for pair in chain:
-        assert pair in ALLOWED_TRANSITIONS, f"Missing transition {pair}"
+os.environ.setdefault("APEIRON_REPO_PATH", "/tmp/fake-repo")
+os.environ.setdefault("RESPOND_DB", "/tmp/test_respond_sessions.db")
 
 
 # ---------------------------------------------------------------------------
-# _add_label / _remove_label
+# Import helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_completed_process(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
-    p = MagicMock()
-    p.returncode = returncode
-    p.stdout = stdout
-    p.stderr = stderr
-    return p
+def _import_labels():
+    """Import the labels module, isolating it from the test namespace."""
+    import apeiron_flow.labels as labels
+
+    return labels
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_add_label_calls_gh_correctly(mock_run):
-    mock_run.return_value = _make_completed_process(0)
-    _add_label(42, "status:todo")
-    mock_run.assert_called_once_with(
-        [
-            "gh",
-            "issue",
-            "edit",
-            "42",
-            "--repo",
-            pytest.importorskip("apeiron_flow.config").REPO,
-            "--add-label",
-            "status:todo",
-        ],
-        capture_output=True,
-        text=True,
-    )
+# ---------------------------------------------------------------------------
+# 1. Constants
+# ---------------------------------------------------------------------------
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_add_label_raises_on_nonzero_exit(mock_run):
-    mock_run.return_value = _make_completed_process(1, stderr="not found")
-    with pytest.raises(RuntimeError, match="not found"):
-        _add_label(42, "status:todo")
+class TestConstants:
+    """Status label constants must match the ADR 002 spec exactly."""
 
+    def setup_method(self):
+        self.labels = _import_labels()
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_remove_label_calls_gh_correctly(mock_run):
-    mock_run.return_value = _make_completed_process(0)
-    _remove_label(42, "status:triage")
-    mock_run.assert_called_once_with(
-        [
-            "gh",
-            "issue",
-            "edit",
-            "42",
-            "--repo",
-            pytest.importorskip("apeiron_flow.config").REPO,
-            "--remove-label",
+    def test_status_triage(self):
+        assert self.labels.STATUS_TRIAGE == "status:triage"
+
+    def test_status_todo(self):
+        assert self.labels.STATUS_TODO == "status:todo"
+
+    def test_status_ready(self):
+        assert self.labels.STATUS_READY == "status:ready"
+
+    def test_status_in_progress(self):
+        assert self.labels.STATUS_IN_PROGRESS == "status:in-progress"
+
+    def test_status_agent_review(self):
+        assert self.labels.STATUS_AGENT_REVIEW == "status:agent-review"
+
+    def test_status_review(self):
+        assert self.labels.STATUS_REVIEW == "status:review"
+
+    def test_status_blocked(self):
+        assert self.labels.STATUS_BLOCKED == "status:blocked"
+
+    def test_status_done(self):
+        assert self.labels.STATUS_DONE == "status:done"
+
+    def test_all_status_labels_is_frozenset(self):
+        assert isinstance(self.labels.ALL_STATUS_LABELS, frozenset)
+
+    def test_all_status_labels_contains_all_eight_states(self):
+        expected = {
             "status:triage",
-        ],
-        capture_output=True,
-        text=True,
-    )
-
-
-@patch("apeiron_flow.labels.subprocess.run")
-def test_remove_label_raises_on_nonzero_exit(mock_run):
-    mock_run.return_value = _make_completed_process(1, stderr="label not found")
-    with pytest.raises(RuntimeError, match="label not found"):
-        _remove_label(42, "status:triage")
+            "status:todo",
+            "status:ready",
+            "status:in-progress",
+            "status:agent-review",
+            "status:review",
+            "status:blocked",
+            "status:done",
+        }
+        assert expected == self.labels.ALL_STATUS_LABELS
 
 
 # ---------------------------------------------------------------------------
-# transition()
+# 2. LabelTransitionError
 # ---------------------------------------------------------------------------
 
 
-def _gh_view_response(labels: list[str]) -> MagicMock:
-    """Build a fake subprocess.run return for 'gh issue view --json labels'."""
-    body = json.dumps({"labels": [{"name": lbl} for lbl in labels]})
-    return _make_completed_process(0, stdout=body)
+class TestLabelTransitionError:
+    def setup_method(self):
+        self.labels = _import_labels()
+
+    def test_inherits_from_exception(self):
+        err = self.labels.LabelTransitionError("msg", issue_number=1)
+        assert isinstance(err, Exception)
+
+    def test_message_is_str_arg(self):
+        err = self.labels.LabelTransitionError("test message", issue_number=42)
+        assert str(err) == "test message"
+
+    def test_attributes_are_set(self):
+        err = self.labels.LabelTransitionError(
+            "bad",
+            issue_number=7,
+            from_label="status:triage",
+            to_label="status:done",
+        )
+        assert err.issue_number == 7
+        assert err.from_label == "status:triage"
+        assert err.to_label == "status:done"
+
+    def test_optional_labels_default_to_none(self):
+        err = self.labels.LabelTransitionError("msg", issue_number=1)
+        assert err.from_label is None
+        assert err.to_label is None
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_triage_to_todo(mock_run):
-    """Normal happy path: status:triage → status:todo."""
-    # First call: gh issue view (returns current labels)
-    # Subsequent calls: gh issue edit --remove-label, --add-label
-    mock_run.side_effect = [
-        _gh_view_response(["status:triage", "priority:high"]),
-        _make_completed_process(0),  # remove status:triage
-        _make_completed_process(0),  # add status:todo
-    ]
-
-    transition(42, LABEL_TODO, from_label=LABEL_TRIAGE)
-
-    assert mock_run.call_count == 3
-    # Second call removes old label
-    assert "--remove-label" in mock_run.call_args_list[1][0][0]
-    assert "status:triage" in mock_run.call_args_list[1][0][0]
-    # Third call adds new label
-    assert "--add-label" in mock_run.call_args_list[2][0][0]
-    assert "status:todo" in mock_run.call_args_list[2][0][0]
+# ---------------------------------------------------------------------------
+# Shared mock factory
+# ---------------------------------------------------------------------------
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_does_not_remove_target_label_if_already_present(mock_run):
-    """If the issue already has the target label, it should not be removed then re-added
-    in a way that causes a spurious remove call."""
-    mock_run.side_effect = [
-        _gh_view_response(["status:todo"]),  # already has target
-        _make_completed_process(0),  # add (idempotent on GitHub)
-    ]
-
-    # triage → todo is a valid transition; supply from_label so validation passes
-    transition(42, LABEL_TODO, from_label=LABEL_TRIAGE)
-
-    # Should NOT have called remove for status:todo
-    calls_args = [c[0][0] for c in mock_run.call_args_list]
-    for args in calls_args:
-        if "--remove-label" in args:
-            assert "status:todo" not in args, "Must not remove the target label"
+def _make_label_response(names: list[str]) -> list[dict]:
+    """Build the list GitHub returns from GET /issues/{n}/labels."""
+    return [{"name": n, "color": "ff0000", "description": ""} for n in names]
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_raises_for_disallowed_from_to(mock_run):
-    """Providing an invalid from_label should raise ValueError before any gh call."""
-    with pytest.raises(ValueError, match="not in ALLOWED_TRANSITIONS"):
-        transition(42, LABEL_TRIAGE, from_label=LABEL_DONE)
-
-    mock_run.assert_not_called()
+# ---------------------------------------------------------------------------
+# 3. get_status()
+# ---------------------------------------------------------------------------
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_raises_when_no_from_and_no_wildcard(mock_run):
-    """Transitioning to a non-wildcard target without from_label should raise."""
-    with pytest.raises(ValueError, match="not in ALLOWED_TRANSITIONS"):
-        transition(42, LABEL_TRIAGE)  # (None, triage) is not in table
+class TestGetStatus:
+    def setup_method(self):
+        self.labels = _import_labels()
 
-    mock_run.assert_not_called()
+    @patch("apeiron_flow.labels._gh_get")
+    def test_returns_current_status_label(self, mock_get):
+        mock_get.return_value = _make_label_response(["status:in-progress", "priority:high"])
+        result = self.labels.get_status(42)
+        assert result == "status:in-progress"
+
+    @patch("apeiron_flow.labels._gh_get")
+    def test_returns_none_when_no_status_label(self, mock_get):
+        mock_get.return_value = _make_label_response(["priority:high", "bug"])
+        result = self.labels.get_status(42)
+        assert result is None
+
+    @patch("apeiron_flow.labels._gh_get")
+    def test_returns_none_for_empty_label_list(self, mock_get):
+        mock_get.return_value = []
+        result = self.labels.get_status(42)
+        assert result is None
+
+    @patch("apeiron_flow.labels._gh_get")
+    def test_raises_on_multiple_status_labels(self, mock_get):
+        mock_get.return_value = _make_label_response(["status:in-progress", "status:review"])
+        with pytest.raises(self.labels.LabelTransitionError, match="multiple status"):
+            self.labels.get_status(42)
+
+    def test_calls_correct_api_path(self):
+        import apeiron_flow.config as cfg
+
+        owner, repo = cfg.REPO.split("/")
+        with patch("apeiron_flow.labels._gh_get") as mock_get:
+            mock_get.return_value = _make_label_response(["status:todo"])
+            self.labels.get_status(99)
+            mock_get.assert_called_once_with(f"/repos/{owner}/{repo}/issues/99/labels")
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_wildcard_any_to_blocked(mock_run):
-    """Any state → blocked should succeed without specifying from_label."""
-    mock_run.side_effect = [
-        _gh_view_response(["status:in-progress"]),
-        _make_completed_process(0),  # remove status:in-progress
-        _make_completed_process(0),  # add status:blocked
-    ]
-
-    transition(99, LABEL_BLOCKED)  # no from_label — uses (None, blocked) wildcard
-    assert mock_run.call_count == 3
+# ---------------------------------------------------------------------------
+# 4. transition()
+# ---------------------------------------------------------------------------
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_transition_raises_on_gh_view_failure(mock_run):
-    """gh issue view failure should raise RuntimeError."""
-    mock_run.return_value = _make_completed_process(1, stderr="API rate limit")
-    with pytest.raises(RuntimeError, match="API rate limit"):
-        # Use a wildcard-safe transition so we get past validation
-        transition(42, LABEL_BLOCKED)  # (None, blocked) wildcard is valid
+class TestTransition:
+    def setup_method(self):
+        self.labels = _import_labels()
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_happy_path_adds_then_removes(self, mock_get, mock_post):
+        """to_label added first, from_label removed second."""
+        import apeiron_flow.config as cfg
+
+        owner, repo = cfg.REPO.split("/")
+
+        mock_get.return_value = _make_label_response(["status:triage", "priority:low"])
+
+        with patch("apeiron_flow.labels._gh_delete") as mock_delete:
+            self.labels.transition(42, from_label="status:triage", to_label="status:todo")
+
+            # Add was called with correct path and body
+            mock_post.assert_called_once_with(
+                f"/repos/{owner}/{repo}/issues/42/labels",
+                {"labels": ["status:todo"]},
+            )
+            # Remove was called after add
+            mock_delete.assert_called_once_with(
+                f"/repos/{owner}/{repo}/issues/42/labels/status:triage", ignore_not_found=True
+            )
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_no_op_when_to_label_already_present(self, mock_get, mock_post):
+        """If the issue already has to_label, nothing should happen."""
+        mock_get.return_value = _make_label_response(["status:todo"])
+
+        with patch("apeiron_flow.labels._gh_delete") as mock_delete:
+            self.labels.transition(42, from_label="status:triage", to_label="status:todo")
+            mock_post.assert_not_called()
+            mock_delete.assert_not_called()
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_raises_label_transition_error_when_remove_fails(self, mock_get, mock_post):
+        """Add succeeds, remove fails -> LabelTransitionError naming both labels."""
+        mock_get.return_value = _make_label_response(["status:triage"])
+
+        http_error = RuntimeError("422 Unprocessable Entity")
+
+        with patch("apeiron_flow.labels._gh_delete", side_effect=http_error):
+            with pytest.raises(self.labels.LabelTransitionError) as exc_info:
+                self.labels.transition(42, from_label="status:triage", to_label="status:todo")
+
+            err = exc_info.value
+            assert err.from_label == "status:triage"
+            assert err.to_label == "status:todo"
+            assert err.issue_number == 42
+            # Both label names must appear in the message
+            assert "status:triage" in str(err)
+            assert "status:todo" in str(err)
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_add_is_called_before_remove(self, mock_get, mock_post):
+        """Ordering guarantee: add first, remove second."""
+        call_order = []
+        mock_get.return_value = _make_label_response(["status:ready"])
+        mock_post.side_effect = lambda *a, **kw: call_order.append("add")
+
+        with patch("apeiron_flow.labels._gh_delete", side_effect=lambda *a, **kw: call_order.append("remove")):
+            self.labels.transition(7, from_label="status:ready", to_label="status:in-progress")
+
+        assert call_order == ["add", "remove"], f"Expected add before remove, got: {call_order}"
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_non_status_labels_are_not_removed(self, mock_get, mock_post):
+        """Only from_label should be removed — other labels on the issue are untouched."""
+        mock_get.return_value = _make_label_response(["status:ready", "priority:high", "story"])
+
+        deleted_paths = []
+        with patch("apeiron_flow.labels._gh_delete", side_effect=lambda p, **kw: deleted_paths.append(p)):
+            self.labels.transition(10, from_label="status:ready", to_label="status:in-progress")
+
+        # Only one delete call — the from_label
+        assert len(deleted_paths) == 1
+        assert "status:ready" in deleted_paths[0]
+
+
+# ---------------------------------------------------------------------------
+# 5. retire_in_review()
+# ---------------------------------------------------------------------------
+
+
+class TestRetireInReview:
+    def setup_method(self):
+        self.labels = _import_labels()
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_migrates_in_review_to_review(self, mock_get, mock_post):
+        """status:in-review -> status:review when the label is present."""
+        import apeiron_flow.config as cfg
+
+        owner, repo = cfg.REPO.split("/")
+
+        mock_get.return_value = _make_label_response(["status:in-review", "priority:low"])
+
+        with patch("apeiron_flow.labels._gh_delete") as mock_delete:
+            self.labels.retire_in_review(55)
+
+            # add status:review
+            mock_post.assert_called_once_with(
+                f"/repos/{owner}/{repo}/issues/55/labels",
+                {"labels": ["status:review"]},
+            )
+            # remove status:in-review
+            mock_delete.assert_called_once_with(
+                f"/repos/{owner}/{repo}/issues/55/labels/status:in-review", ignore_not_found=True
+            )
+
+    @patch("apeiron_flow.labels._gh_post")
+    @patch("apeiron_flow.labels._gh_get")
+    def test_no_op_when_in_review_absent(self, mock_get, mock_post):
+        """If the legacy label is not present, nothing should happen."""
+        mock_get.return_value = _make_label_response(["status:review"])
+
+        with patch("apeiron_flow.labels._gh_delete") as mock_delete:
+            self.labels.retire_in_review(55)
+            mock_post.assert_not_called()
+            mock_delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. _get_issue_labels() edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestGetIssueLabels:
+    def setup_method(self):
+        import apeiron_flow.labels as labels
+
+        self.labels = labels
+        self._get_issue_labels = labels._get_issue_labels
+
+    @patch("apeiron_flow.labels._gh_get")
+    def test_raises_on_non_list_response(self, mock_get):
+        """If GitHub returns a dict (error) instead of a list, raise LabelTransitionError."""
+        mock_get.return_value = {"message": "Not Found"}
+        with pytest.raises(self.labels.LabelTransitionError, match="Unexpected response"):
+            self._get_issue_labels(42)
+
+    @patch("apeiron_flow.labels._gh_get")
+    def test_returns_list_of_label_names(self, mock_get):
+        mock_get.return_value = _make_label_response(["a", "b", "c"])
+        result = self._get_issue_labels(1)
+        assert result == ["a", "b", "c"]

--- a/apeiron_flow/tests/test_make_check_gate.py
+++ b/apeiron_flow/tests/test_make_check_gate.py
@@ -323,7 +323,9 @@ def test_implement_blocks_after_max_retries(
     # check called MAX_CHECK_RETRIES times
     assert mock_check.call_count == MAX_CHECK_RETRIES
     # label transition to blocked
-    mock_labels.transition.assert_called_once_with(state.issue_number, mock_labels.LABEL_BLOCKED)
+    mock_labels.transition.assert_called_once_with(
+        state.issue_number, from_label=mock_labels.STATUS_IN_PROGRESS, to_label=mock_labels.STATUS_BLOCKED
+    )
     # blocker comment posted
     mock_post_comment.assert_called_once()
     comment_body = mock_post_comment.call_args[0][1]

--- a/apeiron_flow/tests/test_migrate_in_review.py
+++ b/apeiron_flow/tests/test_migrate_in_review.py
@@ -8,11 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from apeiron_flow.labels import (
-    LABEL_AGENT_REVIEW,
-    LABEL_IN_PROGRESS,
     LABEL_IN_REVIEW,
-    LABEL_REVIEW,
-    retire_in_review,
+    STATUS_AGENT_REVIEW,
+    STATUS_IN_PROGRESS,
+    STATUS_REVIEW,
 )
 from apeiron_flow.migrate_in_review import (
     _archive_label,
@@ -41,53 +40,47 @@ def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_retire_in_review_no_pr_gives_in_progress(mock_run):
-    """No PR open → status:in-progress."""
-    mock_run.side_effect = [
-        _proc(0),  # _remove_label(status:in-review)
-        _proc(0),  # _add_label(status:in-progress)
-    ]
-    result = retire_in_review(42, has_pr=False)
-    assert result == LABEL_IN_PROGRESS
-    # First call removes status:in-review
-    assert "--remove-label" in mock_run.call_args_list[0][0][0]
-    assert LABEL_IN_REVIEW in mock_run.call_args_list[0][0][0]
-    # Second call adds status:in-progress
-    assert "--add-label" in mock_run.call_args_list[1][0][0]
-    assert LABEL_IN_PROGRESS in mock_run.call_args_list[1][0][0]
+@patch("apeiron_flow.labels._gh_delete")
+@patch("apeiron_flow.labels._gh_post")
+@patch("apeiron_flow.labels._gh_get")
+def test_retire_in_review_no_in_review_label_is_noop(mock_get, mock_post, mock_delete):
+    """Issue already migrated (no status:in-review) → no-op."""
+    mock_get.return_value = [{"name": STATUS_REVIEW}]
+    from apeiron_flow.labels import retire_in_review
+
+    retire_in_review(42)
+    mock_post.assert_not_called()
+    mock_delete.assert_not_called()
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_retire_in_review_pr_no_agent_review_gives_agent_review(mock_run):
-    """PR open, no agent review → status:agent-review."""
-    mock_run.side_effect = [
-        _proc(0),  # _remove_label
-        _proc(0),  # _add_label
-    ]
-    result = retire_in_review(7, has_pr=True, agent_review_posted=False)
-    assert result == LABEL_AGENT_REVIEW
-    assert LABEL_AGENT_REVIEW in mock_run.call_args_list[1][0][0]
+@patch("apeiron_flow.labels._gh_delete")
+@patch("apeiron_flow.labels._gh_post")
+@patch("apeiron_flow.labels._gh_get")
+def test_retire_in_review_migrates_to_review(mock_get, mock_post, mock_delete):
+    """Issue has status:in-review → transition to status:review."""
+    mock_get.return_value = [{"name": LABEL_IN_REVIEW}]
+    mock_post.return_value = [{"name": STATUS_REVIEW}]
+    from apeiron_flow.labels import retire_in_review
+
+    retire_in_review(7)
+    # _add_label call goes via _gh_post
+    mock_post.assert_called_once()
+    post_body = mock_post.call_args[0][1]
+    assert STATUS_REVIEW in post_body["labels"]
 
 
-@patch("apeiron_flow.labels.subprocess.run")
-def test_retire_in_review_pr_with_agent_review_gives_review(mock_run):
-    """PR open, agent review posted → status:review."""
-    mock_run.side_effect = [
-        _proc(0),  # _remove_label
-        _proc(0),  # _add_label
-    ]
-    result = retire_in_review(7, has_pr=True, agent_review_posted=True)
-    assert result == LABEL_REVIEW
-    assert LABEL_REVIEW in mock_run.call_args_list[1][0][0]
+@patch("apeiron_flow.labels._gh_delete")
+@patch("apeiron_flow.labels._gh_post")
+@patch("apeiron_flow.labels._gh_get")
+def test_retire_in_review_propagates_remove_failure(mock_get, mock_post, mock_delete):
+    """LabelTransitionError from _remove_label bubbles up."""
+    from apeiron_flow.labels import LabelTransitionError, retire_in_review
 
-
-@patch("apeiron_flow.labels.subprocess.run")
-def test_retire_in_review_propagates_remove_failure(mock_run):
-    """RuntimeError from _remove_label bubbles up."""
-    mock_run.return_value = _proc(1, stderr="not found")
-    with pytest.raises(RuntimeError, match="not found"):
-        retire_in_review(99, has_pr=False)
+    mock_get.return_value = [{"name": LABEL_IN_REVIEW}]
+    mock_post.return_value = [{"name": STATUS_REVIEW}]
+    mock_delete.side_effect = RuntimeError("delete failed")
+    with pytest.raises((LabelTransitionError, RuntimeError)):
+        retire_in_review(99)
 
 
 # ---------------------------------------------------------------------------
@@ -221,64 +214,61 @@ def test_archive_label_dry_run_does_not_call_gh(capsys):
 
 @patch("apeiron_flow.migrate_in_review._archive_label")
 @patch("apeiron_flow.migrate_in_review._post_comment")
-@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review.transition")
 @patch("apeiron_flow.migrate_in_review._has_agent_review")
 @patch("apeiron_flow.migrate_in_review._find_open_pr")
 @patch("apeiron_flow.migrate_in_review._list_in_review_issues")
-def test_run_migration_no_pr(mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive):
-    """Issue with no PR → retire_in_review called with has_pr=False."""
+def test_run_migration_no_pr(mock_list, mock_find_pr, mock_has_review, mock_transition, mock_comment, mock_archive):
+    """Issue with no PR → transition called with STATUS_IN_PROGRESS."""
     mock_list.return_value = [{"number": 14, "title": "Story 3.3", "labels": []}]
     mock_find_pr.return_value = None
-    mock_retire.return_value = LABEL_IN_PROGRESS
 
     run_migration(dry_run=False)
 
-    mock_retire.assert_called_once_with(14, has_pr=False, agent_review_posted=False)
+    mock_transition.assert_called_once_with(14, from_label=LABEL_IN_REVIEW, to_label=STATUS_IN_PROGRESS)
     mock_comment.assert_called_once()
     comment_body = mock_comment.call_args[0][1]
-    assert LABEL_IN_PROGRESS in comment_body
+    assert STATUS_IN_PROGRESS in comment_body
     mock_archive.assert_called_once_with(False)
 
 
 @patch("apeiron_flow.migrate_in_review._archive_label")
 @patch("apeiron_flow.migrate_in_review._post_comment")
-@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review.transition")
 @patch("apeiron_flow.migrate_in_review._has_agent_review")
 @patch("apeiron_flow.migrate_in_review._find_open_pr")
 @patch("apeiron_flow.migrate_in_review._list_in_review_issues")
 def test_run_migration_pr_no_agent_review(
-    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+    mock_list, mock_find_pr, mock_has_review, mock_transition, mock_comment, mock_archive
 ):
-    """Issue with open PR, no agent review → retire_in_review with has_pr=True, agent_review_posted=False."""
+    """Issue with open PR, no agent review → transition to STATUS_AGENT_REVIEW."""
     mock_list.return_value = [{"number": 7, "title": "Story X", "labels": []}]
     mock_find_pr.return_value = {"number": 55, "title": "feat", "headRefName": "feat/issue-7"}
     mock_has_review.return_value = False
-    mock_retire.return_value = LABEL_AGENT_REVIEW
 
     run_migration(dry_run=False)
 
-    mock_retire.assert_called_once_with(7, has_pr=True, agent_review_posted=False)
+    mock_transition.assert_called_once_with(7, from_label=LABEL_IN_REVIEW, to_label=STATUS_AGENT_REVIEW)
     mock_archive.assert_called_once_with(False)
 
 
 @patch("apeiron_flow.migrate_in_review._archive_label")
 @patch("apeiron_flow.migrate_in_review._post_comment")
-@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review.transition")
 @patch("apeiron_flow.migrate_in_review._has_agent_review")
 @patch("apeiron_flow.migrate_in_review._find_open_pr")
 @patch("apeiron_flow.migrate_in_review._list_in_review_issues")
 def test_run_migration_pr_with_agent_review(
-    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+    mock_list, mock_find_pr, mock_has_review, mock_transition, mock_comment, mock_archive
 ):
-    """Issue with open PR, agent review present → retire_in_review with has_pr=True, agent_review_posted=True."""
+    """Issue with open PR, agent review present → transition to STATUS_REVIEW."""
     mock_list.return_value = [{"number": 7, "title": "Story X", "labels": []}]
     mock_find_pr.return_value = {"number": 55, "title": "feat", "headRefName": "feat/issue-7"}
     mock_has_review.return_value = True
-    mock_retire.return_value = LABEL_REVIEW
 
     run_migration(dry_run=False)
 
-    mock_retire.assert_called_once_with(7, has_pr=True, agent_review_posted=True)
+    mock_transition.assert_called_once_with(7, from_label=LABEL_IN_REVIEW, to_label=STATUS_REVIEW)
     mock_archive.assert_called_once_with(False)
 
 
@@ -293,20 +283,20 @@ def test_run_migration_nothing_to_do(mock_list, mock_archive):
 
 @patch("apeiron_flow.migrate_in_review._archive_label")
 @patch("apeiron_flow.migrate_in_review._post_comment")
-@patch("apeiron_flow.migrate_in_review.retire_in_review")
+@patch("apeiron_flow.migrate_in_review.transition")
 @patch("apeiron_flow.migrate_in_review._has_agent_review")
 @patch("apeiron_flow.migrate_in_review._find_open_pr")
 @patch("apeiron_flow.migrate_in_review._list_in_review_issues")
-def test_run_migration_dry_run_does_not_call_retire(
-    mock_list, mock_find_pr, mock_has_review, mock_retire, mock_comment, mock_archive
+def test_run_migration_dry_run_does_not_call_transition(
+    mock_list, mock_find_pr, mock_has_review, mock_transition, mock_comment, mock_archive
 ):
-    """Dry run: retire_in_review is NOT called; comment and archive are called with dry_run=True."""
+    """Dry run: transition is NOT called; comment and archive are called with dry_run=True."""
     mock_list.return_value = [{"number": 14, "title": "Story 3.3", "labels": []}]
     mock_find_pr.return_value = None
 
     run_migration(dry_run=True)
 
-    mock_retire.assert_not_called()
+    mock_transition.assert_not_called()
     mock_comment.assert_called_once()
     # _post_comment(issue_number, body, dry_run=True)
     comment_call_args = mock_comment.call_args

--- a/apeiron_flow/tests/test_triage_flow.py
+++ b/apeiron_flow/tests/test_triage_flow.py
@@ -95,7 +95,7 @@ def test_triage_flow_calls_label_transition_on_classified_issue(mock_crew_cls):
     with patch("apeiron_flow.main._labels.transition") as mock_transition:
         result = flow.run_triage()
 
-    mock_transition.assert_called_once_with(42, "status:todo", "status:triage")
+    mock_transition.assert_called_once_with(42, from_label="status:triage", to_label="status:todo")
     assert result.classification == "epic"
 
 


### PR DESCRIPTION
Label transition module per ADR 002 — STATUS_* constants, get_status, retire_in_review, LabelTransitionError; all HTTP via github_http only.

Rebased cleanly onto develop. Integrates with migrate_in_review.py (transition() called directly instead of old retire_in_review(has_pr, ...) API).

107/107 tests pass, make o-check clean.

Related to #507